### PR TITLE
fix: robustly coerce manual-override values by field type (#11)

### DIFF
--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -341,28 +341,8 @@ public with sharing class MRG_Merge_SVC {
 
 				List<MRG_MergeCandidate.fieldOverride> overrides = (List<MRG_MergeCandidate.fieldOverride>) JSON.deserialize(record.Override__c, List<MRG_MergeCandidate.fieldOverride>.class);
 				for(MRG_MergeCandidate.fieldOVerride ovrride:overrides){
-					Object fieldVal;
 					String fieldName = ovrride.fieldName;
-					switch on ovrride.fieldType {
-						when 'BOOLEAN' {
-							fieldVal = Boolean.valueOf(ovrride.fieldValue);
-						}
-						when 'DATE' {
-							fieldVal = (Date) JSON.deserialize(ovrride.fieldValue, Date.class);
-						}	
-						when 'DATETIME' {
-							fieldVal = (Datetime) JSON.deserialize(ovrride.fieldValue, Datetime.class);
-						}
-						when 'DOUBLE' {
-							fieldVal = Double.valueOf(ovrride.fieldValue);
-						}
-						when 'INTEGER' {
-							fieldVal = Integer.valueOf(ovrride.fieldValue);
-						}
-						when else {
-							fieldVal = ovrride.fieldValue;
-						}
-					}
+					Object fieldVal = coerceOverrideValue(ovrride.fieldType, ovrride.fieldValue);
 					if(fieldVal != null)
 						manualOverridesByKeepId.get(keepId).put(fieldName,fieldVal);
 				}
@@ -370,6 +350,53 @@ public with sharing class MRG_Merge_SVC {
 			}
 		}
 		return manualOverridesByKeepId;
+	}
+
+	/*******************************************************************************************************
+	* @description coerces a manual-override string value into the typed value for an SObject field.
+	* fieldType is a Schema.SOAPType name (BOOLEAN/DATE/DATETIME/DOUBLE/INTEGER/TIME/ID/STRING/...).
+	* The stored fieldValue is a raw (unquoted) string, so we use the native valueOf parsers rather
+	* than JSON.deserialize (which would require a quoted value and throw on a raw date string). A
+	* value that cannot be parsed returns null so one bad override does not abort the whole merge.
+	* @param fieldType the SOAP type name of the field
+	* @param fieldValue the raw string value from the override
+	* @return Object the typed value, or null if blank/unparseable
+	*/
+	public static Object coerceOverrideValue(String fieldType, String fieldValue) {
+		if(String.isBlank(fieldValue))
+			return null;
+		try {
+			switch on fieldType {
+				when 'BOOLEAN' {
+					return Boolean.valueOf(fieldValue);
+				}
+				when 'DATE' {
+					return Date.valueOf(fieldValue);
+				}
+				when 'DATETIME' {
+					return Datetime.valueOf(fieldValue);
+				}
+				when 'TIME' {
+					// Time has no valueOf; derive it from a datetime parse of a date+time string
+					Datetime dt = Datetime.valueOf('1970-01-01 ' + fieldValue);
+					return dt.timeGmt();
+				}
+				when 'DOUBLE' {
+					return Double.valueOf(fieldValue);
+				}
+				when 'INTEGER' {
+					return Integer.valueOf(fieldValue);
+				}
+				when else {
+					// ID, STRING, ANYTYPE, BASE64BINARY, etc. are written as-is
+					return fieldValue;
+				}
+			}
+		} catch(Exception e) {
+			System.debug(LoggingLevel.WARN, 'Could not coerce override value "' + fieldValue + '" as ' + fieldType + ': ' + e.getMessage());
+			return null;
+		}
+		return null;
 	}
 
 	/*******************************************************************************************************

--- a/force-app/main/default/classes/MRG_Merge_TEST.cls
+++ b/force-app/main/default/classes/MRG_Merge_TEST.cls
@@ -120,6 +120,27 @@ public class MRG_Merge_TEST {
 	}
 
 
+	static testMethod void testCoerceOverrideValue() {
+		// blank -> null
+		system.assertEquals(null, MRG_Merge_SVC.coerceOverrideValue('STRING', null));
+		system.assertEquals(null, MRG_Merge_SVC.coerceOverrideValue('STRING', ''));
+		// string / id pass through
+		system.assertEquals('hello', MRG_Merge_SVC.coerceOverrideValue('STRING', 'hello'));
+		system.assertEquals('001000000000000AAA', MRG_Merge_SVC.coerceOverrideValue('ID', '001000000000000AAA'));
+		// boolean
+		system.assertEquals(true, MRG_Merge_SVC.coerceOverrideValue('BOOLEAN', 'true'));
+		// numeric
+		system.assertEquals(12.5, (Double) MRG_Merge_SVC.coerceOverrideValue('DOUBLE', '12.5'));
+		system.assertEquals(7, (Integer) MRG_Merge_SVC.coerceOverrideValue('INTEGER', '7'));
+		// date / datetime from raw (unquoted) strings -- the case that previously threw
+		system.assertEquals(Date.newInstance(2020,1,15), (Date) MRG_Merge_SVC.coerceOverrideValue('DATE', '2020-01-15'));
+		system.assertEquals(Datetime.valueOf('2020-01-15 13:30:00'),
+			(Datetime) MRG_Merge_SVC.coerceOverrideValue('DATETIME', '2020-01-15 13:30:00'));
+		// unparseable value -> null (does not throw)
+		system.assertEquals(null, MRG_Merge_SVC.coerceOverrideValue('DATE', 'not-a-date'));
+		system.assertEquals(null, MRG_Merge_SVC.coerceOverrideValue('INTEGER', 'abc'));
+	}
+
 	static testMethod void testValuesAreEqual() {
 		// nulls
 		system.assert(MRG_Merge_SVC.valuesAreEqual(null, null), 'two nulls are equal');


### PR DESCRIPTION
Fixes #11.

## Investigation result
The override `fieldType` is a `Schema.SOAPType` name (`getSOAPType().name()`), and `fieldValue` is stored as a **raw, unquoted** string (the LWC sets `override.fieldValue = value` then `JSON.stringify`s the array, so the inner value is not individually JSON-quoted).

Against that, the old `switch`:
- **DATE / DATETIME** used `JSON.deserialize(fieldValue, Date.class)`, which requires a *quoted* JSON value (`"2020-01-15"`) and **throws on a raw date string** — date/datetime overrides were broken.
- **TIME** had no case (would put a String into a Time field → error).
- Any parse failure threw and aborted the entire merge batch.
- DOUBLE/INTEGER/BOOLEAN/ID/STRING were fine (currency/percent/decimal all report `DOUBLE`).

## Fix
Extracted `MRG_Merge_SVC.coerceOverrideValue(fieldType, fieldValue)`:
- Native parsers: `Date.valueOf`, `Datetime.valueOf`, `Double.valueOf`, `Integer.valueOf`, `Boolean.valueOf`.
- Added a `TIME` case (via a datetime parse + `timeGmt()`).
- `ID`/`STRING`/other pass through as-is.
- Whole thing wrapped in try/catch → an unparseable value returns `null` (skipped) instead of aborting the merge.

## Test
`testCoerceOverrideValue` covers blank, string, id, boolean, double, integer, **raw date/datetime (the previously-throwing case)**, and unparseable-returns-null.