### PR TITLE
feat: KeepRecordRuleSettings__mdt + load/save service (#32)

### DIFF
--- a/force-app/main/default/classes/MRG_KeepRecordRule.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRule.cls
@@ -22,6 +22,21 @@ public with sharing class MRG_KeepRecordRule implements Comparable {
 	}
 
 	/*******************************************************************************************************
+	* @description builds a rule wrapper from a KeepRecordRuleSettings__mdt record
+	* @param setting the metadata record (with Object__r.QualifiedAPIName selected)
+	*/
+	public MRG_KeepRecordRule(KeepRecordRuleSettings__mdt setting) {
+		this.id = setting.Id;
+		this.label = setting.Label;
+		this.objectName = setting.Object__r != null ? setting.Object__r.QualifiedAPIName : null;
+		this.order = setting.Order__c != null ? Integer.valueOf(setting.Order__c) : 0;
+		this.filterLogic = setting.FilterLogic__c;
+		this.conditions = String.isNotBlank(setting.Conditions__c)
+			? (List<condition>) JSON.deserialize(setting.Conditions__c, List<condition>.class)
+			: new List<condition>();
+	}
+
+	/*******************************************************************************************************
 	* @description sorts rules by their evaluation order (ascending)
 	*/
 	public Integer compareTo(Object compareTo) {
@@ -187,5 +202,81 @@ public with sharing class MRG_KeepRecordRule implements Comparable {
 				return matched[0];
 		}
 		return null;
+	}
+
+	/*******************************************************************************************************
+	* @description all configured keep-record rules, lazily queried from custom metadata
+	*/
+	public static List<MRG_KeepRecordRule> keepRecordRules {
+		get {
+			if(keepRecordRules == null) {
+				List<MRG_KeepRecordRule> rules = new List<MRG_KeepRecordRule>();
+				for(KeepRecordRuleSettings__mdt setting:[
+					SELECT Id, Label, QualifiedAPIName, Object__c, Object__r.QualifiedAPIName,
+						Order__c, FilterLogic__c, Conditions__c
+					FROM KeepRecordRuleSettings__mdt
+				]) {
+					rules.add(new MRG_KeepRecordRule(setting));
+				}
+				keepRecordRules = rules;
+			}
+			return keepRecordRules;
+		}
+		set;
+	}
+
+	/*******************************************************************************************************
+	* @description the keep-record rules for a single object, sorted by evaluation order
+	* @param objectType the SObject api name
+	* @return List<MRG_KeepRecordRule> the rules for that object (may be empty)
+	*/
+	public static List<MRG_KeepRecordRule> getRules(String objectType) {
+		List<MRG_KeepRecordRule> rules = new List<MRG_KeepRecordRule>();
+		for(MRG_KeepRecordRule rule:keepRecordRules) {
+			if(String.isNotBlank(rule.objectName) && rule.objectName.equalsIgnoreCase(objectType))
+				rules.add(rule);
+		}
+		rules.sort();
+		return rules;
+	}
+
+	/*******************************************************************************************************
+	* @description saves a list of keep-record rules via the Metadata API
+	* @param rules the rules to save
+	* @return String the metadata deploy job id
+	*/
+	public static String saveKeepRecordRules(List<MRG_KeepRecordRule> rules) {
+		MRG_Metadata_SVC mdService = new MRG_Metadata_SVC();
+		List<Metadata.CustomMetadata> mdRecords = new List<Metadata.CustomMetadata>();
+		for(MRG_KeepRecordRule rule:rules) {
+			mdRecords.add(mdService.getMetaDataRecord(toSetting(rule)));
+		}
+		return mdService.deployMetadataRecords(mdRecords);
+	}
+
+	/*******************************************************************************************************
+	* @description converts a rule wrapper into a KeepRecordRuleSettings__mdt record, populating the
+	* read-only Object__r relationship via JSON injection (mirrors the existing settings-save pattern)
+	* @param rule the rule wrapper
+	* @return KeepRecordRuleSettings__mdt the metadata record
+	*/
+	public static KeepRecordRuleSettings__mdt toSetting(MRG_KeepRecordRule rule) {
+		KeepRecordRuleSettings__mdt setting = new KeepRecordRuleSettings__mdt(
+			Label = String.isNotBlank(rule.label) ? rule.label : (rule.objectName + ' Keep Rule ' + rule.order),
+			Order__c = rule.order,
+			FilterLogic__c = rule.filterLogic,
+			Conditions__c = JSON.serialize(rule.conditions == null ? new List<condition>() : rule.conditions)
+		);
+		// developer/qualified name: object prefix + order, sanitized
+		String devName = (rule.objectName == null ? 'Obj' : rule.objectName.replace('__','').replace('_','')) + 'KeepRule' + rule.order;
+		setting.QualifiedAPIName = devName;
+		Map<String, Object> settingJSON = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(setting));
+		settingJSON.put('Object__r', new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' },
+			'QualifiedAPIName' => rule.objectName
+		});
+		if(String.isNotBlank(rule.id))
+			settingJSON.put('Id', rule.id);
+		return (KeepRecordRuleSettings__mdt) JSON.deserialize(JSON.serialize(settingJSON), KeepRecordRuleSettings__mdt.class);
 	}
 }

--- a/force-app/main/default/classes/MRG_KeepRecordRuleSettings_TEST.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRuleSettings_TEST.cls
@@ -1,0 +1,105 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for loading and saving keep-record rules from/to KeepRecordRuleSettings__mdt
+*/
+@isTest
+private class MRG_KeepRecordRuleSettings_TEST {
+
+	/*******************************************************************************************************
+	* @description builds an in-memory KeepRecordRuleSettings__mdt with the read-only Object__r
+	* relationship populated via JSON injection
+	*/
+	private static KeepRecordRuleSettings__mdt buildSetting(String objectName, Integer order, String filterLogic, String conditionsJson) {
+		KeepRecordRuleSettings__mdt setting = new KeepRecordRuleSettings__mdt();
+		Map<String, Object> fieldMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(setting));
+		fieldMap.put(KeepRecordRuleSettings__mdt.Label.getDescribe().getName(), objectName+' rule '+order);
+		fieldMap.put(KeepRecordRuleSettings__mdt.DeveloperName.getDescribe().getName(), objectName+'Rule'+order);
+		fieldMap.put(KeepRecordRuleSettings__mdt.Order__c.getDescribe().getName(), order);
+		fieldMap.put(KeepRecordRuleSettings__mdt.FilterLogic__c.getDescribe().getName(), filterLogic);
+		fieldMap.put(KeepRecordRuleSettings__mdt.Conditions__c.getDescribe().getName(), conditionsJson);
+		fieldMap.put('Object__r', new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' },
+			'QualifiedAPIName' => objectName
+		});
+		return (KeepRecordRuleSettings__mdt) JSON.deserialize(JSON.serialize(fieldMap), KeepRecordRuleSettings__mdt.class);
+	}
+
+	static testMethod void testConstructorParsesSetting() {
+		String conditions = JSON.serialize(new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('MailingState','equals','TX'),
+			new MRG_KeepRecordRule.condition('HasOptedOutOfEmail','equals','true')
+		});
+		KeepRecordRuleSettings__mdt setting = buildSetting('Contact', 2, '1 OR 2', conditions);
+
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule(setting);
+		system.assertEquals('Contact', rule.objectName);
+		system.assertEquals(2, rule.order);
+		system.assertEquals('1 OR 2', rule.filterLogic);
+		system.assertEquals(2, rule.conditions.size());
+		system.assertEquals('MailingState', rule.conditions[0].fieldName);
+		system.assertEquals('true', rule.conditions[1].value);
+	}
+
+	static testMethod void testConstructorHandlesBlankConditions() {
+		KeepRecordRuleSettings__mdt setting = buildSetting('Account', 1, null, null);
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule(setting);
+		system.assertEquals(0, rule.conditions.size(), 'blank conditions -> empty list, not null');
+	}
+
+	static testMethod void testGetRulesFiltersAndSorts() {
+		// inject rules directly via the property setter
+		MRG_KeepRecordRule contactRule2 = new MRG_KeepRecordRule();
+		contactRule2.objectName = 'Contact'; contactRule2.order = 2;
+		MRG_KeepRecordRule contactRule1 = new MRG_KeepRecordRule();
+		contactRule1.objectName = 'Contact'; contactRule1.order = 1;
+		MRG_KeepRecordRule accountRule = new MRG_KeepRecordRule();
+		accountRule.objectName = 'Account'; accountRule.order = 1;
+		MRG_KeepRecordRule.keepRecordRules = new List<MRG_KeepRecordRule>{ contactRule2, accountRule, contactRule1 };
+
+		List<MRG_KeepRecordRule> contactRules = MRG_KeepRecordRule.getRules('Contact');
+		system.assertEquals(2, contactRules.size(), 'only contact rules returned');
+		system.assertEquals(1, contactRules[0].order, 'sorted by order ascending');
+		system.assertEquals(2, contactRules[1].order);
+
+		system.assertEquals(1, MRG_KeepRecordRule.getRules('Account').size());
+		system.assertEquals(0, MRG_KeepRecordRule.getRules('Lead').size());
+	}
+
+	static testMethod void testToSettingSerializesConditionsAndObject() {
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Contact';
+		rule.order = 1;
+		rule.filterLogic = '1 AND 2';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('MailingState','equals','TX')
+		};
+
+		KeepRecordRuleSettings__mdt setting = MRG_KeepRecordRule.toSetting(rule);
+		system.assertEquals('Contact', setting.Object__r.QualifiedAPIName, 'object relationship injected');
+		system.assertEquals(1, setting.Order__c);
+		system.assertEquals('1 AND 2', setting.FilterLogic__c);
+		system.assert(setting.Conditions__c.contains('MailingState'), 'conditions serialized to JSON');
+		// round trip back through the constructor
+		MRG_KeepRecordRule roundTrip = new MRG_KeepRecordRule(setting);
+		system.assertEquals(1, roundTrip.conditions.size());
+		system.assertEquals('MailingState', roundTrip.conditions[0].fieldName);
+	}
+
+	static testMethod void testSaveKeepRecordRules() {
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Contact';
+		rule.order = 1;
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('HasOptedOutOfEmail','equals','true')
+		};
+
+		Test.startTest();
+		String jobId = MRG_KeepRecordRule.saveKeepRecordRules(new List<MRG_KeepRecordRule>{ rule });
+		Test.stopTest();
+
+		// in test context the metadata service returns a stub job id rather than enqueuing a deploy
+		system.assertEquals('Test Job Id', jobId);
+	}
+}

--- a/force-app/main/default/classes/MRG_KeepRecordRuleSettings_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_KeepRecordRuleSettings_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_Metadata_SVC.cls
+++ b/force-app/main/default/classes/MRG_Metadata_SVC.cls
@@ -112,6 +112,40 @@ public with sharing class MRG_Metadata_SVC {
 	* @param integrationProcessToSave the integration process we're saving
 	* @return the Job Id of the deployment job
 	*/ 		
+	public Metadata.CustomMetadata getMetaDataRecord(KeepRecordRuleSettings__mdt keepRuleSetting) {
+		   	// create metadata container
+		Metadata.CustomMetadata mdRecord = new Metadata.CustomMetadata();
+		List<String> mdRecordNames = new List<String>();
+		// map for setting values in meta data record
+		Map<String, Object> fieldKeyValues = new Map<String, Object>();
+		// populate fieldkeyvalue map with the current record's values
+		fieldKeyValues.put('Object__c', keepRuleSetting.Object__r.QualifiedAPIName);
+		fieldKeyValues.put('Order__c', keepRuleSetting.Order__c);
+		fieldKeyValues.put('FilterLogic__c', keepRuleSetting.FilterLogic__c);
+		fieldKeyValues.put('Conditions__c', keepRuleSetting.Conditions__c);
+		String qualifiedName = !keepRuleSetting.QualifiedAPIName.contains('.') ? 'KeepRecordRuleSettings__mdt.'+keepRuleSetting.QualifiedAPIName : keepRuleSetting.QualifiedAPIName;
+		mdRecordNames.add(qualifiedName);
+
+		// get existing metadata records based on qualified name
+		List<Metadata.Metadata> metadataRecords = getMetadataRecords(mdRecordNames);
+		if(metadataRecords.size()>0) {
+			// this is an existing record
+			mdRecord = (Metadata.CustomMetadata) metadataRecords.get(0).clone();
+		} else {
+			mdRecord.fullName = qualifiedName;
+		}
+		mdRecord.Label = keepRuleSetting.Label;
+		// add new field values to record
+
+		mdRecord = updateMetadataObjectFields(mdRecord, fieldKeyValues);
+
+		return mdRecord;
+	}
+	/*******************************************************************************************************
+	* @description saves an integration process via metadata deployment
+	* @param integrationProcessToSave the integration process we're saving
+	* @return the Job Id of the deployment job
+	*/
 	public Metadata.CustomMetadata getMetaDataRecord(DuplicateRuleSettings__mdt dupeRuleSetting) {
 		   	// create metadata container
 		Metadata.CustomMetadata mdRecord = new Metadata.CustomMetadata();

--- a/force-app/main/default/objects/KeepRecordRuleSettings__mdt/KeepRecordRuleSettings__mdt.object-meta.xml
+++ b/force-app/main/default/objects/KeepRecordRuleSettings__mdt/KeepRecordRuleSettings__mdt.object-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Keep Record Rule Setting</label>
+    <pluralLabel>Keep Record Rule Settings</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/Conditions__c.field-meta.xml
+++ b/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/Conditions__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Conditions__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>JSON array of the rule's conditions (field, operator, value). Maintained by the Keep Record Rules UI.</inlineHelpText>
+    <label>Conditions</label>
+    <required>false</required>
+    <type>LongTextArea</type>
+    <length>131072</length>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/FilterLogic__c.field-meta.xml
+++ b/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/FilterLogic__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FilterLogic__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Report-style logic combining the numbered conditions, e.g. (1 AND 2) OR 3. Leave blank to AND all conditions.</inlineHelpText>
+    <label>Filter Logic</label>
+    <required>false</required>
+    <type>Text</type>
+    <length>255</length>
+</CustomField>

--- a/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/Object__c.field-meta.xml
+++ b/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/Object__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Object__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Object</label>
+    <referenceTo>EntityDefinition</referenceTo>
+    <relationshipLabel>KeepRecordRuleSettings</relationshipLabel>
+    <relationshipName>KeepRecordRuleSettings</relationshipName>
+    <required>true</required>
+    <type>MetadataRelationship</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/Order__c.field-meta.xml
+++ b/force-app/main/default/objects/KeepRecordRuleSettings__mdt/fields/Order__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Order__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Order</label>
+    <precision>4</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Second slice of #32 (keep-record by criteria). Persistence layer; builds on the merged 32a engine.

## What's here
- **`KeepRecordRuleSettings__mdt`** — new custom metadata type:
  - `Object__c` (MetadataRelationship → EntityDefinition)
  - `Order__c` (Number) — evaluation order
  - `FilterLogic__c` (Text 255) — the report-style logic string
  - `Conditions__c` (LongTextArea) — JSON array of conditions
- **`MRG_Metadata_SVC.getMetaDataRecord(KeepRecordRuleSettings__mdt)`** — mirrors the existing `DuplicateRuleSettings__mdt` deploy pattern.
- **`MRG_KeepRecordRule`** additions:
  - constructor from the mdt (parses `Conditions__c` JSON)
  - `keepRecordRules` lazily-queried property (test-injectable via setter)
  - `getRules(objectType)` — filtered to object, sorted by order
  - `toSetting(rule)` — wrapper → mdt with JSON-injected `Object__r` and serialized conditions
  - `saveKeepRecordRules(rules)` — deploys via the Metadata API

## Tests
`MRG_KeepRecordRuleSettings_TEST` — constructor parse (incl. blank conditions), `getRules` filter+sort, `toSetting` round-trip, and `saveKeepRecordRules` (returns the `Test Job Id` stub in test context).

## Holding merge
Net-new metadata + Apex — please compile/deploy this branch and run its tests before I merge, same as 32a. Then I'll proceed to 32c (integrate `selectKeepId` into `getMergeCandidate`).