### PR TITLE
feat: persist Complex preserve rules on MergeFieldSetting__mdt (#33)

### DIFF
--- a/force-app/main/default/classes/MRG_ComplexPreserveSettings_TEST.cls
+++ b/force-app/main/default/classes/MRG_ComplexPreserveSettings_TEST.cls
@@ -1,0 +1,74 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for Complex-rule config: mergeFieldWrap round-trip and getComplexPreserveRules
+*/
+@isTest
+private class MRG_ComplexPreserveSettings_TEST {
+
+	private static String conditionsJson() {
+		return JSON.serialize(new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('HasOptedOutOfEmail','equals','true')
+		});
+	}
+
+	/*******************************************************************************************************
+	* @description builds an in-memory Complex MergeFieldSetting__mdt via JSON injection
+	*/
+	private static MergeFieldSetting__mdt buildComplexSetting(String objectName, String fieldName, String tieBreakField) {
+		MergeFieldSetting__mdt mf = new MergeFieldSetting__mdt();
+		Map<String, Object> fieldMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(mf));
+		fieldMap.put(MergeFieldSetting__mdt.Label.getDescribe().getName(), 'test'+fieldName);
+		fieldMap.put(MergeFieldSetting__mdt.DeveloperName.getDescribe().getName(), 'test'+fieldName);
+		fieldMap.put(MergeFieldSetting__mdt.Type__c.getDescribe().getName(), 'Preserve');
+		fieldMap.put(MergeFieldSetting__mdt.Disable__c.getDescribe().getName(), false);
+		fieldMap.put(MergeFieldSetting__mdt.PreservationRule__c.getDescribe().getName(), 'Complex');
+		fieldMap.put(MergeFieldSetting__mdt.FilterLogic__c.getDescribe().getName(), '1');
+		fieldMap.put(MergeFieldSetting__mdt.Conditions__c.getDescribe().getName(), conditionsJson());
+		fieldMap.put(MergeFieldSetting__mdt.TieBreakDirection__c.getDescribe().getName(), 'DESC');
+		fieldMap.put('Object__r', new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' }, 'QualifiedAPIName' => objectName });
+		fieldMap.put('Field__r', new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'EntityParticle' }, 'QualifiedAPIName' => fieldName });
+		fieldMap.put('TieBreakField__r', new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'EntityParticle' }, 'QualifiedAPIName' => tieBreakField });
+		return (MergeFieldSetting__mdt) JSON.deserialize(JSON.serialize(fieldMap), MergeFieldSetting__mdt.class);
+	}
+
+	static testMethod void testWrapperParsesComplexFields() {
+		MergeFieldSetting__mdt setting = buildComplexSetting('Contact', 'MailingStreet', 'Birthdate');
+		MRG_Merge_SVC.mergeFieldWrap mfw = new MRG_Merge_SVC.mergeFieldWrap(setting);
+		system.assertEquals('Complex', mfw.rule);
+		system.assertEquals('1', mfw.filterLogic);
+		system.assertEquals('Birthdate', mfw.tieBreakField);
+		system.assertEquals('DESC', mfw.tieBreakDirection);
+		system.assertEquals(1, mfw.conditions.size());
+		system.assertEquals('HasOptedOutOfEmail', mfw.conditions[0].fieldName);
+	}
+
+	static testMethod void testGetComplexPreserveRulesFiltersByObjectAndType() {
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>{
+			buildComplexSetting('Contact', 'MailingStreet', 'Birthdate'),
+			buildComplexSetting('Account', 'Phone', 'CreatedDate')
+		};
+		List<MRG_ComplexPreserveRule> contactRules = MRG_Merge_SVC.getComplexPreserveRules('Contact');
+		system.assertEquals(1, contactRules.size(), 'only the Contact complex rule');
+		system.assertEquals('MailingStreet', contactRules[0].fieldName);
+		system.assertEquals('Birthdate', contactRules[0].tieBreakField);
+		system.assertEquals(1, contactRules[0].conditions.size());
+		system.assertEquals(1, MRG_Merge_SVC.getComplexPreserveRules('Account').size());
+		system.assertEquals(0, MRG_Merge_SVC.getComplexPreserveRules('Lead').size());
+	}
+
+	static testMethod void testToMdtRoundTripSerializesComplexFields() {
+		MRG_Merge_SVC.mergeFieldWrap mfw = new MRG_Merge_SVC.mergeFieldWrap(
+			buildComplexSetting('Contact', 'MailingStreet', 'Birthdate'));
+		MergeFieldSetting__mdt setting = MRG_Merge_SVC.getMergeFieldFromObject(mfw);
+		system.assertEquals('Complex', setting.PreservationRule__c);
+		system.assertEquals('Preserve', setting.Type__c);
+		system.assertEquals('DESC', setting.TieBreakDirection__c);
+		system.assert(String.isNotBlank(setting.Conditions__c), 'conditions serialized');
+		system.assertEquals('Birthdate', setting.TieBreakField__r.QualifiedAPIName, 'tie-break relationship injected');
+		system.assertEquals('MailingStreet', setting.Field__r.QualifiedAPIName);
+	}
+}

--- a/force-app/main/default/classes/MRG_ComplexPreserveSettings_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_ComplexPreserveSettings_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -164,6 +164,11 @@ public with sharing class MRG_Merge_SVC {
 		@auraEnabled public String rule;
 		@auraEnabled public String relatedField;
 		@auraEnabled public Boolean disable;
+		// Complex-rule (#33) configuration; populated only when rule == 'Complex'
+		@auraEnabled public String filterLogic;
+		@auraEnabled public List<MRG_KeepRecordRule.condition> conditions;
+		@auraEnabled public String tieBreakField;
+		@auraEnabled public String tieBreakDirection;
 
 		public mergeFieldWrap(MergeFieldSetting__mdt mergeField) {
 			this.id = mergeField.Id;
@@ -175,6 +180,12 @@ public with sharing class MRG_Merge_SVC {
 			this.rule = mergeField.PreservationRule__c;
 			this.relatedField = mergeField.RelatedField__r.QualifiedAPIName;
 			this.disable = mergeField.Disable__c;
+			this.filterLogic = mergeField.FilterLogic__c;
+			this.conditions = String.isNotBlank(mergeField.Conditions__c)
+				? (List<MRG_KeepRecordRule.condition>) JSON.deserialize(mergeField.Conditions__c, List<MRG_KeepRecordRule.condition>.class)
+				: new List<MRG_KeepRecordRule.condition>();
+			this.tieBreakField = mergeField.TieBreakField__r != null ? mergeField.TieBreakField__r.QualifiedAPIName : null;
+			this.tieBreakDirection = mergeField.TieBreakDirection__c;
 		}
 		public Integer compareTo(Object compareTo) {
 			mergeFieldWrap sortObj = (mergeFieldWrap) compareTo;
@@ -227,8 +238,10 @@ public with sharing class MRG_Merge_SVC {
 		MergeFieldSetting__mdt mergeField = new MergeFieldSetting__mdt(
 			Label = mfw.label,
 			PreservationRule__c = mfw.rule,
-			Disable__c = mfw.disable
-
+			Disable__c = mfw.disable,
+			FilterLogic__c = mfw.filterLogic,
+			Conditions__c = mfw.conditions != null && !mfw.conditions.isEmpty() ? JSON.serialize(mfw.conditions) : null,
+			TieBreakDirection__c = mfw.tieBreakDirection
 		);
 		mergeField.Type__c = mfw.type == 't' ? 'Track' : 'Preserve';
 		if(String.isNotBlank(mfw.id))
@@ -255,6 +268,15 @@ public with sharing class MRG_Merge_SVC {
 				'QualifiedAPIName' => mfw.relatedField
 			};
 			mergeFieldJSON.put('RelatedField__r',rltField);
+		}
+		if(String.isNotBlank(mfw.tieBreakField)){
+			Map<String, Object> tbField = new Map<String, Object> {
+				'attributes' => new Map<String, Object> {
+					'type' => 'EntityParticle'
+				},
+				'QualifiedAPIName' => mfw.tieBreakField
+			};
+			mergeFieldJSON.put('TieBreakField__r',tbField);
 		}
 		mergeFieldJSON.put('Field__r',fldField);
 		mergeFieldJSON.put('Object__r',objField);
@@ -290,6 +312,10 @@ public with sharing class MRG_Merge_SVC {
 					Object__r.QualifiedAPIName,
 					Field__r.QualifiedAPIName,
 					RelatedField__r.QualifiedAPIName,
+					TieBreakField__r.QualifiedAPIName,
+					TieBreakDirection__c,
+					FilterLogic__c,
+					Conditions__c,
 					Type__c,
 					Disable__c,
 					PreservationRule__c
@@ -502,6 +528,29 @@ public with sharing class MRG_Merge_SVC {
 				preserveMergeFields.add(new mergeFieldWrap(mergeField));
 		}
 		return preserveMergeFields;
+	}
+	/*******************************************************************************************************
+	* @description the Complex preservation rules for an object: enabled Preserve fields whose rule is
+	* 'Complex', converted to MRG_ComplexPreserveRule for group-wide evaluation
+	* @param objectType the SObject api name
+	* @return List<MRG_ComplexPreserveRule>
+	*/
+	public static List<MRG_ComplexPreserveRule> getComplexPreserveRules(String objectType) {
+		List<MRG_ComplexPreserveRule> complexRules = new List<MRG_ComplexPreserveRule>();
+		for(mergeFieldWrap mfw:getPreserveMergeFields()) {
+			if(!mfw.disable
+				&& mfw.rule != null && mfw.rule.equalsIgnoreCase('Complex')
+				&& mfw.objectName != null && mfw.objectName.equalsIgnoreCase(objectType)) {
+				MRG_ComplexPreserveRule rule = new MRG_ComplexPreserveRule();
+				rule.fieldName = mfw.fieldName;
+				rule.filterLogic = mfw.filterLogic;
+				rule.conditions = mfw.conditions == null ? new List<MRG_KeepRecordRule.condition>() : mfw.conditions;
+				rule.tieBreakField = mfw.tieBreakField;
+				rule.tieBreakDirection = mfw.tieBreakDirection;
+				complexRules.add(rule);
+			}
+		}
+		return complexRules;
 	}
 	/*******************************************************************************************************
 	* @description translates deleted contacts into merge records

--- a/force-app/main/default/classes/MRG_Metadata_SVC.cls
+++ b/force-app/main/default/classes/MRG_Metadata_SVC.cls
@@ -193,6 +193,11 @@ public with sharing class MRG_Metadata_SVC {
 		fieldKeyValues.put('Object__c',mergeField.Object__r.QualifiedAPIName);
 	 	fieldKeyValues.put('PreservationRule__c', mergeField.PreservationRule__c);
 		fieldKeyValues.put('Type__c',mergeField.Type__c);
+		// Complex-rule (#33) fields
+		fieldKeyValues.put('FilterLogic__c', mergeField.FilterLogic__c);
+		fieldKeyValues.put('Conditions__c', mergeField.Conditions__c);
+		fieldKeyValues.put('TieBreakDirection__c', mergeField.TieBreakDirection__c);
+		fieldKeyValues.put('TieBreakField__c', mergeField.TieBreakField__r != null ? mergeField.TieBreakField__r.QualifiedAPIName : null);
 		String qualifiedName = !mergeField.QualifiedAPIName.contains('.') ? 'MergeFieldSetting__mdt.'+mergeField.QualifiedAPIName : mergeField.QualifiedAPIName;	   	
 		mdRecordNames.add(qualifiedName);
 		

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/Conditions__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/Conditions__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Conditions__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>For a Complex rule: JSON array of the conditions (field, operator, value) a record must satisfy. Maintained by the Field Settings UI.</inlineHelpText>
+    <label>Conditions</label>
+    <required>false</required>
+    <type>LongTextArea</type>
+    <length>131072</length>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/FilterLogic__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/FilterLogic__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FilterLogic__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>For a Complex rule: report-style logic combining the numbered conditions, e.g. (1 AND 2) OR 3. Leave blank to AND all conditions.</inlineHelpText>
+    <label>Filter Logic</label>
+    <required>false</required>
+    <type>Text</type>
+    <length>255</length>
+</CustomField>

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PreservationRule__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PreservationRule__c.field-meta.xml
@@ -35,6 +35,11 @@
                 <default>false</default>
                 <label>Related Field</label>
             </value>
+            <value>
+                <fullName>Complex</fullName>
+                <default>false</default>
+                <label>Complex</label>
+            </value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/TieBreakDirection__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/TieBreakDirection__c.field-meta.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TieBreakDirection__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Tie Break Direction</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>DESC</fullName>
+                <default>true</default>
+                <label>Descending</label>
+            </value>
+            <value>
+                <fullName>ASC</fullName>
+                <default>false</default>
+                <label>Ascending</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/TieBreakField__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/TieBreakField__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TieBreakField__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>For a Complex rule: when more than one record matches the conditions, the field used to rank them.</inlineHelpText>
+    <label>Tie Break Field</label>
+    <referenceTo>EntityParticle</referenceTo>
+    <relationshipLabel>Tie_Break_Field</relationshipLabel>
+    <relationshipName>Tie_Break_Field</relationshipName>
+    <required>false</required>
+    <type>MetadataRelationship</type>
+    <metadataRelationshipControllingField>Object__c</metadataRelationshipControllingField>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Second slice of #33 — configuration + persistence. Builds on merged 33a.

## Metadata
`MergeFieldSetting__mdt`:
- `PreservationRule__c` gains a **Complex** value
- new fields: `FilterLogic__c` (Text), `Conditions__c` (LongTextArea JSON), `TieBreakField__c` (MetadataRelationship → EntityParticle, controlled by `Object__c`), `TieBreakDirection__c` (ASC/DESC)

## Apex
- `mergeFieldWrap` carries the Complex fields (parses `Conditions__c` JSON)
- `mergeFields` SOQL selects the new fields
- `getMergeFieldFromObject` writes them on save (incl. `TieBreakField__r` JSON injection)
- `MRG_Metadata_SVC.getMetaDataRecord(MergeFieldSetting__mdt)` deploys them (null-safe tie-break relationship)
- **`MRG_Merge_SVC.getComplexPreserveRules(objectType)`** — the bridge from config to the 33a evaluator: enabled Preserve fields whose rule is `Complex`, for the object

## Tests
`MRG_ComplexPreserveSettings_TEST` — wrapper parse, `getComplexPreserveRules` object/type filtering, mdt round-trip (incl. tie-break relationship + serialized conditions).

## Note
Complex fields have `Type__c=Preserve` + `rule=Complex`. The existing pairwise loop will see them but `testValue(...'Complex'...)` returns false (no-op); 33c will exclude them from the pairwise map and apply them in the dedicated group-wide pass.

## Holding merge
Please compile/deploy + run tests before I merge, as with prior slices.