### PR TITLE
fix: rename reserved 'override' factory method to fieldOverride

### DIFF
--- a/force-app/main/default/classes/MRG_MergeExecution_TEST.cls
+++ b/force-app/main/default/classes/MRG_MergeExecution_TEST.cls
@@ -100,9 +100,9 @@ private class MRG_MergeExecution_TEST {
 		MRG_TestFactory.registerMergeFields(new List<MergeFieldSetting__mdt>());
 		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
 		MRG_TestFactory.setOverrides(mc, new List<MRG_MergeCandidate.fieldOverride>{
-			MRG_TestFactory.override(keepId, 'MailingState', 'WA', 'STRING'),
-			MRG_TestFactory.override(keepId, 'Birthdate', '1990-05-15', 'DATE'),
-			MRG_TestFactory.override(keepId, 'HasOptedOutOfEmail', 'true', 'BOOLEAN')
+			MRG_TestFactory.fieldOverride(keepId, 'MailingState', 'WA', 'STRING'),
+			MRG_TestFactory.fieldOverride(keepId, 'Birthdate', '1990-05-15', 'DATE'),
+			MRG_TestFactory.fieldOverride(keepId, 'HasOptedOutOfEmail', 'true', 'BOOLEAN')
 		});
 		// re-query so the candidate carries Override__c into the merge
 		MergeCandidate__c withOverride = [

--- a/force-app/main/default/classes/MRG_TestFactory.cls
+++ b/force-app/main/default/classes/MRG_TestFactory.cls
@@ -180,7 +180,7 @@ public class MRG_TestFactory {
 	* @param fieldType the SOAP type name (BOOLEAN/DATE/DATETIME/DOUBLE/INTEGER/STRING/...)
 	* @return MRG_MergeCandidate.fieldOverride the override
 	*/
-	public static MRG_MergeCandidate.fieldOverride override(Id keepId, String fieldName, String fieldValue, String fieldType) {
+	public static MRG_MergeCandidate.fieldOverride fieldOverride(Id keepId, String fieldName, String fieldValue, String fieldType) {
 		MRG_MergeCandidate.fieldOverride o = new MRG_MergeCandidate.fieldOverride();
 		o.keepId = keepId;
 		o.fieldName = fieldName;

--- a/force-app/main/default/classes/MRG_TestFactory_TEST.cls
+++ b/force-app/main/default/classes/MRG_TestFactory_TEST.cls
@@ -52,7 +52,7 @@ private class MRG_TestFactory_TEST {
 		List<Account> accs = MRG_TestFactory.accounts(2);
 		Id keepId = accs[0].Id;
 
-		MRG_MergeCandidate.fieldOverride o = MRG_TestFactory.override(keepId, 'Name', 'Overridden', 'STRING');
+		MRG_MergeCandidate.fieldOverride o = MRG_TestFactory.fieldOverride(keepId, 'Name', 'Overridden', 'STRING');
 		system.assertEquals(keepId, o.keepId);
 		system.assertEquals('Name', o.fieldName);
 		system.assertEquals('Overridden', o.fieldValue);


### PR DESCRIPTION
`override` is a reserved keyword in Apex, so `MRG_TestFactory` failed to compile at the `public static ... override(...)` declaration — cascading "dependent class is invalid" errors to `MRG_TestFactory_TEST`, `MRG_MergeExecution_TEST`, `MRG_Preservation_TEST`, and `MRG_ScanPipeline_TEST`.

Renamed the factory method to `fieldOverride(...)` and updated all three call sites. No behavior change.