### PR TITLE
feat: keep-record criteria model + filter-logic engine (#32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Salesforce cache
 .sfdx/
 .localdevserver/
+.sf/
+test-results/
 
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json

--- a/force-app/main/default/classes/MRG_FilterLogic.cls
+++ b/force-app/main/default/classes/MRG_FilterLogic.cls
@@ -1,0 +1,170 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description evaluates report-style filter logic strings such as "(1 AND 2) OR 3" against a map of
+* numbered condition results. Pure and stateless: no SObjects, no DML, no SOQL. Supports AND, OR,
+* and parenthetical grouping with standard precedence (parentheses, then AND, then OR).
+*
+* If the logic string is blank, all referenced conditions are AND-ed together by the caller's map.
+*/
+public with sharing class MRG_FilterLogic {
+
+	/*******************************************************************************************************
+	* @description thrown when a filter logic string cannot be parsed
+	*/
+	public class ParseException extends Exception {}
+
+	/*******************************************************************************************************
+	* @description evaluates a filter logic string against condition results
+	* @param filterLogic e.g. "(1 AND 2) OR 3"; when blank, all results are AND-ed together
+	* @param conditionResults a map of condition number (1-based) to its boolean result
+	* @return Boolean the overall result
+	*/
+	public static Boolean evaluate(String filterLogic, Map<Integer, Boolean> conditionResults) {
+		if(String.isBlank(filterLogic))
+			return evaluateAllAnd(conditionResults);
+		List<String> tokens = tokenize(filterLogic);
+		Parser parser = new Parser(tokens, conditionResults);
+		Boolean result = parser.parseExpression();
+		parser.expectEnd();
+		return result;
+	}
+
+	/*******************************************************************************************************
+	* @description validates that a filter logic string parses and only references condition numbers in
+	* the allowed range [1, conditionCount]. Throws ParseException on any problem.
+	* @param filterLogic the logic string
+	* @param conditionCount the number of available conditions
+	*/
+	public static void validate(String filterLogic, Integer conditionCount) {
+		if(String.isBlank(filterLogic))
+			return;
+		Map<Integer, Boolean> dummy = new Map<Integer, Boolean>();
+		for(Integer i=1; i<=conditionCount; i++)
+			dummy.put(i, true);
+		List<String> tokens = tokenize(filterLogic);
+		// verify every referenced number is in range
+		for(String token:tokens) {
+			if(token.isNumeric()) {
+				Integer n = Integer.valueOf(token);
+				if(n < 1 || n > conditionCount)
+					throw new ParseException('Filter logic references condition ' + n + ' which is out of range 1-' + conditionCount);
+			}
+		}
+		Parser parser = new Parser(tokens, dummy);
+		parser.parseExpression();
+		parser.expectEnd();
+	}
+
+	/*******************************************************************************************************
+	* @description ANDs all condition results together (the default when no logic string is supplied)
+	* @param conditionResults the condition results
+	* @return Boolean true when every result is true (vacuously true when empty)
+	*/
+	private static Boolean evaluateAllAnd(Map<Integer, Boolean> conditionResults) {
+		for(Boolean result:conditionResults.values()) {
+			if(result != true)
+				return false;
+		}
+		return true;
+	}
+
+	/*******************************************************************************************************
+	* @description splits a filter logic string into tokens: numbers, AND, OR, '(' and ')'
+	* @param filterLogic the logic string
+	* @return List<String> the tokens
+	*/
+	@testvisible
+	private static List<String> tokenize(String filterLogic) {
+		List<String> tokens = new List<String>();
+		// pad parentheses so a simple whitespace split separates them from operands
+		String spaced = filterLogic.replace('(', ' ( ').replace(')', ' ) ');
+		for(String raw:spaced.split('\\s+')) {
+			String token = raw.trim();
+			if(String.isBlank(token))
+				continue;
+			String upper = token.toUpperCase();
+			if(upper == 'AND' || upper == 'OR' || token == '(' || token == ')') {
+				tokens.add(token == '(' || token == ')' ? token : upper);
+			} else if(token.isNumeric()) {
+				tokens.add(token);
+			} else {
+				throw new ParseException('Unexpected token in filter logic: "' + token + '"');
+			}
+		}
+		return tokens;
+	}
+
+	/*******************************************************************************************************
+	* @description recursive-descent parser/evaluator. Grammar (lowest to highest precedence):
+	*   expression := andTerm ( OR andTerm )*
+	*   andTerm    := factor ( AND factor )*
+	*   factor     := '(' expression ')' | number
+	* Evaluation happens inline against the supplied condition results.
+	*/
+	private class Parser {
+		private final List<String> tokens;
+		private final Map<Integer, Boolean> conditionResults;
+		private Integer pos;
+
+		public Parser(List<String> tokens, Map<Integer, Boolean> conditionResults) {
+			this.tokens = tokens;
+			this.conditionResults = conditionResults;
+			this.pos = 0;
+		}
+
+		public Boolean parseExpression() {
+			Boolean value = parseAndTerm();
+			while(peek() == 'OR') {
+				consume();
+				Boolean right = parseAndTerm();
+				value = value || right;
+			}
+			return value;
+		}
+
+		private Boolean parseAndTerm() {
+			Boolean value = parseFactor();
+			while(peek() == 'AND') {
+				consume();
+				Boolean right = parseFactor();
+				value = value && right;
+			}
+			return value;
+		}
+
+		private Boolean parseFactor() {
+			String token = peek();
+			if(token == null)
+				throw new ParseException('Unexpected end of filter logic');
+			if(token == '(') {
+				consume();
+				Boolean value = parseExpression();
+				if(peek() != ')')
+					throw new ParseException('Missing closing parenthesis in filter logic');
+				consume();
+				return value;
+			}
+			if(token.isNumeric()) {
+				consume();
+				Integer n = Integer.valueOf(token);
+				Boolean result = conditionResults.get(n);
+				return result == true;
+			}
+			throw new ParseException('Unexpected token "' + token + '" in filter logic');
+		}
+
+		public void expectEnd() {
+			if(pos < tokens.size())
+				throw new ParseException('Unexpected trailing token "' + tokens[pos] + '" in filter logic');
+		}
+
+		private String peek() {
+			return pos < tokens.size() ? tokens[pos] : null;
+		}
+
+		private void consume() {
+			pos++;
+		}
+	}
+}

--- a/force-app/main/default/classes/MRG_FilterLogic.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FilterLogic.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_FilterLogic_TEST.cls
+++ b/force-app/main/default/classes/MRG_FilterLogic_TEST.cls
@@ -1,0 +1,91 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description unit tests for the pure filter-logic parser/evaluator
+*/
+@isTest
+private class MRG_FilterLogic_TEST {
+
+	private static Map<Integer, Boolean> results(Boolean one, Boolean two, Boolean three) {
+		return new Map<Integer, Boolean>{ 1 => one, 2 => two, 3 => three };
+	}
+
+	static testMethod void testBlankLogicAndsAll() {
+		system.assert(MRG_FilterLogic.evaluate('', new Map<Integer, Boolean>{1=>true, 2=>true}), 'all true -> true');
+		system.assert(!MRG_FilterLogic.evaluate(null, new Map<Integer, Boolean>{1=>true, 2=>false}), 'one false -> false');
+		system.assert(MRG_FilterLogic.evaluate('', new Map<Integer, Boolean>()), 'empty -> vacuously true');
+	}
+
+	static testMethod void testSimpleAnd() {
+		system.assert(MRG_FilterLogic.evaluate('1 AND 2', results(true, true, false)));
+		system.assert(!MRG_FilterLogic.evaluate('1 AND 2', results(true, false, false)));
+	}
+
+	static testMethod void testSimpleOr() {
+		system.assert(MRG_FilterLogic.evaluate('1 OR 2', results(false, true, false)));
+		system.assert(!MRG_FilterLogic.evaluate('1 OR 2', results(false, false, false)));
+	}
+
+	static testMethod void testPrecedenceAndBindsTighterThanOr() {
+		// 1 OR 2 AND 3  ==  1 OR (2 AND 3)
+		system.assert(MRG_FilterLogic.evaluate('1 OR 2 AND 3', results(true, false, false)), '1 true -> true');
+		system.assert(!MRG_FilterLogic.evaluate('1 OR 2 AND 3', results(false, true, false)), '2 AND 3 false, 1 false -> false');
+		system.assert(MRG_FilterLogic.evaluate('1 OR 2 AND 3', results(false, true, true)), '2 AND 3 true -> true');
+	}
+
+	static testMethod void testParentheticalGrouping() {
+		// (1 AND 2) OR 3
+		system.assert(MRG_FilterLogic.evaluate('(1 AND 2) OR 3', results(true, true, false)), '1 AND 2 -> true');
+		system.assert(MRG_FilterLogic.evaluate('(1 AND 2) OR 3', results(false, false, true)), '3 -> true');
+		system.assert(!MRG_FilterLogic.evaluate('(1 AND 2) OR 3', results(true, false, false)), 'neither group -> false');
+	}
+
+	static testMethod void testNestedParentheses() {
+		// ((1 OR 2) AND 3)
+		system.assert(MRG_FilterLogic.evaluate('((1 OR 2) AND 3)', results(true, false, true)));
+		system.assert(!MRG_FilterLogic.evaluate('((1 OR 2) AND 3)', results(true, false, false)), '3 false -> false');
+	}
+
+	static testMethod void testCaseInsensitiveOperators() {
+		system.assert(MRG_FilterLogic.evaluate('1 and 2 or 3', results(true, true, false)));
+	}
+
+	static testMethod void testMissingConditionTreatedAsFalse() {
+		// references condition 3 but map has no entry -> false
+		system.assert(!MRG_FilterLogic.evaluate('3', new Map<Integer, Boolean>{1=>true}));
+	}
+
+	static testMethod void testTokenize() {
+		List<String> tokens = MRG_FilterLogic.tokenize('(1 AND 2) OR 3');
+		system.assertEquals(new List<String>{'(', '1', 'AND', '2', ')', 'OR', '3'}, tokens);
+	}
+
+	static testMethod void testParseErrors() {
+		assertParseError('1 AND', 'trailing operator with no operand');
+		assertParseError('(1 AND 2', 'missing closing paren');
+		assertParseError('1 2', 'two operands no operator');
+		assertParseError('1 AND $', 'bad token');
+		assertParseError('AND 1', 'leading operator');
+	}
+
+	static testMethod void testValidateRange() {
+		MRG_FilterLogic.validate('(1 AND 2) OR 3', 3); // ok, no throw
+		Boolean threw = false;
+		try {
+			MRG_FilterLogic.validate('1 AND 4', 3);
+		} catch(MRG_FilterLogic.ParseException e) {
+			threw = true;
+		}
+		system.assert(threw, 'referencing out-of-range condition should throw');
+	}
+
+	private static void assertParseError(String logic, String why) {
+		Boolean threw = false;
+		try {
+			MRG_FilterLogic.evaluate(logic, new Map<Integer, Boolean>{1=>true, 2=>true});
+		} catch(MRG_FilterLogic.ParseException e) {
+			threw = true;
+		}
+		system.assert(threw, 'expected parse error: ' + why);
+	}
+}

--- a/force-app/main/default/classes/MRG_FilterLogic_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FilterLogic_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_KeepRecordRule.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRule.cls
@@ -1,0 +1,191 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description model + evaluation for a single keep-record rule. A rule is an ordered set of
+* conditions combined by a report-style filter logic string (see MRG_FilterLogic). A record
+* "matches" a rule when its field values satisfy the rule's conditions under that logic.
+*
+* Stateless: evaluation reads only the supplied SObject and the rule's own definition.
+*/
+public with sharing class MRG_KeepRecordRule implements Comparable {
+
+	@auraEnabled public String id;
+	@auraEnabled public String label;
+	@auraEnabled public String objectName;
+	@auraEnabled public Integer order;
+	@auraEnabled public String filterLogic;
+	@auraEnabled public List<condition> conditions;
+
+	public MRG_KeepRecordRule() {
+		this.conditions = new List<condition>();
+		this.order = 0;
+	}
+
+	/*******************************************************************************************************
+	* @description sorts rules by their evaluation order (ascending)
+	*/
+	public Integer compareTo(Object compareTo) {
+		MRG_KeepRecordRule other = (MRG_KeepRecordRule) compareTo;
+		Integer a = this.order == null ? 0 : this.order;
+		Integer b = other.order == null ? 0 : other.order;
+		return a == b ? 0 : (a > b ? 1 : -1);
+	}
+
+	/*******************************************************************************************************
+	* @description evaluates whether a record matches this rule
+	* @param record the SObject to test (must have the condition fields populated)
+	* @return Boolean true when the record satisfies the rule's conditions under its filter logic
+	*/
+	public Boolean matches(SObject record) {
+		if(conditions == null || conditions.isEmpty())
+			return false;
+		Map<Integer, Boolean> results = new Map<Integer, Boolean>();
+		Integer i = 1;
+		for(condition c:conditions) {
+			results.put(i, c.evaluate(record));
+			i++;
+		}
+		return MRG_FilterLogic.evaluate(filterLogic, results);
+	}
+
+	/*******************************************************************************************************
+	* @description the set of field api names referenced by this rule's conditions (for SOQL building)
+	* @return Set<String> field api names
+	*/
+	public Set<String> referencedFields() {
+		Set<String> fields = new Set<String>();
+		if(conditions != null) {
+			for(condition c:conditions) {
+				if(String.isNotBlank(c.fieldName))
+					fields.add(c.fieldName);
+			}
+		}
+		return fields;
+	}
+
+	/*******************************************************************************************************
+	* @description a single condition: a field, an operator, and a comparison value
+	*/
+	public class condition {
+		@auraEnabled public String fieldName;
+		@auraEnabled public String operator;   // equals, notEquals, lessThan, lessOrEqual, greaterThan, greaterOrEqual, contains, startsWith, endsWith
+		@auraEnabled public String value;      // raw string value; typed via the record's field type
+
+		public condition() {}
+
+		public condition(String fieldName, String operator, String value) {
+			this.fieldName = fieldName;
+			this.operator = operator;
+			this.value = value;
+		}
+
+		/*******************************************************************************************************
+		* @description evaluates this condition against a record's field value
+		* @param record the SObject under test
+		* @return Boolean the condition result
+		*/
+		public Boolean evaluate(SObject record) {
+			Object fieldVal = record.get(fieldName);
+			String type = MRG_Merge_SVC.getObjectType(fieldVal);
+			switch on operator {
+				when 'equals' {
+					return compareEquals(fieldVal, type);
+				}
+				when 'notEquals' {
+					return !compareEquals(fieldVal, type);
+				}
+				when 'contains' {
+					return fieldVal != null && value != null && String.valueOf(fieldVal).contains(value);
+				}
+				when 'startsWith' {
+					return fieldVal != null && value != null && String.valueOf(fieldVal).startsWith(value);
+				}
+				when 'endsWith' {
+					return fieldVal != null && value != null && String.valueOf(fieldVal).endsWith(value);
+				}
+				when 'lessThan', 'lessOrEqual', 'greaterThan', 'greaterOrEqual' {
+					return compareOrdered(fieldVal, type);
+				}
+				when else {
+					return false;
+				}
+			}
+		}
+
+		/*******************************************************************************************************
+		* @description equality comparison normalized to string, with explicit null handling
+		*/
+		private Boolean compareEquals(Object fieldVal, String type) {
+			if(fieldVal == null)
+				return String.isBlank(value);
+			if(type == 'Boolean')
+				return ((Boolean) fieldVal) == Boolean.valueOf(value);
+			return String.valueOf(fieldVal) == value;
+		}
+
+		/*******************************************************************************************************
+		* @description ordered (<, <=, >, >=) comparison, typed by the field value. A null field value or
+		* an unparseable comparison value yields false.
+		*/
+		private Boolean compareOrdered(Object fieldVal, String type) {
+			if(fieldVal == null || String.isBlank(value))
+				return false;
+			Integer cmp;
+			try {
+				switch on type {
+					when 'Date' {
+						cmp = ((Date) fieldVal) < Date.valueOf(value) ? -1 : (((Date) fieldVal) > Date.valueOf(value) ? 1 : 0);
+					}
+					when 'Datetime' {
+						Datetime dv = Datetime.valueOf(value);
+						cmp = ((Datetime) fieldVal) < dv ? -1 : (((Datetime) fieldVal) > dv ? 1 : 0);
+					}
+					when 'Integer', 'Long', 'Decimal', 'Double' {
+						Decimal fv = Decimal.valueOf(String.valueOf(fieldVal));
+						Decimal cv = Decimal.valueOf(value);
+						cmp = fv < cv ? -1 : (fv > cv ? 1 : 0);
+					}
+					when else {
+						String fv = String.valueOf(fieldVal);
+						cmp = fv < value ? -1 : (fv > value ? 1 : 0);
+					}
+				}
+			} catch(Exception e) {
+				return false;
+			}
+			switch on operator {
+				when 'lessThan' { return cmp < 0; }
+				when 'lessOrEqual' { return cmp <= 0; }
+				when 'greaterThan' { return cmp > 0; }
+				when 'greaterOrEqual' { return cmp >= 0; }
+				when else { return false; }
+			}
+		}
+	}
+
+	/*******************************************************************************************************
+	* @description from an ordered list of rules and a set of candidate records, returns the Id of the
+	* record to keep. Rules are evaluated in order; the first rule matched by exactly one record selects
+	* that record. Rules matched by zero or multiple records are skipped. Returns null when no rule yields
+	* a unique match (the caller falls back to its default keep selection).
+	* @param rules the ordered keep-record rules (already filtered to the object)
+	* @param records the candidate records (with condition fields populated)
+	* @return Id the keep record id, or null when no rule produced a unique match
+	*/
+	public static Id selectKeepId(List<MRG_KeepRecordRule> rules, List<SObject> records) {
+		if(rules == null || rules.isEmpty() || records == null || records.isEmpty())
+			return null;
+		List<MRG_KeepRecordRule> ordered = new List<MRG_KeepRecordRule>(rules);
+		ordered.sort();
+		for(MRG_KeepRecordRule rule:ordered) {
+			List<Id> matched = new List<Id>();
+			for(SObject record:records) {
+				if(rule.matches(record))
+					matched.add((Id) record.get('Id'));
+			}
+			if(matched.size() == 1)
+				return matched[0];
+		}
+		return null;
+	}
+}

--- a/force-app/main/default/classes/MRG_KeepRecordRule.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_KeepRecordRule.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_KeepRecordRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRule_TEST.cls
@@ -1,0 +1,137 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description unit tests for keep-record rule conditions, matching, and ordered keep selection
+*/
+@isTest
+private class MRG_KeepRecordRule_TEST {
+
+	private static MRG_KeepRecordRule.condition cond(String field, String op, String val) {
+		return new MRG_KeepRecordRule.condition(field, op, val);
+	}
+
+	static testMethod void testEqualsAndNotEquals() {
+		Contact c = new Contact(LastName='Smith', MailingState='TX');
+		system.assert(cond('MailingState','equals','TX').evaluate(c));
+		system.assert(!cond('MailingState','equals','CA').evaluate(c));
+		system.assert(cond('MailingState','notEquals','CA').evaluate(c));
+		// null field equals blank value
+		Contact blank = new Contact(LastName='X');
+		system.assert(cond('MailingState','equals','').evaluate(blank), 'null field equals blank');
+		system.assert(!cond('MailingState','equals','TX').evaluate(blank));
+	}
+
+	static testMethod void testBooleanEquals() {
+		Contact c = new Contact(LastName='X', HasOptedOutOfEmail=true);
+		system.assert(cond('HasOptedOutOfEmail','equals','true').evaluate(c));
+		system.assert(!cond('HasOptedOutOfEmail','equals','false').evaluate(c));
+		system.assert(cond('HasOptedOutOfEmail','notEquals','false').evaluate(c));
+	}
+
+	static testMethod void testStringOperators() {
+		Contact c = new Contact(LastName='Johnson');
+		system.assert(cond('LastName','contains','ohns').evaluate(c));
+		system.assert(cond('LastName','startsWith','John').evaluate(c));
+		system.assert(cond('LastName','endsWith','son').evaluate(c));
+		system.assert(!cond('LastName','contains','xyz').evaluate(c));
+	}
+
+	static testMethod void testOrderedDateOperators() {
+		Contact c = new Contact(LastName='X', Birthdate=Date.newInstance(2000,1,1));
+		system.assert(cond('Birthdate','greaterThan','1999-01-01').evaluate(c));
+		system.assert(cond('Birthdate','lessThan','2001-01-01').evaluate(c));
+		system.assert(cond('Birthdate','greaterOrEqual','2000-01-01').evaluate(c));
+		system.assert(cond('Birthdate','lessOrEqual','2000-01-01').evaluate(c));
+		system.assert(!cond('Birthdate','greaterThan','2001-01-01').evaluate(c));
+		// null field -> ordered comparison false
+		system.assert(!cond('Birthdate','greaterThan','2000-01-01').evaluate(new Contact(LastName='Y')));
+		// unparseable comparison value -> false, not an exception
+		system.assert(!cond('Birthdate','greaterThan','not-a-date').evaluate(c));
+	}
+
+	static testMethod void testMatchesUsesFilterLogic() {
+		Contact c = new Contact(LastName='X', MailingState='TX', HasOptedOutOfEmail=true);
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.filterLogic = '1 OR 2';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			cond('MailingState','equals','CA'),      // false
+			cond('HasOptedOutOfEmail','equals','true') // true
+		};
+		system.assert(rule.matches(c), '1 OR 2 with second true should match');
+
+		rule.filterLogic = '1 AND 2';
+		system.assert(!rule.matches(c), '1 AND 2 with first false should not match');
+	}
+
+	static testMethod void testMatchesEmptyConditionsIsFalse() {
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		system.assert(!rule.matches(new Contact(LastName='X')), 'no conditions -> no match');
+	}
+
+	static testMethod void testReferencedFields() {
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			cond('MailingState','equals','TX'),
+			cond('Birthdate','greaterThan','2000-01-01')
+		};
+		system.assertEquals(new Set<String>{'MailingState','Birthdate'}, rule.referencedFields());
+	}
+
+	static testMethod void testSelectKeepIdUniqueMatchWins() {
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', MailingState='TX'),
+			new Contact(FirstName='B', LastName='B', MailingState='CA')
+		};
+		insert cons;
+
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.order = 1;
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('MailingState','equals','CA') };
+
+		List<Contact> queried = [SELECT Id, MailingState FROM Contact];
+		Id keepId = MRG_KeepRecordRule.selectKeepId(new List<MRG_KeepRecordRule>{ rule }, queried);
+		system.assertEquals(cons[1].Id, keepId, 'the single CA record should be chosen');
+	}
+
+	static testMethod void testSelectKeepIdSkipsAmbiguousFallsToNextRule() {
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', MailingState='TX', HasOptedOutOfEmail=true),
+			new Contact(FirstName='B', LastName='B', MailingState='TX', HasOptedOutOfEmail=false)
+		};
+		insert cons;
+		List<Contact> queried = [SELECT Id, MailingState, HasOptedOutOfEmail FROM Contact];
+
+		// rule 1 matches BOTH (state=TX) -> ambiguous, skipped
+		MRG_KeepRecordRule rule1 = new MRG_KeepRecordRule();
+		rule1.order = 1;
+		rule1.conditions = new List<MRG_KeepRecordRule.condition>{ cond('MailingState','equals','TX') };
+		// rule 2 matches exactly one (opted out) -> wins
+		MRG_KeepRecordRule rule2 = new MRG_KeepRecordRule();
+		rule2.order = 2;
+		rule2.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+
+		Id keepId = MRG_KeepRecordRule.selectKeepId(new List<MRG_KeepRecordRule>{ rule2, rule1 }, queried);
+		system.assertEquals(cons[0].Id, keepId, 'rule order should be respected and ambiguous rule skipped');
+	}
+
+	static testMethod void testSelectKeepIdNoMatchReturnsNull() {
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', MailingState='TX'),
+			new Contact(FirstName='B', LastName='B', MailingState='TX')
+		};
+		insert cons;
+		List<Contact> queried = [SELECT Id, MailingState FROM Contact];
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('MailingState','equals','CA') };
+		system.assertEquals(null, MRG_KeepRecordRule.selectKeepId(new List<MRG_KeepRecordRule>{ rule }, queried),
+			'no unique match -> null (caller uses default)');
+	}
+
+	static testMethod void testCompareToOrders() {
+		MRG_KeepRecordRule a = new MRG_KeepRecordRule(); a.order = 2;
+		MRG_KeepRecordRule b = new MRG_KeepRecordRule(); b.order = 1;
+		List<MRG_KeepRecordRule> rules = new List<MRG_KeepRecordRule>{ a, b };
+		rules.sort();
+		system.assertEquals(1, rules[0].order, 'lower order sorts first');
+	}
+}

--- a/force-app/main/default/classes/MRG_KeepRecordRule_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_KeepRecordRule_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
First slice of #32 (keep-record by criteria). Pure core, no DML/UI — fully unit-tested.

Design (confirmed): **ordered priority rules** evaluated **at scan time**, with **full filter logic** (AND/OR/parentheses).

## What's here
- **`MRG_FilterLogic`** — recursive-descent parser/evaluator for strings like `(1 AND 2) OR 3`. Precedence: parentheses > AND > OR. Blank logic ANDs all conditions. `validate(logic, count)` checks syntax + that referenced numbers are in range. `ParseException` on malformed input.
- **`MRG_KeepRecordRule`** — a rule = ordered `condition` list + `filterLogic`. Conditions: `equals`, `notEquals`, `contains`, `startsWith`, `endsWith`, `lessThan/lessOrEqual/greaterThan/greaterOrEqual`, typed via `MRG_Merge_SVC.getObjectType` (date/datetime/number/string), unparseable comparisons return false rather than throwing. `selectKeepId(rules, records)` returns the keep id from the first rule with **exactly one** match; ambiguous/no-match rules are skipped; returns `null` when nothing is unique (caller keeps its current default).

## Tests
- `MRG_FilterLogic_TEST` — AND/OR/precedence/nested parens/case-insensitivity/tokenize/parse errors/range validation.
- `MRG_KeepRecordRule_TEST` — every operator, boolean/date typing, filter-logic matching, `selectKeepId` unique-match / ordered fall-through / no-match-null.

## Next slices
- 32b: `KeepRecordRuleSettings__mdt` + load/save via Metadata API
- 32c: integrate `selectKeepId` into `getMergeCandidate` at scan time
- 32d: Keep Record Rules LWC tab + controller