### PR TITLE
feat: Keep Record Rules UI tab + controller (#32)

### DIFF
--- a/force-app/main/default/classes/MRG_KeepRecordRules_CTRL.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRules_CTRL.cls
@@ -1,0 +1,82 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description controller for the Keep Record Rules LWC tab. Loads/saves keep-record rules and
+* provides the object field list and operator options for the criteria builder.
+*/
+public with sharing class MRG_KeepRecordRules_CTRL {
+
+	/*******************************************************************************************************
+	* @description the keep-record rules configured for an object, ordered
+	* @param objectType the SObject api name
+	* @return List<MRG_KeepRecordRule> the rules (empty when none)
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_KeepRecordRule> getKeepRecordRules(String objectType) {
+		if(String.isBlank(objectType))
+			return new List<MRG_KeepRecordRule>();
+		return MRG_KeepRecordRule.getRules(objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description the updateable, accessible fields for an object (label, name, type) for field pickers.
+	* Reuses the field describe used by the field-settings UI.
+	* @param objectType the SObject api name
+	* @return List<MRG_Merge_SVC.objectField>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_Merge_SVC.objectField> getObjectFields(String objectType) {
+		return MRG_MergeSettings_CTRL.getObjectFields(objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description the condition operator options for the criteria builder
+	* @return List<operatorOption>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<operatorOption> getOperators() {
+		return new List<operatorOption>{
+			new operatorOption('equals', 'equals'),
+			new operatorOption('notEquals', 'not equals'),
+			new operatorOption('lessThan', 'less than'),
+			new operatorOption('lessOrEqual', 'less or equal'),
+			new operatorOption('greaterThan', 'greater than'),
+			new operatorOption('greaterOrEqual', 'greater or equal'),
+			new operatorOption('contains', 'contains'),
+			new operatorOption('startsWith', 'starts with'),
+			new operatorOption('endsWith', 'ends with')
+		};
+	}
+
+	/*******************************************************************************************************
+	* @description saves the keep-record rules supplied as JSON from the UI. Validates each rule's filter
+	* logic before deploying so a malformed expression is rejected with a clear message.
+	* @param jsonData a JSON array of MRG_KeepRecordRule
+	* @return String the metadata deploy job id
+	*/
+	@auraEnabled
+	public static String saveKeepRecordRules(String jsonData) {
+		List<MRG_KeepRecordRule> rules = (List<MRG_KeepRecordRule>) JSON.deserialize(jsonData, List<MRG_KeepRecordRule>.class);
+		for(MRG_KeepRecordRule rule:rules) {
+			Integer count = rule.conditions == null ? 0 : rule.conditions.size();
+			try {
+				MRG_FilterLogic.validate(rule.filterLogic, count);
+			} catch(MRG_FilterLogic.ParseException e) {
+				throw new AuraHandledException('Invalid filter logic for rule "' + rule.label + '": ' + e.getMessage());
+			}
+		}
+		return MRG_KeepRecordRule.saveKeepRecordRules(rules);
+	}
+
+	/*******************************************************************************************************
+	* @description a condition operator option for the UI
+	*/
+	public class operatorOption {
+		@auraEnabled public String value;
+		@auraEnabled public String label;
+		public operatorOption(String value, String label) {
+			this.value = value;
+			this.label = label;
+		}
+	}
+}

--- a/force-app/main/default/classes/MRG_KeepRecordRules_CTRL.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_KeepRecordRules_CTRL.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_KeepRecordRules_CTRL_TEST.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRules_CTRL_TEST.cls
@@ -1,0 +1,70 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for the Keep Record Rules controller
+*/
+@isTest
+private class MRG_KeepRecordRules_CTRL_TEST {
+
+	static testMethod void testGetKeepRecordRules() {
+		system.assertEquals(0, MRG_KeepRecordRules_CTRL.getKeepRecordRules('').size(), 'blank object -> empty');
+		// inject a rule and read it back through the controller
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Contact';
+		rule.order = 1;
+		MRG_KeepRecordRule.keepRecordRules = new List<MRG_KeepRecordRule>{ rule };
+		system.assertEquals(1, MRG_KeepRecordRules_CTRL.getKeepRecordRules('Contact').size());
+		system.assertEquals(0, MRG_KeepRecordRules_CTRL.getKeepRecordRules('Account').size());
+	}
+
+	static testMethod void testGetOperators() {
+		List<MRG_KeepRecordRules_CTRL.operatorOption> ops = MRG_KeepRecordRules_CTRL.getOperators();
+		system.assert(ops.size() >= 9, 'all operators returned');
+		Set<String> values = new Set<String>();
+		for(MRG_KeepRecordRules_CTRL.operatorOption op:ops)
+			values.add(op.value);
+		system.assert(values.contains('equals') && values.contains('greaterThan') && values.contains('contains'));
+	}
+
+	static testMethod void testGetObjectFields() {
+		List<MRG_Merge_SVC.objectField> fields = MRG_KeepRecordRules_CTRL.getObjectFields('Contact');
+		system.assert(fields.size() > 0, 'contact has updateable fields');
+		system.assertEquals(0, MRG_KeepRecordRules_CTRL.getObjectFields('').size(), 'blank object -> empty');
+	}
+
+	static testMethod void testSaveValid() {
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Contact';
+		rule.order = 1;
+		rule.label = 'r1';
+		rule.filterLogic = '1 AND 2';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('MailingState','equals','TX'),
+			new MRG_KeepRecordRule.condition('HasOptedOutOfEmail','equals','true')
+		};
+
+		Test.startTest();
+		String jobId = MRG_KeepRecordRules_CTRL.saveKeepRecordRules(JSON.serialize(new List<MRG_KeepRecordRule>{ rule }));
+		Test.stopTest();
+		system.assertEquals('Test Job Id', jobId, 'valid rules deploy (stub job id in test context)');
+	}
+
+	static testMethod void testSaveInvalidFilterLogicThrows() {
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Contact';
+		rule.order = 1;
+		rule.label = 'bad';
+		rule.filterLogic = '1 AND 5'; // references condition 5 with only 1 condition
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('MailingState','equals','TX')
+		};
+
+		Boolean threw = false;
+		try {
+			MRG_KeepRecordRules_CTRL.saveKeepRecordRules(JSON.serialize(new List<MRG_KeepRecordRule>{ rule }));
+		} catch(AuraHandledException e) {
+			threw = true;
+		}
+		system.assert(threw, 'invalid filter logic should raise an AuraHandledException');
+	}
+}

--- a/force-app/main/default/classes/MRG_KeepRecordRules_CTRL_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_KeepRecordRules_CTRL_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/keepRecordRules/keepRecordRules.html
+++ b/force-app/main/default/lwc/keepRecordRules/keepRecordRules.html
@@ -1,0 +1,123 @@
+<template>
+    <lightning-card title="Keep Record Rules" icon-name="standard:record">
+        <div class="slds-m-horizontal_medium">
+            <p class="slds-m-bottom_small slds-text-color_weak">
+                Rules are evaluated in order. The first rule matched by exactly one record in a duplicate
+                group chooses the record to keep; rules matched by zero or multiple records are skipped.
+                If no rule produces a single match, the default keep selection is used.
+            </p>
+
+            <lightning-combobox
+                label="Object"
+                value={objectType}
+                options={objectOptions}
+                onchange={handleObjectChange}>
+            </lightning-combobox>
+
+            <template if:true={hasObject}>
+                <template for:each={rules} for:item="rule">
+                    <div key={rule.uiKey} class="slds-box slds-m-vertical_small">
+                        <div class="slds-grid slds-grid_align-spread slds-m-bottom_x-small">
+                            <lightning-input
+                                class="slds-size_1-of-2"
+                                label="Rule Label"
+                                value={rule.label}
+                                data-rule={rule.ruleIndex}
+                                onchange={handleLabelChange}>
+                            </lightning-input>
+                            <div class="slds-text-body_small slds-align-middle">Order: {rule.order}</div>
+                            <lightning-button-icon
+                                icon-name="utility:delete"
+                                alternative-text="Remove rule"
+                                title="Remove rule"
+                                data-rule={rule.ruleIndex}
+                                onclick={removeRule}>
+                            </lightning-button-icon>
+                        </div>
+
+                        <template for:each={rule.conditions} for:item="condition">
+                            <div key={condition.uiKey} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
+                                <div class="slds-col slds-size_1-of-12 slds-text-body_small slds-align-middle">
+                                    {condition.conditionIndex}
+                                </div>
+                                <div class="slds-col slds-size_4-of-12">
+                                    <lightning-combobox
+                                        label="Field"
+                                        value={condition.fieldName}
+                                        options={fieldOptions}
+                                        data-rule={condition.ruleIndex}
+                                        data-condition={condition.conditionIndex}
+                                        onchange={handleFieldChange}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_3-of-12">
+                                    <lightning-combobox
+                                        label="Operator"
+                                        value={condition.operator}
+                                        options={operatorOptions}
+                                        data-rule={condition.ruleIndex}
+                                        data-condition={condition.conditionIndex}
+                                        onchange={handleOperatorChange}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_3-of-12">
+                                    <template if:true={condition.isCheckbox}>
+                                        <lightning-input
+                                            type="checkbox"
+                                            label="Value"
+                                            checked={condition.checked}
+                                            data-rule={condition.ruleIndex}
+                                            data-condition={condition.conditionIndex}
+                                            onchange={handleValueChange}>
+                                        </lightning-input>
+                                    </template>
+                                    <template if:false={condition.isCheckbox}>
+                                        <lightning-input
+                                            type={condition.inputType}
+                                            label="Value"
+                                            value={condition.value}
+                                            data-rule={condition.ruleIndex}
+                                            data-condition={condition.conditionIndex}
+                                            onchange={handleValueChange}>
+                                        </lightning-input>
+                                    </template>
+                                </div>
+                                <div class="slds-col slds-size_1-of-12">
+                                    <lightning-button-icon
+                                        icon-name="utility:close"
+                                        alternative-text="Remove condition"
+                                        title="Remove condition"
+                                        data-rule={condition.ruleIndex}
+                                        data-condition={condition.conditionIndex}
+                                        onclick={removeCondition}>
+                                    </lightning-button-icon>
+                                </div>
+                            </div>
+                        </template>
+
+                        <lightning-button
+                            label="Add Condition"
+                            icon-name="utility:add"
+                            variant="base"
+                            class="slds-m-bottom_x-small"
+                            data-rule={rule.ruleIndex}
+                            onclick={addCondition}>
+                        </lightning-button>
+
+                        <lightning-input
+                            label="Filter Logic (e.g. (1 AND 2) OR 3 — leave blank to AND all conditions)"
+                            value={rule.filterLogic}
+                            data-rule={rule.ruleIndex}
+                            onchange={handleLogicChange}>
+                        </lightning-input>
+                    </div>
+                </template>
+
+                <div class="slds-grid slds-gutters slds-m-vertical_small">
+                    <lightning-button label="Add Rule" icon-name="utility:add" onclick={addRule} class="slds-m-right_x-small"></lightning-button>
+                    <lightning-button label="Save" variant="brand" onclick={handleSave}></lightning-button>
+                </div>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/keepRecordRules/keepRecordRules.js
+++ b/force-app/main/default/lwc/keepRecordRules/keepRecordRules.js
@@ -1,0 +1,249 @@
+import { LightningElement, track, wire } from 'lwc';
+import { subscribe, onError } from 'lightning/empApi';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getKeepRecordRules from '@salesforce/apex/MRG_KeepRecordRules_CTRL.getKeepRecordRules';
+import getObjectFields from '@salesforce/apex/MRG_KeepRecordRules_CTRL.getObjectFields';
+import getOperators from '@salesforce/apex/MRG_KeepRecordRules_CTRL.getOperators';
+import saveKeepRecordRules from '@salesforce/apex/MRG_KeepRecordRules_CTRL.saveKeepRecordRules';
+
+export default class KeepRecordRules extends LightningElement {
+    @track objectType = '';
+    @track rules = [];
+    @track fieldOptions = [];
+    @track operatorOptions = [];
+    fieldTypeByName = {};
+
+    objectOptions = [
+        { label: 'Select an Object', value: '' },
+        { label: 'Account', value: 'Account' },
+        { label: 'Contact', value: 'Contact' }
+    ];
+
+    channelName = '/event/MergeRecordSave__e';
+    notificationTitle;
+    notificationBody;
+    notificationStyle;
+
+    connectedCallback() {
+        this.registerErrorListener();
+        this.handleSubscribe();
+    }
+
+    @wire(getOperators)
+    wiredOperators({ data }) {
+        if (data) {
+            this.operatorOptions = data;
+        }
+    }
+
+    get hasObject() {
+        return this.objectType !== '' && this.objectType != null;
+    }
+
+    handleObjectChange(event) {
+        this.objectType = event.detail.value;
+        this.rules = [];
+        if (this.hasObject) {
+            this.loadFields();
+            this.loadRules();
+        }
+    }
+
+    loadFields() {
+        getObjectFields({ objectType: this.objectType })
+            .then((result) => {
+                this.fieldOptions = result.map((f) => ({ label: f.label, value: f.name }));
+                const map = {};
+                result.forEach((f) => { map[f.name] = f.type; });
+                this.fieldTypeByName = map;
+            })
+            .catch((error) => this.handleError(error));
+    }
+
+    loadRules() {
+        getKeepRecordRules({ objectType: this.objectType })
+            .then((result) => {
+                this.rules = this.decorate(JSON.parse(JSON.stringify(result)));
+            })
+            .catch((error) => this.handleError(error));
+    }
+
+    // add UI-only keys (stable row keys, indices for event handlers, per-condition input type)
+    decorate(rules) {
+        const decorated = rules.map((rule, ri) => {
+            rule.uiKey = 'rule-' + ri + '-' + Date.now();
+            rule.ruleIndex = ri;
+            rule.conditions = (rule.conditions || []).map((c, ci) => this.decorateCondition(c, ri, ci));
+            return rule;
+        });
+        return decorated;
+    }
+
+    decorateCondition(condition, ri, ci) {
+        condition.uiKey = 'cond-' + ri + '-' + ci + '-' + Date.now();
+        condition.ruleIndex = ri;
+        condition.conditionIndex = ci;
+        const type = this.fieldTypeByName[condition.fieldName];
+        condition.inputType = this.inputTypeForFieldType(type);
+        condition.isCheckbox = condition.inputType === 'checkbox';
+        condition.checked = condition.isCheckbox && condition.value === 'true';
+        return condition;
+    }
+
+    inputTypeForFieldType(fieldType) {
+        switch (fieldType) {
+            case 'BOOLEAN': return 'checkbox';
+            case 'DATE': return 'date';
+            case 'DATETIME': return 'datetime-local';
+            case 'DOUBLE':
+            case 'CURRENCY':
+            case 'INTEGER':
+            case 'LONG':
+            case 'PERCENT': return 'number';
+            default: return 'text';
+        }
+    }
+
+    addRule() {
+        const order = this.rules.length + 1;
+        const rule = {
+            id: null,
+            label: this.objectType + ' Keep Rule ' + order,
+            objectName: this.objectType,
+            order: order,
+            filterLogic: '',
+            conditions: []
+        };
+        this.rules = this.decorate([...this.rules, rule]);
+    }
+
+    removeRule(event) {
+        const idx = parseInt(event.target.dataset.rule, 10);
+        const rules = [...this.rules];
+        rules.splice(idx, 1);
+        // renumber order to stay 1-based and contiguous
+        rules.forEach((r, i) => { r.order = i + 1; });
+        this.rules = this.decorate(rules);
+    }
+
+    addCondition(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions = [...rules[ri].conditions, { fieldName: '', operator: 'equals', value: '' }];
+        this.rules = this.decorate(rules);
+    }
+
+    removeCondition(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions.splice(ci, 1);
+        this.rules = this.decorate(rules);
+    }
+
+    handleLogicChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        this.rules[ri].filterLogic = event.target.value;
+    }
+
+    handleLabelChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        this.rules[ri].label = event.target.value;
+    }
+
+    handleFieldChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions[ci].fieldName = event.detail.value;
+        // re-derive the value input type for the newly chosen field
+        const type = this.fieldTypeByName[event.detail.value];
+        rules[ri].conditions[ci].inputType = this.inputTypeForFieldType(type);
+        rules[ri].conditions[ci].isCheckbox = rules[ri].conditions[ci].inputType === 'checkbox';
+        this.rules = rules;
+    }
+
+    handleOperatorChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        this.rules[ri].conditions[ci].operator = event.detail.value;
+    }
+
+    handleValueChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const cond = this.rules[ri].conditions[ci];
+        cond.value = cond.isCheckbox ? String(event.target.checked) : event.target.value;
+    }
+
+    handleSave() {
+        // strip UI-only keys before sending to Apex
+        const payload = this.rules.map((rule) => ({
+            id: rule.id,
+            label: rule.label,
+            objectName: rule.objectName,
+            order: rule.order,
+            filterLogic: rule.filterLogic,
+            conditions: (rule.conditions || []).map((c) => ({
+                fieldName: c.fieldName,
+                operator: c.operator,
+                value: c.value
+            }))
+        }));
+        saveKeepRecordRules({ jsonData: JSON.stringify(payload) })
+            .then(() => {
+                // success surfaced via the platform-event subscription
+            })
+            .catch((error) => this.handleError(error));
+    }
+
+    // --- platform event + notifications (same pattern as the other settings tabs) ---
+
+    handleSubscribe() {
+        const messageCallback = (response) => {
+            if (response && response.data && response.data.payload &&
+                response.data.payload.IsSuccess__c === true) {
+                this.handleSuccess();
+            }
+        };
+        subscribe(this.channelName, -1, messageCallback).then((response) => {
+            this.subscription = response;
+        });
+    }
+
+    registerErrorListener() {
+        onError((error) => this.handleError(error));
+    }
+
+    handleSuccess() {
+        this.notificationTitle = 'Keep Record Rules Saved';
+        this.notificationStyle = 'success';
+        this.notificationBody = '';
+        this.showNotification();
+        if (this.hasObject) {
+            this.loadRules();
+        }
+    }
+
+    handleError(error) {
+        this.notificationTitle = 'An error has occurred';
+        this.notificationStyle = 'error';
+        this.notificationBody = 'Unknown error';
+        if (error && error.body) {
+            if (Array.isArray(error.body)) {
+                this.notificationBody = error.body.map((e) => e.message).join(', ');
+            } else if (typeof error.body.message === 'string') {
+                this.notificationBody = error.body.message;
+            }
+        }
+        this.showNotification();
+    }
+
+    showNotification() {
+        this.dispatchEvent(new ShowToastEvent({
+            title: this.notificationTitle,
+            message: this.notificationBody,
+            variant: this.notificationStyle
+        }));
+    }
+}

--- a/force-app/main/default/lwc/keepRecordRules/keepRecordRules.js-meta.xml
+++ b/force-app/main/default/lwc/keepRecordRules/keepRecordRules.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/mergeMain/mergeMain.html
+++ b/force-app/main/default/lwc/mergeMain/mergeMain.html
@@ -10,6 +10,9 @@
             <lightning-tab label="Auto Merge Settings">
                 <c-dupe-rule-list></c-dupe-rule-list>
             </lightning-tab>
+            <lightning-tab label="Keep Record Rules">
+                <c-keep-record-rules></c-keep-record-rules>
+            </lightning-tab>
             <lightning-tab label="Global Settings">
                 <c-merge-settings></c-merge-settings>
             </lightning-tab>


### PR DESCRIPTION
Final slice of #32 — the admin UI. Builds on merged 32a/b/c.

## What's here
- **`MRG_KeepRecordRules_CTRL`**:
  - `getKeepRecordRules(objectType)` — ordered rules for the object
  - `getObjectFields(objectType)` — reuses the field-settings describe (label/name/type)
  - `getOperators()` — operator options
  - `saveKeepRecordRules(jsonData)` — validates each rule's filter logic via `MRG_FilterLogic.validate` (bad logic → `AuraHandledException`), then deploys via the Metadata API
- **`keepRecordRules` LWC** — chosen UX: **object filter + rule cards**. Each card = condition rows (field / operator / value) + a filter-logic input; add/remove rules and conditions; order shown per card. **Type-aware value input**: checkbox / date / datetime-local / number / text based on the selected field's DisplayType. Save uses the same platform-event success toast as the other settings tabs.
- New **"Keep Record Rules"** tab in `mergeMain` (between Auto Merge Settings and Global Settings).
- `MRG_KeepRecordRules_CTRL_TEST`.

## Notes / watch on deploy
- LWC `data-*` attributes arrive as strings; handlers `parseInt` them. Input-change handlers intentionally mutate in place (no reassignment) to avoid losing focus; structural add/remove re-decorate and reassign.
- `AuraHandledException` message surfacing is the usual Salesforce caveat; the test only asserts it throws.

## Holding merge
Please deploy this branch (LWC + Apex + the tab) and run the controller tests / open the tab. With this merged, #32 is feature-complete end to end.