### PR TITLE
fix: populate required KeepName__c in test factory candidates

### DIFF
--- a/force-app/main/default/classes/MRG_TestFactory.cls
+++ b/force-app/main/default/classes/MRG_TestFactory.cls
@@ -149,8 +149,13 @@ public class MRG_TestFactory {
 	* @return MergeCandidate__c the inserted candidate
 	*/
 	public static MergeCandidate__c mergeCandidate(Id keepId, Id mergeId, Id merge2Id, String objectType) {
+		// KeepName__c is required on MergeCandidate__c; populate it from the kept record's Name
+		String keepName = (String) Database.query(
+			'SELECT Name FROM '+String.escapeSingleQuotes(objectType)+' WHERE Id=:keepId'
+		)[0].get('Name');
 		MergeCandidate__c mc = new MergeCandidate__c(
 			KeepRecordId__c = keepId,
+			KeepName__c = keepName,
 			MergeRecordId__c = mergeId,
 			Merge2RecordId__c = merge2Id,
 			Object__c = objectType,


### PR DESCRIPTION
`MergeCandidate__c.KeepName__c` is required, but `MRG_TestFactory.mergeCandidate` didn't set it, so every factory-built candidate insert failed with `REQUIRED_FIELD_MISSING: [KeepName__c]` — taking down ~20 tests across `MRG_Preservation_TEST`, `MRG_MergeExecution_TEST`, `MRG_ScanPipeline_TEST`, and `MRG_TestFactory_TEST`.

Populate `KeepName__c` from the kept record's `Name` (mirrors production, where `getMergeCandidate` sets `KeepName__c` from the record name).

## Scope note
The two remaining failures in the run — `MRG_Merge_TEST.testContactMerge` (NPE) and `testTriggers` (ENTITY_IS_DELETED) — are pre-existing tests authored before this work (commit b7380bb) that fail due to org metadata / async-queueable fragility, not these changes. Left as-is per direction.