### PR TITLE
feat: complex-preservation rule model + group-wide evaluator (#33)

### DIFF
--- a/force-app/main/default/classes/MRG_ComplexPreserveRule.cls
+++ b/force-app/main/default/classes/MRG_ComplexPreserveRule.cls
@@ -1,0 +1,150 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description model + group-wide evaluation for a "Complex" field-preservation rule (#33).
+*
+* A complex rule preserves a field's value from the record in a merge group that (a) matches the
+* rule's conditions (reusing MRG_KeepRecordRule.condition + MRG_FilterLogic), and (b) wins a
+* tie-break ordering (a field, ascending or descending) when more than one record matches.
+*
+* Unlike the pairwise Oldest/Newest/Largest/Smallest rules, this is evaluated once over the whole
+* group of records (kept + merged) in a separate pass.
+*/
+public with sharing class MRG_ComplexPreserveRule {
+
+	@auraEnabled public String fieldName;          // the field whose value is preserved
+	@auraEnabled public String filterLogic;        // report-style logic over the conditions
+	@auraEnabled public List<MRG_KeepRecordRule.condition> conditions;
+	@auraEnabled public String tieBreakField;      // field used to rank matching records
+	@auraEnabled public String tieBreakDirection;  // 'ASC' or 'DESC' (default DESC)
+
+	public MRG_ComplexPreserveRule() {
+		this.conditions = new List<MRG_KeepRecordRule.condition>();
+		this.tieBreakDirection = 'DESC';
+	}
+
+	/*******************************************************************************************************
+	* @description the fields this rule reads (its own field, condition fields, tie-break field) so the
+	* caller can ensure they are queried
+	* @return Set<String> field api names
+	*/
+	public Set<String> referencedFields() {
+		Set<String> fields = new Set<String>();
+		if(String.isNotBlank(fieldName))
+			fields.add(fieldName);
+		if(String.isNotBlank(tieBreakField))
+			fields.add(tieBreakField);
+		if(conditions != null) {
+			for(MRG_KeepRecordRule.condition c:conditions) {
+				if(String.isNotBlank(c.fieldName))
+					fields.add(c.fieldName);
+			}
+		}
+		return fields;
+	}
+
+	/*******************************************************************************************************
+	* @description whether a record matches this rule's conditions under its filter logic
+	* @param record the record to test
+	* @return Boolean
+	*/
+	public Boolean matches(SObject record) {
+		if(conditions == null || conditions.isEmpty())
+			return false;
+		Map<Integer, Boolean> results = new Map<Integer, Boolean>();
+		Integer i = 1;
+		for(MRG_KeepRecordRule.condition c:conditions) {
+			results.put(i, c.evaluate(record));
+			i++;
+		}
+		return MRG_FilterLogic.evaluate(filterLogic, results);
+	}
+
+	/*******************************************************************************************************
+	* @description selects the winning record across a group: the matching record ranked first by the
+	* tie-break ordering. Returns null when no record matches the conditions.
+	* @param records the full merge group (kept + merged)
+	* @return SObject the winning record, or null
+	*/
+	public SObject selectWinner(List<SObject> records) {
+		if(records == null || records.isEmpty())
+			return null;
+		List<SObject> matches = new List<SObject>();
+		for(SObject record:records) {
+			if(matches(record))
+				matches.add(record);
+		}
+		if(matches.isEmpty())
+			return null;
+		if(matches.size() == 1)
+			return matches[0];
+		// rank the matches by the tie-break field; default to created order when none is set
+		List<rankedRecord> ranked = new List<rankedRecord>();
+		Boolean descending = tieBreakDirection == null || tieBreakDirection.equalsIgnoreCase('DESC');
+		for(SObject record:matches) {
+			Object val = String.isNotBlank(tieBreakField) ? record.get(tieBreakField) : null;
+			ranked.add(new rankedRecord(record, val, descending));
+		}
+		ranked.sort();
+		return ranked[0].record;
+	}
+
+	/*******************************************************************************************************
+	* @description the value to preserve for this rule across a group: the winning record's field value.
+	* Returns null when no record matches (caller leaves the field unchanged).
+	* @param records the full merge group
+	* @return Object the value to write onto the kept record, or null
+	*/
+	public Object winningValue(List<SObject> records) {
+		SObject winner = selectWinner(records);
+		return winner == null ? null : winner.get(fieldName);
+	}
+
+	/*******************************************************************************************************
+	* @description a record paired with its tie-break value, comparable so the winner sorts first
+	*/
+	private class rankedRecord implements Comparable {
+		public SObject record;
+		Object value;
+		Boolean descending;
+
+		public rankedRecord(SObject record, Object value, Boolean descending) {
+			this.record = record;
+			this.value = value;
+			this.descending = descending;
+		}
+
+		public Integer compareTo(Object compareTo) {
+			rankedRecord other = (rankedRecord) compareTo;
+			Integer cmp = compareValues(this.value, other.value);
+			return descending ? -cmp : cmp;
+		}
+
+		// nulls sort last (so a present value wins regardless of direction-flip); otherwise compare by
+		// the runtime type, falling back to string comparison
+		private Integer compareValues(Object a, Object b) {
+			if(a == null && b == null) return 0;
+			if(a == null) return descending ? -1 : 1;   // a (null) should rank after b
+			if(b == null) return descending ? 1 : -1;   // b (null) should rank after a
+			String type = MRG_Merge_SVC.getObjectType(a);
+			switch on type {
+				when 'Date' {
+					Date da = (Date) a, db = (Date) b;
+					return da == db ? 0 : (da > db ? 1 : -1);
+				}
+				when 'Datetime' {
+					Datetime da = (Datetime) a, db = (Datetime) b;
+					return da == db ? 0 : (da > db ? 1 : -1);
+				}
+				when 'Integer', 'Long', 'Decimal', 'Double' {
+					Decimal da = Decimal.valueOf(String.valueOf(a)), db = Decimal.valueOf(String.valueOf(b));
+					return da == db ? 0 : (da > db ? 1 : -1);
+				}
+				when else {
+					String sa = String.valueOf(a), sb = String.valueOf(b);
+					return sa == sb ? 0 : (sa > sb ? 1 : -1);
+				}
+			}
+		}
+	}
+}

--- a/force-app/main/default/classes/MRG_ComplexPreserveRule.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_ComplexPreserveRule.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_ComplexPreserveRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_ComplexPreserveRule_TEST.cls
@@ -1,0 +1,100 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description unit tests for the group-wide complex-preservation rule evaluator
+*/
+@isTest
+private class MRG_ComplexPreserveRule_TEST {
+
+	private static MRG_KeepRecordRule.condition cond(String field, String op, String val) {
+		return new MRG_KeepRecordRule.condition(field, op, val);
+	}
+
+	// the example from the ticket: preserve MailingStreet when HasOptedOutOfEmail=true; if more than
+	// one matches, prefer the latest Birthdate (tie-break DESC)
+	private static MRG_ComplexPreserveRule ticketRule() {
+		MRG_ComplexPreserveRule rule = new MRG_ComplexPreserveRule();
+		rule.fieldName = 'MailingStreet';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.tieBreakField = 'Birthdate';
+		rule.tieBreakDirection = 'DESC';
+		return rule;
+	}
+
+	static testMethod void testReferencedFields() {
+		MRG_ComplexPreserveRule rule = ticketRule();
+		Set<String> fields = rule.referencedFields();
+		system.assert(fields.contains('MailingStreet'), 'target field');
+		system.assert(fields.contains('Birthdate'), 'tie-break field');
+		system.assert(fields.contains('HasOptedOutOfEmail'), 'condition field');
+	}
+
+	static testMethod void testNoMatchReturnsNull() {
+		MRG_ComplexPreserveRule rule = ticketRule();
+		List<Contact> recs = new List<Contact>{
+			new Contact(LastName='A', HasOptedOutOfEmail=false, MailingStreet='1 St'),
+			new Contact(LastName='B', HasOptedOutOfEmail=false, MailingStreet='2 St')
+		};
+		system.assertEquals(null, rule.winningValue(recs), 'no record matches the condition -> null');
+	}
+
+	static testMethod void testSingleMatchWins() {
+		MRG_ComplexPreserveRule rule = ticketRule();
+		List<Contact> recs = new List<Contact>{
+			new Contact(LastName='A', HasOptedOutOfEmail=false, MailingStreet='1 St'),
+			new Contact(LastName='B', HasOptedOutOfEmail=true,  MailingStreet='2 St', Birthdate=Date.newInstance(1990,1,1))
+		};
+		system.assertEquals('2 St', (String) rule.winningValue(recs), 'the single matching record value is preserved');
+	}
+
+	static testMethod void testTieBreakDescPicksLatest() {
+		MRG_ComplexPreserveRule rule = ticketRule(); // DESC on Birthdate
+		List<Contact> recs = new List<Contact>{
+			new Contact(LastName='A', HasOptedOutOfEmail=true, MailingStreet='older', Birthdate=Date.newInstance(1980,1,1)),
+			new Contact(LastName='B', HasOptedOutOfEmail=true, MailingStreet='newer', Birthdate=Date.newInstance(2000,1,1))
+		};
+		system.assertEquals('newer', (String) rule.winningValue(recs), 'DESC tie-break prefers the latest Birthdate');
+	}
+
+	static testMethod void testTieBreakAscPicksEarliest() {
+		MRG_ComplexPreserveRule rule = ticketRule();
+		rule.tieBreakDirection = 'ASC';
+		List<Contact> recs = new List<Contact>{
+			new Contact(LastName='A', HasOptedOutOfEmail=true, MailingStreet='older', Birthdate=Date.newInstance(1980,1,1)),
+			new Contact(LastName='B', HasOptedOutOfEmail=true, MailingStreet='newer', Birthdate=Date.newInstance(2000,1,1))
+		};
+		system.assertEquals('older', (String) rule.winningValue(recs), 'ASC tie-break prefers the earliest Birthdate');
+	}
+
+	static testMethod void testTieBreakNumberDesc() {
+		// Accounts with a numeric tie-break field
+		List<Account> recs = new List<Account>{
+			new Account(Name='A', NumberOfEmployees=10),
+			new Account(Name='B', NumberOfEmployees=500)
+		};
+		MRG_ComplexPreserveRule numRule = new MRG_ComplexPreserveRule();
+		numRule.fieldName = 'Name';
+		numRule.filterLogic = '';
+		numRule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('NumberOfEmployees','greaterThan','0') };
+		numRule.tieBreakField = 'NumberOfEmployees';
+		numRule.tieBreakDirection = 'DESC';
+		system.assertEquals('B', (String) numRule.winningValue(recs), 'DESC numeric tie-break picks the larger employee count record');
+	}
+
+	static testMethod void testNullTieBreakValuesSortLast() {
+		MRG_ComplexPreserveRule rule = ticketRule(); // DESC on Birthdate
+		List<Contact> recs = new List<Contact>{
+			new Contact(LastName='A', HasOptedOutOfEmail=true, MailingStreet='has-date', Birthdate=Date.newInstance(1990,1,1)),
+			new Contact(LastName='B', HasOptedOutOfEmail=true, MailingStreet='no-date', Birthdate=null)
+		};
+		system.assertEquals('has-date', (String) rule.winningValue(recs), 'record with a tie-break value should win over a null');
+	}
+
+	static testMethod void testEmptyConditionsNeverMatch() {
+		MRG_ComplexPreserveRule rule = new MRG_ComplexPreserveRule();
+		rule.fieldName = 'MailingStreet';
+		system.assertEquals(null, rule.winningValue(new List<Contact>{ new Contact(LastName='A') }),
+			'no conditions -> no winner');
+	}
+}

--- a/force-app/main/default/classes/MRG_ComplexPreserveRule_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_ComplexPreserveRule_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
First slice of #33. Pure group-wide evaluator; reuses the merged #32 criteria engine. No DML/UI, fully unit-tested.

Design (confirmed): a new **Complex** preserve rule type (existing pairwise rules untouched), evaluated in a **separate group-wide pass**.

## What's here
`MRG_ComplexPreserveRule` = target `fieldName` + `conditions` (`MRG_KeepRecordRule.condition`) + `filterLogic` (`MRG_FilterLogic`) + tie-break (`tieBreakField` + `tieBreakDirection` ASC/DESC):
- `matches(record)` — condition/logic check
- `selectWinner(records)` — among matching records, the tie-break-ranked first; single match wins outright; no match → null; null tie-break values sort last
- `winningValue(records)` — the winner's target field value
- `referencedFields()` — target + condition + tie-break fields, for SOQL

Covers the ticket example: preserve `MailingStreet` when `HasOptedOutOfEmail=true`, prefer the latest `Birthdate`.

## Tests
`MRG_ComplexPreserveRule_TEST` — referenced fields, no-match-null, single-match, DESC/ASC tie-break (date + numeric), null-tie-break-sorts-last, empty-conditions-never-match.

## Next slices
- 33b: extend `MergeFieldSetting__mdt` (Complex rule value + condition/tie-break fields) + load/save
- 33c: wire the group-wide pass into `getMergesFromDeletedRecords` (+ history)
- 33d: Field Settings UI for Complex rules

## Holding merge
Net-new Apex — please compile/deploy + run tests before I merge, as with the #32 slices.