### PR TITLE
fix: assign field history in getMergeHistoryResultByKeepId (#7)

### DIFF
--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -924,7 +924,7 @@ public with sharing class MRG_Merge_SVC {
 				updateRecords.add(updateRecordsById.get(keepId));
 			List<MergeFieldHistory__c> fieldHistory = new List<MergeFieldHistory__c>();
 			if(fieldHistoryByKeepId.containsKey(keepId))
-				fieldHistoryByKeepId.get(keepId);
+				fieldHistory = fieldHistoryByKeepId.get(keepId);
 			Map<Id, SObject> objectMap = new Map<Id, SObject>();
 			if(mergeResult.objectMap.containsKey(keepId))
 				objectMap.put(keepId, mergeResult.objectMap.get(keepId));

--- a/force-app/main/default/classes/MRG_Merge_TEST.cls
+++ b/force-app/main/default/classes/MRG_Merge_TEST.cls
@@ -120,6 +120,35 @@ public class MRG_Merge_TEST {
 	}
 
 
+	static testMethod void testFieldHistoryCarriesIntoPerKeepResult() {
+		List<Contact> cons = [SELECT Id FROM Contact ORDER BY CreatedDate ASC];
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+
+		MergeFieldHistory__c history = new MergeFieldHistory__c(
+			KeptRecordId__c = keepId,
+			MergedRecordId__c = mergeId,
+			KeptValue__c = 'kept',
+			MergeValue__c = 'merged',
+			MergeValueType__c = 'Email'
+		);
+		MRG_Merge_SVC.mergeHistoryResult result = new MRG_Merge_SVC.mergeHistoryResult(
+			new List<SObject>(),
+			new List<MergeFieldHistory__c>{ history }
+		);
+		Map<Id, Set<Id>> mergeKeyMap = new Map<Id, Set<Id>>{ keepId => new Set<Id>{ mergeId } };
+
+		test.startTest();
+		Map<Id, MRG_Merge_SVC.mergeHistoryResult> byKeep =
+			MRG_Merge_SVC.getMergeHistoryResultByKeepId(result, mergeKeyMap);
+		test.stopTest();
+
+		system.assert(byKeep.containsKey(keepId), 'result should be keyed by keep id');
+		system.assertEquals(1, byKeep.get(keepId).fieldHistory.size(),
+			'field history must carry into the per-keep result, not be dropped');
+		system.assertEquals('Email', byKeep.get(keepId).fieldHistory[0].MergeValueType__c);
+	}
+
 	static testMethod void testAccountMerge() {
 		Contact oldestCon;
 		Contact newestCon;


### PR DESCRIPTION
Fixes #7.

## Problem
In `getMergeHistoryResultByKeepId`, the per-keep field-history list was looked up but the result was discarded:
```apex
if(fieldHistoryByKeepId.containsKey(keepId))
    fieldHistoryByKeepId.get(keepId);   // not assigned
```
So `fieldHistory` stayed empty, the serialized `Data__c` on processed candidates had no history, and the preview screen showed no tracked changes for already-merged candidates.

## Fix
Assign the fetched list: `fieldHistory = fieldHistoryByKeepId.get(keepId);`

## Test
`testFieldHistoryCarriesIntoPerKeepResult` builds a `mergeHistoryResult` with one history entry and asserts it survives into the per-keep result.