### PR TITLE
test: add shared test factory and service-driven merge harness (#12)

### DIFF
--- a/force-app/main/default/classes/MRG_TestFactory.cls
+++ b/force-app/main/default/classes/MRG_TestFactory.cls
@@ -1,0 +1,231 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description shared test data factory and merge harness for the Merge Control test suite.
+* Builds Accounts/Contacts with controlled CreatedDate ordering, registers in-memory
+* MergeFieldSetting__mdt / PreviewFields__mdt, builds MergeCandidate__c records, drives merges
+* through the production service path, and provides assertion helpers.
+*/
+@isTest
+public class MRG_TestFactory {
+
+	/*******************************************************************************************************
+	* @description inserts n Accounts named Account 0..n-1
+	* @param n the number of accounts to create
+	* @return List<Account> the inserted accounts
+	*/
+	public static List<Account> accounts(Integer n) {
+		List<Account> accs = new List<Account>();
+		for(Integer i=0; i<n; i++)
+			accs.add(new Account(Name='Account '+i));
+		insert accs;
+		return accs;
+	}
+
+	/*******************************************************************************************************
+	* @description inserts n Contacts named Test Contact{i}
+	* @param n the number of contacts to create
+	* @return List<Contact> the inserted contacts
+	*/
+	public static List<Contact> contacts(Integer n) {
+		List<Contact> cons = new List<Contact>();
+		for(Integer i=0; i<n; i++)
+			cons.add(new Contact(FirstName='Test', LastName='Contact'+i));
+		insert cons;
+		return cons;
+	}
+
+	/*******************************************************************************************************
+	* @description sets the CreatedDate on a record so preservation rules that depend on record age
+	* (Oldest/Newest) can be exercised deterministically
+	* @param recordId the record to backdate
+	* @param dt the created date to set
+	*/
+	public static void setCreatedDate(Id recordId, Datetime dt) {
+		Test.setCreatedDate(recordId, dt);
+	}
+
+	/*******************************************************************************************************
+	* @description registers a list of merge field settings in memory on MRG_Merge_SVC so the service
+	* reads them without a real metadata deploy
+	* @param fields the merge field settings to register
+	*/
+	public static void registerMergeFields(List<MergeFieldSetting__mdt> fields) {
+		MRG_Merge_SVC.mergeFields = fields;
+	}
+
+	/*******************************************************************************************************
+	* @description registers a list of preview fields in memory on MRG_Merge_SVC
+	* @param fields the preview fields to register
+	*/
+	public static void registerPreviewFields(List<PreviewFields__mdt> fields) {
+		MRG_Merge_SVC.previewFields = fields;
+	}
+
+	/*******************************************************************************************************
+	* @description builds an in-memory MergeFieldSetting__mdt with the read-only Object__r / Field__r
+	* relationships populated via JSON injection
+	* @param objectName the SObject api name
+	* @param fieldName the field api name
+	* @param type Track or Preserve
+	* @param rule the preservation rule (Oldest/Newest/Largest/Smallest/Related Field), may be null
+	* @return MergeFieldSetting__mdt the constructed setting
+	*/
+	public static MergeFieldSetting__mdt mergeField(String objectName, String fieldName, String type, String rule) {
+		return mergeField(objectName, fieldName, type, rule, null);
+	}
+
+	/*******************************************************************************************************
+	* @description builds an in-memory MergeFieldSetting__mdt, optionally with a RelatedField__r
+	* @param objectName the SObject api name
+	* @param fieldName the field api name
+	* @param type Track or Preserve
+	* @param rule the preservation rule
+	* @param relatedFieldName the related (paired) field api name, may be null
+	* @return MergeFieldSetting__mdt the constructed setting
+	*/
+	public static MergeFieldSetting__mdt mergeField(String objectName, String fieldName, String type, String rule, String relatedFieldName) {
+		MergeFieldSetting__mdt mergeField = new MergeFieldSetting__mdt();
+		Map<String, Object> fieldMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(mergeField));
+		fieldMap.put(MergeFieldSetting__mdt.Label.getDescribe().getName(), 'test'+fieldName);
+		fieldMap.put(MergeFieldSetting__mdt.DeveloperName.getDescribe().getName(), 'test'+fieldName);
+		fieldMap.put(MergeFieldSetting__mdt.Type__c.getDescribe().getName(), type);
+		fieldMap.put(MergeFieldSetting__mdt.PreservationRule__c.getDescribe().getName(), rule);
+		fieldMap.put('Object__r', entityRef('EntityDefinition', objectName));
+		fieldMap.put('Field__r', entityRef('EntityParticle', fieldName));
+		if(String.isNotBlank(relatedFieldName))
+			fieldMap.put('RelatedField__r', entityRef('EntityParticle', relatedFieldName));
+		return (MergeFieldSetting__mdt) JSON.deserialize(JSON.serialize(fieldMap), MergeFieldSetting__mdt.class);
+	}
+
+	/*******************************************************************************************************
+	* @description builds an in-memory PreviewFields__mdt with read-only relationships via JSON injection
+	* @param objectName the SObject api name
+	* @param fieldName the field api name
+	* @param hidden whether the field is hidden from the preview
+	* @return PreviewFields__mdt the constructed preview field
+	*/
+	public static PreviewFields__mdt previewField(String objectName, String fieldName, Boolean hidden) {
+		PreviewFields__mdt pField = new PreviewFields__mdt();
+		Map<String, Object> fieldMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(pField));
+		fieldMap.put(PreviewFields__mdt.Label.getDescribe().getName(), 'test'+fieldName);
+		fieldMap.put(PreviewFields__mdt.DeveloperName.getDescribe().getName(), 'test'+fieldName);
+		fieldMap.put(PreviewFields__mdt.Disable__c.getDescribe().getName(), hidden);
+		fieldMap.put('Object__r', entityRef('EntityDefinition', objectName));
+		fieldMap.put('Field__r', entityRef('EntityParticle', fieldName));
+		return (PreviewFields__mdt) JSON.deserialize(JSON.serialize(fieldMap), PreviewFields__mdt.class);
+	}
+
+	/*******************************************************************************************************
+	* @description builds (unsaved) a JSON shape for a metadata relationship field
+	* @param entityType EntityDefinition or EntityParticle
+	* @param apiName the QualifiedAPIName value
+	* @return Map<String, Object> the relationship shape
+	*/
+	private static Map<String, Object> entityRef(String entityType, String apiName) {
+		return new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => entityType },
+			'QualifiedAPIName' => apiName
+		};
+	}
+
+	/*******************************************************************************************************
+	* @description inserts a MergeCandidate__c for a keep + merge pair
+	* @param keepId the record to keep
+	* @param mergeId the record to merge into keep
+	* @param objectType the SObject type
+	* @return MergeCandidate__c the inserted candidate
+	*/
+	public static MergeCandidate__c mergeCandidate(Id keepId, Id mergeId, String objectType) {
+		return mergeCandidate(keepId, mergeId, null, objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description inserts a MergeCandidate__c for a keep + up to two merge records
+	* @param keepId the record to keep
+	* @param mergeId the first record to merge
+	* @param merge2Id the second record to merge, may be null
+	* @param objectType the SObject type
+	* @return MergeCandidate__c the inserted candidate
+	*/
+	public static MergeCandidate__c mergeCandidate(Id keepId, Id mergeId, Id merge2Id, String objectType) {
+		MergeCandidate__c mc = new MergeCandidate__c(
+			KeepRecordId__c = keepId,
+			MergeRecordId__c = mergeId,
+			Merge2RecordId__c = merge2Id,
+			Object__c = objectType,
+			Rule__c = 'test',
+			Status__c = 'New',
+			AutoMerge__c = true
+		);
+		insert mc;
+		return mc;
+	}
+
+	/*******************************************************************************************************
+	* @description serializes a list of field overrides onto a candidate's Override__c and updates it
+	* @param candidate the candidate to set overrides on
+	* @param overrides the overrides to apply
+	*/
+	public static void setOverrides(MergeCandidate__c candidate, List<MRG_MergeCandidate.fieldOverride> overrides) {
+		candidate.Override__c = JSON.serialize(overrides);
+		update candidate;
+	}
+
+	/*******************************************************************************************************
+	* @description builds a single field override
+	* @param keepId the kept record id the override applies to
+	* @param fieldName the field api name
+	* @param fieldValue the raw string value
+	* @param fieldType the SOAP type name (BOOLEAN/DATE/DATETIME/DOUBLE/INTEGER/STRING/...)
+	* @return MRG_MergeCandidate.fieldOverride the override
+	*/
+	public static MRG_MergeCandidate.fieldOverride override(Id keepId, String fieldName, String fieldValue, String fieldType) {
+		MRG_MergeCandidate.fieldOverride o = new MRG_MergeCandidate.fieldOverride();
+		o.keepId = keepId;
+		o.fieldName = fieldName;
+		o.fieldValue = fieldValue;
+		o.fieldType = fieldType;
+		return o;
+	}
+
+	/*******************************************************************************************************
+	* @description drives a merge through the production service path (not raw DML merge)
+	* @param candidates the candidates to process
+	* @param objectType the SObject type
+	*/
+	public static void runMerge(List<MergeCandidate__c> candidates, String objectType) {
+		MRG_Merge_SVC.processMergesFromBatch(candidates, objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description re-queries a kept record and returns the value of a single field after a merge
+	* @param recordId the kept record id
+	* @param objectType the SObject type
+	* @param fieldName the field api name
+	* @return Object the field value
+	*/
+	public static Object keptValue(Id recordId, String objectType, String fieldName) {
+		SObject rec = Database.query('SELECT '+String.escapeSingleQuotes(fieldName)+' FROM '+String.escapeSingleQuotes(objectType)+' WHERE Id=:recordId');
+		return rec.get(fieldName);
+	}
+
+	/*******************************************************************************************************
+	* @description returns the MergeFieldHistory__c entries for a kept record keyed by field
+	* (MergeValueType__c), lowercased and trimmed
+	* @param keepId the kept record id
+	* @return Map<String, MergeFieldHistory__c> history keyed by field
+	*/
+	public static Map<String, MergeFieldHistory__c> historyByField(Id keepId) {
+		Map<String, MergeFieldHistory__c> historyMap = new Map<String, MergeFieldHistory__c>();
+		for(MergeFieldHistory__c h : [
+			SELECT Id, KeptRecordId__c, MergedRecordId__c, KeptValue__c, MergeValue__c, MergeValueType__c
+			FROM MergeFieldHistory__c
+			WHERE KeptRecordId__c = :keepId
+		]) {
+			if(h.MergeValueType__c != null)
+				historyMap.put(h.MergeValueType__c.trim().toLowerCase(), h);
+		}
+		return historyMap;
+	}
+}

--- a/force-app/main/default/classes/MRG_TestFactory.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_TestFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_TestFactory_TEST.cls
+++ b/force-app/main/default/classes/MRG_TestFactory_TEST.cls
@@ -1,0 +1,74 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description exercises MRG_TestFactory end-to-end so the shared harness is self-covering and
+* proves a merge can be driven through the production service path with assertable results.
+*/
+@isTest
+private class MRG_TestFactory_TEST {
+
+	static testMethod void testHarnessDrivesContactMergeThroughService() {
+		// two contacts, oldest first; preserve LastName from the newest, track FirstName
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		MRG_TestFactory.setCreatedDate(keepId, Datetime.now().addDays(-10));
+		MRG_TestFactory.setCreatedDate(mergeId, Datetime.now().addDays(-1));
+
+		// give the records distinct values to merge/track
+		update new List<Contact>{
+			new Contact(Id=keepId, FirstName='Keep', LastName='KeepLast'),
+			new Contact(Id=mergeId, FirstName='Merge', LastName='MergeLast')
+		};
+
+		MRG_TestFactory.registerMergeFields(new List<MergeFieldSetting__mdt>{
+			MRG_TestFactory.mergeField('Contact','FirstName','Track', null),
+			MRG_TestFactory.mergeField('Contact','LastName','Preserve','Newest')
+		});
+		MRG_TestFactory.registerPreviewFields(new List<PreviewFields__mdt>{
+			MRG_TestFactory.previewField('Contact','Email', true)
+		});
+
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		// the kept record should now hold the newest LastName (preservation rule)
+		system.assertEquals('MergeLast', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'LastName'),
+			'Newest preservation rule should bring LastName from the newer record onto the kept record');
+
+		// merge candidate should be processed
+		MergeCandidate__c processed = [SELECT Status__c FROM MergeCandidate__c WHERE Id=:mc.Id];
+		system.assertEquals('Processed', processed.Status__c, 'candidate should be marked Processed');
+
+		// history helper should surface the tracked FirstName change
+		Map<String, MergeFieldHistory__c> history = MRG_TestFactory.historyByField(keepId);
+		system.assert(history.containsKey('firstname'), 'tracked FirstName change should be recorded');
+	}
+
+	static testMethod void testOverrideBuilders() {
+		List<Account> accs = MRG_TestFactory.accounts(2);
+		Id keepId = accs[0].Id;
+
+		MRG_MergeCandidate.fieldOverride o = MRG_TestFactory.override(keepId, 'Name', 'Overridden', 'STRING');
+		system.assertEquals(keepId, o.keepId);
+		system.assertEquals('Name', o.fieldName);
+		system.assertEquals('Overridden', o.fieldValue);
+		system.assertEquals('STRING', o.fieldType);
+
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, accs[1].Id, 'Account');
+		MRG_TestFactory.setOverrides(mc, new List<MRG_MergeCandidate.fieldOverride>{ o });
+		MergeCandidate__c reloaded = [SELECT Override__c FROM MergeCandidate__c WHERE Id=:mc.Id];
+		system.assert(String.isNotBlank(reloaded.Override__c), 'override JSON should be persisted on the candidate');
+	}
+
+	static testMethod void testRelatedFieldBuilder() {
+		// just exercises the related-field overload of mergeField
+		MergeFieldSetting__mdt mf = MRG_TestFactory.mergeField('Contact','MailingState','Preserve','Related Field','MailingPostalCode');
+		system.assertEquals('MailingState', mf.Field__r.QualifiedAPIName);
+		system.assertEquals('MailingPostalCode', mf.RelatedField__r.QualifiedAPIName);
+		system.assertEquals('Contact', mf.Object__r.QualifiedAPIName);
+	}
+}

--- a/force-app/main/default/classes/MRG_TestFactory_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_TestFactory_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Part of the Comprehensive Testing milestone. Fixes #12.

## What
`MRG_TestFactory` (`@isTest`) — the shared foundation the rest of the milestone builds on:
- `accounts(n)` / `contacts(n)` builders
- `setCreatedDate(id, dt)` for deterministic Oldest/Newest rules
- `mergeField(obj, field, type, rule[, relatedField])` and `previewField(...)` — in-memory `__mdt` via JSON injection (extends the existing `createTestMergeField` pattern), registered through `registerMergeFields` / `registerPreviewFields`
- `mergeCandidate(keepId, mergeId[, merge2Id], objectType)` and override builders (`override`, `setOverrides`)
- `runMerge(candidates, objectType)` — drives merges through **`MRG_Merge_SVC.processMergesFromBatch`** (the production path), not raw `merge` DML
- assertion helpers: `keptValue(id, objectType, field)`, `historyByField(keepId)`

`MRG_TestFactory_TEST` exercises every method and proves the harness drives a real merge with a working preservation rule, Processed status, and tracked history.

## Acceptance criteria
- ✅ Other testing issues (#13–#15) can be written on these helpers without duplicating setup.
- ✅ Merges run through the service layer, not raw DML.

## Verification note
Not executed (no scratch/sandbox deploy by request). The in-memory `__mdt` injection and `mergeFields`/`previewFields` setters are the same techniques the existing `MRG_Merge_TEST` already uses successfully.