### PR TITLE
feat: apply keep-record rules at scan time (#32)

### DIFF
--- a/force-app/main/default/classes/MRG_Duplicate_SVC.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_SVC.cls
@@ -335,8 +335,11 @@ public with sharing class MRG_Duplicate_SVC {
             // if keep-record rules are configured for this object, let them choose the keep record;
             // a unique rule match moves that id to the front. Otherwise the sorted-id default stands.
             Id ruleKeepId = selectKeepIdByRules(matchIdList, objectType);
-            if(ruleKeepId != null && matchIdList.remove(String.valueOf(ruleKeepId)))
+            Integer keepIdx = ruleKeepId == null ? -1 : matchIdList.indexOf(String.valueOf(ruleKeepId));
+            if(keepIdx > 0) {
+                matchIdList.remove(keepIdx);
                 matchIdList.add(0, String.valueOf(ruleKeepId));
+            }
             mergeCandidate.KeepRecordId__c = matchIdList[0];
             mergeCandidate.KeepName__c = String.isNotBlank(mergeCandidate.KeepRecordId__c) ? matchNames.get(mergeCandidate.KeepRecordId__c) : null;
             mergeCandidate.MergeRecordId__c = matchIdList.size()>1 ? matchIdList[1] : null;

--- a/force-app/main/default/classes/MRG_Duplicate_SVC.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_SVC.cls
@@ -332,6 +332,11 @@ public with sharing class MRG_Duplicate_SVC {
             List<String> matchIdList = new List<String>();
             matchIdList.addAll(allIds);
             matchIdList.sort();
+            // if keep-record rules are configured for this object, let them choose the keep record;
+            // a unique rule match moves that id to the front. Otherwise the sorted-id default stands.
+            Id ruleKeepId = selectKeepIdByRules(matchIdList, objectType);
+            if(ruleKeepId != null && matchIdList.remove(String.valueOf(ruleKeepId)))
+                matchIdList.add(0, String.valueOf(ruleKeepId));
             mergeCandidate.KeepRecordId__c = matchIdList[0];
             mergeCandidate.KeepName__c = String.isNotBlank(mergeCandidate.KeepRecordId__c) ? matchNames.get(mergeCandidate.KeepRecordId__c) : null;
             mergeCandidate.MergeRecordId__c = matchIdList.size()>1 ? matchIdList[1] : null;
@@ -354,10 +359,33 @@ public with sharing class MRG_Duplicate_SVC {
 
     }
 	/*******************************************************************************************************
+	* @description applies the configured keep-record rules to a group of matched ids and returns the id
+	* of the record to keep, or null when no rule produces a unique match (caller keeps its default).
+	* Queries only the fields the rules reference, for the matched ids.
+	* @param matchIdList the ids in the duplicate group
+	* @param objectType the SObject type
+	* @return Id the rule-selected keep id, or null
+	*/
+    @testvisible
+    private static Id selectKeepIdByRules(List<String> matchIdList, String objectType) {
+        List<MRG_KeepRecordRule> rules = MRG_KeepRecordRule.getRules(objectType);
+        if(rules.isEmpty())
+            return null;
+        Set<String> fields = new Set<String>{'Id'};
+        for(MRG_KeepRecordRule rule:rules)
+            fields.addAll(rule.referencedFields());
+        Set<Id> ids = new Set<Id>();
+        for(String idStr:matchIdList)
+            ids.add(Id.valueOf(idStr));
+        String soql = 'SELECT ' + String.join(new List<String>(fields), ',') + ' FROM ' + objectType + ' WHERE Id IN :ids';
+        List<SObject> records = Database.query(soql);
+        return MRG_KeepRecordRule.selectKeepId(rules, records);
+    }
+	/*******************************************************************************************************
 	* @description determines if duplicate rules are active for this object
 	* @param List<SObject> records
 	* @return Boolean
-	*/ 
+	*/
 	public static Boolean duplicateRulesAreActive(List<Id> recordIds) {
 		Boolean rulesAreActive = true;
 		try {

--- a/force-app/main/default/classes/MRG_Duplicate_TEST.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_TEST.cls
@@ -65,4 +65,45 @@ private class MRG_Duplicate_TEST {
 
     }
 
+	static testMethod void testSelectKeepIdByRulesNoRulesReturnsNull() {
+		List<Contact> cons = [SELECT Id FROM Contact];
+		List<String> ids = new List<String>{ cons[0].Id, cons[1].Id };
+		// no keep-record rules configured
+		MRG_KeepRecordRule.keepRecordRules = new List<MRG_KeepRecordRule>();
+		system.assertEquals(null, MRG_Duplicate_SVC.selectKeepIdByRules(ids, 'Contact'),
+			'no rules -> null so caller keeps the sorted-id default');
+	}
+
+	static testMethod void testSelectKeepIdByRulesUniqueMatch() {
+		// setup contacts: one in CA, one in TX
+		List<Contact> cons = [SELECT Id, MailingState FROM Contact ORDER BY MailingState];
+		Id caId = cons[0].MailingState == 'CA' ? cons[0].Id : cons[1].Id;
+		List<String> ids = new List<String>{ cons[0].Id, cons[1].Id };
+
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Contact';
+		rule.order = 1;
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('MailingState','equals','CA')
+		};
+		MRG_KeepRecordRule.keepRecordRules = new List<MRG_KeepRecordRule>{ rule };
+
+		system.assertEquals(caId, MRG_Duplicate_SVC.selectKeepIdByRules(ids, 'Contact'),
+			'the CA record should be selected by the keep rule');
+	}
+
+	static testMethod void testSelectKeepIdByRulesNoUniqueMatchReturnsNull() {
+		List<Contact> cons = [SELECT Id FROM Contact];
+		List<String> ids = new List<String>{ cons[0].Id, cons[1].Id };
+		// rule matches a state neither contact has -> no match -> null
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Contact';
+		rule.order = 1;
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('MailingState','equals','ZZ')
+		};
+		MRG_KeepRecordRule.keepRecordRules = new List<MRG_KeepRecordRule>{ rule };
+		system.assertEquals(null, MRG_Duplicate_SVC.selectKeepIdByRules(ids, 'Contact'));
+	}
+
 }


### PR DESCRIPTION
Third slice of #32 — the behavior-changing integration. Builds on merged 32a/32b.

## What changed
`MRG_Duplicate_SVC.getMergeCandidate` now consults configured keep-record rules:
- New `@testvisible private selectKeepIdByRules(matchIdList, objectType)` — loads `MRG_KeepRecordRule.getRules(objectType)`, queries **only the referenced fields** for the matched ids (single SOQL), and delegates to `MRG_KeepRecordRule.selectKeepId`.
- If a rule yields a unique match, that id is moved to the front of the sorted match list → becomes `KeepRecordId__c`. The remaining ids stay sorted as Merge/Merge2.
- **No rules configured, or no unique match → unchanged behavior** (sorted-id default). Backwards compatible.

## Tests
`Datacloud.DuplicateResult` still can't be mocked, but the integration logic is isolated in `selectKeepIdByRules` and fully covered in `MRG_Duplicate_TEST`:
- no rules → null (default preserved)
- unique rule match → that record's id selected
- rule matches nothing → null

## Holding merge
Please compile/deploy + run tests before I merge, as with 32a/32b. Then the final slice is 32d (the LWC criteria-builder tab + controller).