### PR TITLE
fix: use normalized value equality for field comparisons (#9)

### DIFF
--- a/force-app/main/default/classes/MRG_MergeCandidate_SVC.cls
+++ b/force-app/main/default/classes/MRG_MergeCandidate_SVC.cls
@@ -55,7 +55,7 @@ public with sharing class MRG_MergeCandidate_SVC {
                             if(fieldDifferences.contains(field))
                                 continue;
                             Object fieldVal = keepRecord.get(field);
-                            if(testRecord.get(field) != fieldVal) {
+                            if(!MRG_Merge_SVC.valuesAreEqual(testRecord.get(field), fieldVal)) {
                                 String fieldApiName = fieldmap.containsKey(field) ? fieldmap.get(field).getDescribe().getName() : field;
                                 fieldDifferences.add(fieldApiName);
 

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -736,10 +736,10 @@ public with sharing class MRG_Merge_SVC {
 								&& hasChange)) {
 							if(keepValue != null
 								&& mergeValue != null
-								&& keepValue != mergeValue) {
-									
+								&& !valuesAreEqual(keepValue, mergeValue)) {
+
 								mergeRecords.add(getMergeRecord(keepValue, mergeValue, keptRec, mergedRecordId, fieldName));
-								
+
 							}
 						}
 
@@ -868,6 +868,19 @@ public with sharing class MRG_Merge_SVC {
 		if(fieldValue instanceOf Decimal) return 'Decimal';
 		if(fieldValue instanceOf Double) return 'Double';
 		return 'String';
+	}
+	/*******************************************************************************************************
+	* @description compares two field values for equality. Both values are normalized through
+	* String.valueOf so the comparison matches how values are persisted to MergeFieldHistory__c and
+	* avoids unreliable Object inequality across field value types. Two nulls are equal; one null is not.
+	* @param a the first value
+	* @param b the second value
+	* @return Boolean true when the values are considered equal
+	*/
+	public static Boolean valuesAreEqual(Object a, Object b) {
+		if(a == null && b == null) return true;
+		if(a == null || b == null) return false;
+		return String.valueOf(a) == String.valueOf(b);
 	}
 	/*******************************************************************************************************
 	* @description objectField class

--- a/force-app/main/default/classes/MRG_Merge_TEST.cls
+++ b/force-app/main/default/classes/MRG_Merge_TEST.cls
@@ -120,6 +120,23 @@ public class MRG_Merge_TEST {
 	}
 
 
+	static testMethod void testValuesAreEqual() {
+		// nulls
+		system.assert(MRG_Merge_SVC.valuesAreEqual(null, null), 'two nulls are equal');
+		system.assert(!MRG_Merge_SVC.valuesAreEqual(null, 'x'), 'one null is not equal');
+		system.assert(!MRG_Merge_SVC.valuesAreEqual('x', null), 'one null is not equal');
+		// equal values across types
+		system.assert(MRG_Merge_SVC.valuesAreEqual('abc', 'abc'), 'equal strings');
+		system.assert(MRG_Merge_SVC.valuesAreEqual(5, 5), 'equal integers');
+		system.assert(MRG_Merge_SVC.valuesAreEqual(true, true), 'equal booleans');
+		Date d = Date.newInstance(2020,1,1);
+		system.assert(MRG_Merge_SVC.valuesAreEqual(d, Date.newInstance(2020,1,1)), 'equal dates');
+		// different values
+		system.assert(!MRG_Merge_SVC.valuesAreEqual('abc', 'abd'), 'different strings');
+		system.assert(!MRG_Merge_SVC.valuesAreEqual(5, 6), 'different integers');
+		system.assert(!MRG_Merge_SVC.valuesAreEqual(true, false), 'different booleans');
+	}
+
 	static testMethod void testFieldHistoryCarriesIntoPerKeepResult() {
 		List<Contact> cons = [SELECT Id FROM Contact ORDER BY CreatedDate ASC];
 		Id keepId = cons[0].Id;


### PR DESCRIPTION
Fixes #9.

## Problem
Two sites compared field values with raw `Object !=`:
- `MRG_MergeCandidate_SVC` — building the field-difference set that drives the preview UI.
- `MRG_Merge_SVC` — deciding whether to write a `MergeFieldHistory__c` entry.

Comparing boxed `Object` values returned from `SObject.get()` is unreliable across field value types and can report equal values as different (phantom diffs / spurious history).

## Fix
- Added `MRG_Merge_SVC.valuesAreEqual(Object, Object)`: two nulls are equal, one null is not, otherwise compare via `String.valueOf` normalization — which matches how values are actually persisted (`KeptValue__c = String.valueOf(...)`).
- Applied it at both comparison sites (negated, since both ask "is it different").

## Test
`testValuesAreEqual` covers nulls, equal values (string/int/boolean/date), and differing values. The helper is also exercised through the existing merge tests.