### PR TITLE
feat: apply Complex preserve rules in a group-wide merge pass (#33)

### DIFF
--- a/force-app/main/default/classes/MRG_ComplexMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_ComplexMerge_TEST.cls
@@ -1,0 +1,93 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description integration test: a Complex preserve rule applied through the production merge path
+*/
+@isTest
+private class MRG_ComplexMerge_TEST {
+
+	// in-memory Complex MergeFieldSetting__mdt (Preserve + rule Complex) via JSON injection
+	private static MergeFieldSetting__mdt complexSetting(String objectName, String fieldName, String tieBreakField, String tieBreakDir, List<MRG_KeepRecordRule.condition> conditions) {
+		MergeFieldSetting__mdt mf = new MergeFieldSetting__mdt();
+		Map<String, Object> m = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(mf));
+		m.put(MergeFieldSetting__mdt.Label.getDescribe().getName(), 'test'+fieldName);
+		m.put(MergeFieldSetting__mdt.DeveloperName.getDescribe().getName(), 'test'+fieldName);
+		m.put(MergeFieldSetting__mdt.Type__c.getDescribe().getName(), 'Preserve');
+		m.put(MergeFieldSetting__mdt.Disable__c.getDescribe().getName(), false);
+		m.put(MergeFieldSetting__mdt.PreservationRule__c.getDescribe().getName(), 'Complex');
+		m.put(MergeFieldSetting__mdt.FilterLogic__c.getDescribe().getName(), '');
+		m.put(MergeFieldSetting__mdt.Conditions__c.getDescribe().getName(), JSON.serialize(conditions));
+		m.put(MergeFieldSetting__mdt.TieBreakDirection__c.getDescribe().getName(), tieBreakDir);
+		m.put('Object__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' }, 'QualifiedAPIName' => objectName });
+		m.put('Field__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityParticle' }, 'QualifiedAPIName' => fieldName });
+		m.put('TieBreakField__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityParticle' }, 'QualifiedAPIName' => tieBreakField });
+		return (MergeFieldSetting__mdt) JSON.deserialize(JSON.serialize(m), MergeFieldSetting__mdt.class);
+	}
+
+	private static MRG_KeepRecordRule.condition cond(String field, String op, String val) {
+		return new MRG_KeepRecordRule.condition(field, op, val);
+	}
+
+	static testMethod void testComplexRulePreservesWinningValueThroughMerge() {
+		// ticket example: preserve MailingStreet from the record where HasOptedOutOfEmail = true,
+		// tie-broken by the latest Birthdate (DESC). Three records, two opted out.
+		List<Contact> cons = MRG_TestFactory.contacts(3);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		Id merge2Id = cons[2].Id;
+		update new List<Contact>{
+			// keep: not opted out, no street
+			new Contact(Id=keepId, HasOptedOutOfEmail=false, MailingStreet=null, Birthdate=Date.newInstance(1970,1,1)),
+			// merged A: opted out, older birthdate
+			new Contact(Id=mergeId, HasOptedOutOfEmail=true, MailingStreet='OLD STREET', Birthdate=Date.newInstance(1980,1,1)),
+			// merged B: opted out, newest birthdate -> tie-break DESC winner
+			new Contact(Id=merge2Id, HasOptedOutOfEmail=true, MailingStreet='WIN STREET', Birthdate=Date.newInstance(2000,1,1))
+		};
+
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>{
+			complexSetting('Contact', 'MailingStreet', 'Birthdate', 'DESC',
+				new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') })
+		};
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, merge2Id, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		// the kept record should carry the winning record's street (the opted-out, newest-birthdate one)
+		system.assertEquals('WIN STREET', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'MailingStreet'),
+			'Complex rule should preserve the value from the condition-matching, tie-break-winning record');
+
+		// and a field-history entry should record the change
+		Map<String, MergeFieldHistory__c> history = MRG_TestFactory.historyByField(keepId);
+		system.assert(history.containsKey('mailingstreet'), 'complex preserve change should be tracked');
+		system.assertEquals('WIN STREET', history.get('mailingstreet').KeptValue__c);
+	}
+
+	static testMethod void testComplexRuleNoConditionMatchLeavesFieldUnchanged() {
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, HasOptedOutOfEmail=false, MailingStreet='KEEP'),
+			new Contact(Id=mergeId, HasOptedOutOfEmail=false, MailingStreet='LOSE')
+		};
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>{
+			complexSetting('Contact', 'MailingStreet', 'Birthdate', 'DESC',
+				new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') })
+		};
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		// no record matches the condition -> complex rule does not change the kept value
+		system.assertEquals('KEEP', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'MailingStreet'),
+			'no condition match -> kept value unchanged by the complex rule');
+	}
+}

--- a/force-app/main/default/classes/MRG_ComplexMerge_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_ComplexMerge_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -725,6 +725,16 @@ public with sharing class MRG_Merge_SVC {
 		Map<Id,Id> keepIdMap = getKeepIdMap(mergeKeyMap);
 		Map<String, mergeFieldWrap> trackfieldMap = new Map<String, mergeFieldWrap>(getMergeFieldMap(trackMergeFields));
 		Map<String, mergeFieldWrap> preserveFieldMap = new Map<String, mergeFieldWrap>(getMergeFieldMap(preserveMergeFields));
+		// Complex rules (#33) are evaluated group-wide in a separate pass below; collect their target
+		// fields so the pairwise loop skips them entirely (no preserve map entry, no default fill).
+		List<MRG_ComplexPreserveRule> complexRules = getComplexPreserveRules(objectType);
+		Set<String> complexFields = new Set<String>();
+		for(MRG_ComplexPreserveRule complexRule:complexRules) {
+			if(String.isNotBlank(complexRule.fieldName)) {
+				preserveFieldMap.remove(complexRule.fieldName.toLowerCase());
+				complexFields.add(complexRule.fieldName.toLowerCase());
+			}
+		}
 		/****
 		*	a map of child field to master field keyed by child field
 		***/
@@ -759,7 +769,9 @@ public with sharing class MRG_Merge_SVC {
 				Boolean keptRecordIsOlder = (Datetime) keptRec.get('CreatedDate') < (Datetime) obj.get('CreatedDate');
 				Boolean hasChange = false;
 				for(String fieldName:fieldsToCheck) {
-					system.debug(JSON.serializePretty(fieldsToCheck));
+					// Complex-rule fields are handled in the group-wide pass; skip them here
+					if(complexFields.contains(fieldName))
+						continue;
 					Boolean isMaster = masterFields.contains(fieldName);
 					Boolean isChild = masterChildFields.containsKey(fieldName);
 					String masterFieldName = isChild ? masterChildFields.get(fieldName) : null;
@@ -835,6 +847,43 @@ public with sharing class MRG_Merge_SVC {
 				}
 				if(hasChange)
 					updateRecordMap.put(keptRec.Id,keptRec);
+			}
+		}
+		// --- group-wide Complex-rule pass (#33) ---------------------------------------------------
+		// For each kept record, gather its full group (kept + merged) and, per Complex rule, preserve
+		// the value from the rule's winning record (condition match + tie-break). Emits field history
+		// when the kept value changes.
+		if(!complexRules.isEmpty()) {
+			Map<Id, List<SObject>> mergedByKeepId = new Map<Id, List<SObject>>();
+			for(SObject obj:mergedRecords) {
+				Id mId = (Id) obj.get('Id');
+				Id kId = keepIdMap.containsKey(mId) ? keepIdMap.get(mId) : null;
+				if(kId == null) continue;
+				if(!mergedByKeepId.containsKey(kId))
+					mergedByKeepId.put(kId, new List<SObject>());
+				mergedByKeepId.get(kId).add(obj);
+			}
+			for(Id keepId:mergeKeyMap.keyset()) {
+				if(!keptRecordMap.containsKey(keepId))
+					continue;
+				SObject keptRec = keptRecordMap.get(keepId);
+				List<SObject> group = new List<SObject>{ keptRec };
+				if(mergedByKeepId.containsKey(keepId))
+					group.addAll(mergedByKeepId.get(keepId));
+				Boolean complexChange = false;
+				for(MRG_ComplexPreserveRule complexRule:complexRules) {
+					Object winning = complexRule.winningValue(group);
+					if(winning == null)
+						continue;
+					Object current = keptRec.get(complexRule.fieldName);
+					if(valuesAreEqual(current, winning))
+						continue;
+					keptRec.put(complexRule.fieldName, winning);
+					complexChange = true;
+					mergeRecords.add(getMergeRecord(winning, current, keptRec, String.valueOf(keepId), complexRule.fieldName));
+				}
+				if(complexChange)
+					updateRecordMap.put(keptRec.Id, keptRec);
 			}
 		}
 		mergeHistoryResult mergeResult = new mergeHistoryResult(updateRecordMap.values(),mergeRecords);

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -867,12 +867,12 @@ public with sharing class MRG_Merge_SVC {
 				if(!keptRecordMap.containsKey(keepId))
 					continue;
 				SObject keptRec = keptRecordMap.get(keepId);
-				List<SObject> group = new List<SObject>{ keptRec };
+				List<SObject> recordGroup = new List<SObject>{ keptRec };
 				if(mergedByKeepId.containsKey(keepId))
-					group.addAll(mergedByKeepId.get(keepId));
+					recordGroup.addAll(mergedByKeepId.get(keepId));
 				Boolean complexChange = false;
 				for(MRG_ComplexPreserveRule complexRule:complexRules) {
-					Object winning = complexRule.winningValue(group);
+					Object winning = complexRule.winningValue(recordGroup);
 					if(winning == null)
 						continue;
 					Object current = keptRec.get(complexRule.fieldName);


### PR DESCRIPTION
Third slice of #33 — the behavior change. Builds on merged 33a/33b.

## What changed in `getMergesFromDeletedRecords`
- Loads `getComplexPreserveRules(objectType)` and collects their target fields.
- **Skips those fields in the pairwise loop** (removed from `preserveFieldMap` and `continue`-d in the per-field loop) so they aren't default-filled or pairwise-processed.
- After the pairwise loop, runs a **group-wide pass**: for each kept record, gather its full group (kept + merged), and per Complex rule write the winning record's value (`MRG_ComplexPreserveRule.winningValue` = condition match + tie-break) onto the kept record. Emits a `MergeFieldHistory__c` entry when the value changes.
- Incidental: removed a per-field `system.debug(JSON.serializePretty(...))` on the hot path (flagged in the earlier review).

## Tests
`MRG_ComplexMerge_TEST` drives real merges via the factory/service:
- ticket example: preserve `MailingStreet` from the `HasOptedOutOfEmail=true` record, tie-broken by latest `Birthdate` (3 records, 2 matching) → kept gets the winner's street + history entry
- no condition match → kept value unchanged

## Known limitation (documented)
The merge query (`getMergeSOQLQuery`) selects accessible + updateable fields. A tie-break/condition field that is read-only (formula, audit) won't be loaded, so it'd evaluate as null. The 33d UI field picker will offer only the queryable (updateable/accessible) fields, keeping config valid. Expanding the core query is deliberately out of scope here.

## Holding merge
Please compile/deploy + run tests before I merge.