### PR TITLE
fix: merge with clean keep object, apply preserved values after (#29)

### DIFF
--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -413,11 +413,13 @@ public with sharing class MRG_Merge_SVC {
 		Map<Id, Set<Id>> mergeKeyMap = MRG_Duplicate_SVC.getMergeKeyMap(records);
 		if(mergeResult.fieldHistory.size()>0)
 			insert mergeResult.fieldHistory;
-		Map<Id, Sobject> keptRecordMap = new Map<Id, SObject>(mergeResult.updateRecords);
 		Set<Id> keepIdsMerged = new Set<Id>();
 		for(Id keepId:mergeKeyMap.keyset()){
+			// merge with a clean keep object; the queried kept record carries updateable-but-not-
+			// mergeable system fields (e.g. IsCustomerPortal) that the merge DML rejects. Preserved /
+			// override values are applied separately below.
 			if(objectType=='Account') {
-				Account keepObject = keptRecordMap.containsKey(keepId) ? (Account) keptRecordMap.get(keepId).clone(true,false,false,false) : new Account(Id=keepId);
+				Account keepObject = new Account(Id=keepId);
 				List<Account> mergeObjects = new List<Account>();
 				for(Id mergeId:mergeKeyMap.get(keepId)) {
 					mergeObjects.add((Account) objMap.get(mergeId));
@@ -426,7 +428,7 @@ public with sharing class MRG_Merge_SVC {
 				keepIdsMerged.add(keepObject.Id);
 
 			} else {
-				Contact keepObject = keptRecordMap.containsKey(keepId) ? (Contact) keptRecordMap.get(keepId).clone(true,false,false,false) : new Contact(Id=keepId);
+				Contact keepObject = new Contact(Id=keepId);
 				List<Contact> mergeObjects = new List<Contact>();
 				for(Id mergeId:mergeKeyMap.get(keepId)) {
 					mergeObjects.add((Contact) objMap.get(mergeId));
@@ -436,6 +438,9 @@ public with sharing class MRG_Merge_SVC {
 
 			}
 		}
+		// apply preserved / override field values to the surviving records after the merge
+		if(mergeResult.updateRecords != null && mergeResult.updateRecords.size()>0)
+			update mergeResult.updateRecords;
 		Map<Id, mergeHistoryResult> mergeResultByKeepId = getMergeHistoryResultByKeepId(mergeResult,mergeKeyMap);
 		updateMergeCandidateStatus(keepIdsMerged, mergeCandidateMap, mergeCandidateIdByKeepId, mergeResultByKeepId);
 		if(disableTriggers)


### PR DESCRIPTION
Fixes #29.

## Problem
`processMergesFromBatch` merged a clone of the fully-queried kept record. That record includes fields that are `isUpdateable()` but **not valid in a `merge` DML** (e.g. `IsCustomerPortal` on Account), so the merge failed with `MERGE_FAILED, Invalid field IsCustomerPortal for merge` — but only when a preserve rule/override actually changed a field (otherwise a clean `new Account(Id=keepId)` was used).

Surfaced by `MRG_Preservation_TEST.testAccountLargestNumber` / `testAccountSmallestNumber`.

## Fix
- Merge with a clean `new Account(Id=keepId)` / `new Contact(Id=keepId)`.
- Apply preserved/override values via a separate `update mergeResult.updateRecords` **after** the merge.
- Field history is computed and inserted before the merge, so the audit trail is unchanged.
- Removed the now-unused `keptRecordMap`.

## Expected test impact
- `testAccountLargestNumber` / `testAccountSmallestNumber` → pass.
- Contact preservation tests unchanged (same end values, applied via post-merge update).
- No-change Account/Contact merges unchanged (already used a clean keep object).