### PR TITLE
fix: surface duplicate groups larger than three (#10)

### DIFF
--- a/force-app/main/default/classes/MRG_Duplicate_SVC.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_SVC.cls
@@ -340,6 +340,13 @@ public with sharing class MRG_Duplicate_SVC {
             mergeCandidate.Merge2Name__c = String.isNotBlank(mergeCandidate.Merge2RecordId__c) ? matchNames.get(mergeCandidate.Merge2RecordId__c) : null;
             mergeCandidate.Object__c = objectType;
             mergeCandidate.Status__c = 'New';
+            // a merge handles at most 3 records (keep + 2). Surface when the group had more so the
+            // truncation isn't invisible; the remainder is re-found by the next scan after this merges.
+            if(matchIdList.size()>3) {
+                mergeCandidate.HasAdditionalDuplicates__c = true;
+                System.debug(LoggingLevel.WARN, 'Duplicate group for ' + matchIdList[0] + ' has ' + matchIdList.size()
+                    + ' records; ' + (matchIdList.size()-3) + ' deferred to a later run.');
+            }
         } else {
             mergeCandidate = null;
         }

--- a/force-app/main/default/objects/MergeCandidate__c/fields/HasAdditionalDuplicates__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeCandidate__c/fields/HasAdditionalDuplicates__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasAdditionalDuplicates__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <inlineHelpText>Checked when the duplicate group contained more than three records. Only the first three are merged at a time; re-run the scan/merge after this candidate is processed to clean up the remaining duplicates.</inlineHelpText>
+    <label>Has Additional Duplicates</label>
+    <type>Checkbox</type>
+</CustomField>


### PR DESCRIPTION
Fixes #10.

## Problem
A Salesforce `merge` handles at most three records (keep + 2). `getMergeCandidate` populated only Keep + Merge + Merge2 and silently discarded any additional records in a larger duplicate group — with no signal that records were left behind.

## Approach
Per discussion, **make the truncation visible** rather than auto-creating follow-up candidates. The candidate upsert key is `KeepRecordId__c` (one candidate per keep record), so splitting a group into multiple candidates would collide with that key; and once the first three merge, the next scan re-finds the remaining duplicates automatically. This matches the documented "run the merge again for groups larger than three" workflow in the Administrator Guide.

## Fix
- New `MergeCandidate__c.HasAdditionalDuplicates__c` checkbox (with help text explaining to re-run).
- Set the flag and log a `WARN` with the deferred count when a group has more than three records.
- The field is picked up automatically by the describe-based candidate SOQL.

## Verification note
`Datacloud.DuplicateResult` / `MatchRecord` can't be constructed in a test without active duplicate rules, so an executable test is deferred to Comprehensive Testing #15 (scan → candidate creation with an injection seam). The flag/log logic is static-verifiable.