### PR TITLE
feat: Complex preserve rule editor in Field Settings UI (#33)

### DIFF
--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
@@ -108,7 +108,79 @@
                             <lightning-button onclick={handleSave} variant="brand" title="Save" label="Save"></lightning-button>
                         </lightning-button-group>
                     </lightning-layout-item>
-                </lightning-layout>  
+                </lightning-layout>
+
+                <template if:true={isComplex}>
+                    <div class="slds-box slds-m-horizontal_small slds-m-bottom_medium">
+                        <p class="slds-text-title_caps slds-m-bottom_x-small">Complex Rule</p>
+                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
+                            Preserve this field's value from the record that matches the conditions below.
+                            When more than one record matches, the tie-break field decides which wins.
+                        </p>
+
+                        <template for:each={mergeRecord.conditions} for:item="condition">
+                            <div key={condition.conditionIndex} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
+                                <div class="slds-col slds-size_1-of-12 slds-text-body_small slds-align-middle">{condition.conditionIndex}</div>
+                                <div class="slds-col slds-size_4-of-12">
+                                    <lightning-combobox
+                                        label="Field"
+                                        value={condition.fieldName}
+                                        options={allFieldOptions}
+                                        data-condition={condition.conditionIndex}
+                                        onchange={handleConditionFieldSelect}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_3-of-12">
+                                    <lightning-combobox
+                                        label="Operator"
+                                        value={condition.operator}
+                                        options={operatorOptions}
+                                        data-condition={condition.conditionIndex}
+                                        onchange={handleConditionOperatorSelect}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_3-of-12">
+                                    <template if:true={condition.isCheckbox}>
+                                        <lightning-input type="checkbox" label="Value" checked={condition.checked}
+                                            data-condition={condition.conditionIndex} onchange={handleConditionValueChange}>
+                                        </lightning-input>
+                                    </template>
+                                    <template if:false={condition.isCheckbox}>
+                                        <lightning-input type={condition.inputType} label="Value" value={condition.value}
+                                            data-condition={condition.conditionIndex} onchange={handleConditionValueChange}>
+                                        </lightning-input>
+                                    </template>
+                                </div>
+                                <div class="slds-col slds-size_1-of-12">
+                                    <lightning-button-icon icon-name="utility:close" alternative-text="Remove condition"
+                                        title="Remove condition" data-condition={condition.conditionIndex} onclick={removeCondition}>
+                                    </lightning-button-icon>
+                                </div>
+                            </div>
+                        </template>
+
+                        <lightning-button label="Add Condition" icon-name="utility:add" variant="base"
+                            class="slds-m-bottom_x-small" onclick={addCondition}>
+                        </lightning-button>
+
+                        <lightning-input label="Filter Logic (e.g. (1 AND 2) OR 3 — leave blank to AND all conditions)"
+                            value={mergeRecord.filterLogic} onchange={handleFilterLogicChange}>
+                        </lightning-input>
+
+                        <div class="slds-grid slds-gutters slds-m-top_x-small">
+                            <div class="slds-col slds-size_6-of-12">
+                                <lightning-combobox label="Tie-Break Field" value={mergeRecord.tieBreakField}
+                                    placeholder="Select Field" options={allFieldOptions} onchange={handleTieBreakFieldSelect}>
+                                </lightning-combobox>
+                            </div>
+                            <div class="slds-col slds-size_6-of-12">
+                                <lightning-combobox label="Tie-Break Direction" value={mergeRecord.tieBreakDirection}
+                                    options={directionOptions} onchange={handleTieBreakDirectionSelect}>
+                                </lightning-combobox>
+                            </div>
+                        </div>
+                    </div>
+                </template>
             </template>
         </template>
 </template>

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
@@ -32,8 +32,21 @@ export default class mergeSingleRecord extends LightningElement {
         return type;
     }
     trackOptions = [{label:'Track Fields',value:'t'},{label:'Preserve Fields',value:'p'}];
-    ruleOptions = [{label:'Oldest Record',value:'Oldest'},{label:'Newest Record',value:'Newest'},{label:'Largest Field Value',value:'Largest'},{label:'Smallest Field Value',value:'Smallest'},{label:'Related Field Value',value:'Related Field'}];
+    ruleOptions = [{label:'Oldest Record',value:'Oldest'},{label:'Newest Record',value:'Newest'},{label:'Largest Field Value',value:'Largest'},{label:'Smallest Field Value',value:'Smallest'},{label:'Related Field Value',value:'Related Field'},{label:'Complex Rule',value:'Complex'}];
+    operatorOptions = [
+        {label:'equals',value:'equals'},
+        {label:'not equals',value:'notEquals'},
+        {label:'less than',value:'lessThan'},
+        {label:'less or equal',value:'lessOrEqual'},
+        {label:'greater than',value:'greaterThan'},
+        {label:'greater or equal',value:'greaterOrEqual'},
+        {label:'contains',value:'contains'},
+        {label:'starts with',value:'startsWith'},
+        {label:'ends with',value:'endsWith'}
+    ];
+    directionOptions = [{label:'Descending',value:'DESC'},{label:'Ascending',value:'ASC'}];
     objectOptions = [{label:'Account',value:'Account'},{label:'Contact',value:'Contact'}];
+    fieldTypeByName = {};
     notificationBody;
     notificationStyle;
     notificationTitle;
@@ -41,11 +54,15 @@ export default class mergeSingleRecord extends LightningElement {
         value = value === undefined || value == null ? [] : value;
         var options = [];
         var relatedFieldOptions = [];
+        var allOptions = [];
+        var typeMap = {};
         value.forEach(fieldResult=>{
-            
+
                 var option = {};
                 option.label = fieldResult.label;
                 option.value = fieldResult.name;
+                allOptions.push(option);
+                typeMap[fieldResult.name] = fieldResult.type;
             if(!this.usedFields.includes(fieldResult.name)) {
                 options.push(option);
             } else {
@@ -54,6 +71,10 @@ export default class mergeSingleRecord extends LightningElement {
         })
         this.fieldOptions = options;
         this.relatedFieldOptions = relatedFieldOptions;
+        // complex rules can reference any field (conditions + tie-break), not just unused ones
+        this.allFieldOptions = allOptions;
+        this.fieldTypeByName = typeMap;
+        this.refreshConditionInputTypes();
     }
     get fieldResults(){
         return this.fieldOptions;
@@ -66,9 +87,42 @@ export default class mergeSingleRecord extends LightningElement {
     }
     @track relatedFieldOptions;
     @track fieldOptions;
+    @track allFieldOptions = [];
 
     get isRelatedField(){
         return this.mergeRecord !== undefined && this.mergeRecord != null && this.preserve && this.mergeRecord.rule == 'Related Field';
+    }
+
+    get isComplex(){
+        return this.mergeRecord !== undefined && this.mergeRecord != null && this.preserve && this.mergeRecord.rule == 'Complex';
+    }
+
+    // re-derive each condition's value input type from its selected field, and add row indices
+    refreshConditionInputTypes(){
+        if(this.mergeRecord && Array.isArray(this.mergeRecord.conditions)){
+            this.mergeRecord.conditions = this.mergeRecord.conditions.map((c, i)=>{
+                const type = this.fieldTypeByName[c.fieldName];
+                c.inputType = this.inputTypeForFieldType(type);
+                c.isCheckbox = c.inputType === 'checkbox';
+                c.checked = c.isCheckbox && c.value === 'true';
+                c.conditionIndex = i;
+                return c;
+            });
+        }
+    }
+
+    inputTypeForFieldType(fieldType){
+        switch(fieldType){
+            case 'BOOLEAN': return 'checkbox';
+            case 'DATE': return 'date';
+            case 'DATETIME': return 'datetime';
+            case 'DOUBLE':
+            case 'CURRENCY':
+            case 'INTEGER':
+            case 'LONG':
+            case 'PERCENT': return 'number';
+            default: return 'text';
+        }
     }
 
     connectedCallback(){
@@ -114,6 +168,56 @@ export default class mergeSingleRecord extends LightningElement {
     }
     handleRuleSelect(event) {
         this.mergeRecord.rule = event.detail.value;
+        if(this.mergeRecord.rule === 'Complex'){
+            this.mergeRecord.conditions = Array.isArray(this.mergeRecord.conditions) ? this.mergeRecord.conditions : [];
+            this.mergeRecord.filterLogic = this.mergeRecord.filterLogic || '';
+            this.mergeRecord.tieBreakDirection = this.mergeRecord.tieBreakDirection || 'DESC';
+            this.refreshConditionInputTypes();
+        }
+    }
+
+    addCondition(){
+        const conditions = Array.isArray(this.mergeRecord.conditions) ? [...this.mergeRecord.conditions] : [];
+        conditions.push({ fieldName:'', operator:'equals', value:'' });
+        this.mergeRecord.conditions = conditions;
+        this.refreshConditionInputTypes();
+    }
+
+    removeCondition(event){
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const conditions = [...this.mergeRecord.conditions];
+        conditions.splice(ci, 1);
+        this.mergeRecord.conditions = conditions;
+        this.refreshConditionInputTypes();
+    }
+
+    handleConditionFieldSelect(event){
+        const ci = parseInt(event.target.dataset.condition, 10);
+        this.mergeRecord.conditions[ci].fieldName = event.detail.value;
+        this.refreshConditionInputTypes();
+    }
+
+    handleConditionOperatorSelect(event){
+        const ci = parseInt(event.target.dataset.condition, 10);
+        this.mergeRecord.conditions[ci].operator = event.detail.value;
+    }
+
+    handleConditionValueChange(event){
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const cond = this.mergeRecord.conditions[ci];
+        cond.value = cond.isCheckbox ? String(event.target.checked) : event.target.value;
+    }
+
+    handleTieBreakFieldSelect(event){
+        this.mergeRecord.tieBreakField = event.detail.value;
+    }
+
+    handleTieBreakDirectionSelect(event){
+        this.mergeRecord.tieBreakDirection = event.detail.value;
+    }
+
+    handleFilterLogicChange(event){
+        this.mergeRecord.filterLogic = event.target.value;
     }
     doEdit(event){
         this.isEdit=true;
@@ -132,9 +236,17 @@ export default class mergeSingleRecord extends LightningElement {
     }
     doNotify(){
         console.log('do notify');
-        console.log(JSON.stringify(this.record));
         this.isEdit=false;
         this.record.name = this.record.name == null ? this.record.fieldName+''+this.record.objectName : this.record.name;
+        // strip UI-only keys from complex conditions so the saved JSON matches the Apex condition shape
+        if(Array.isArray(this.record.conditions)){
+            this.record.conditions = this.record.conditions.map(c=>({
+                fieldName: c.fieldName,
+                operator: c.operator,
+                value: c.value
+            }));
+        }
+        console.log(JSON.stringify(this.record));
         const notify = new CustomEvent('notify', {
             bubbles:true,
             composed:false,


### PR DESCRIPTION
Final slice of #33 — the admin UI. Builds on merged 33a/b/c. LWC-only (no Apex changes; the controller/save path already carries the Complex fields from 33b).

## What's here
Extends the existing per-field editor `mergeSingleRecord` (so Complex lives next to Oldest/Newest/Largest/Smallest/Related Field):
- **'Complex Rule'** added to the preservation-rule dropdown.
- Selecting it reveals a full-width **Complex panel**:
  - condition rows: **Field** / **Operator** / **type-aware Value** (checkbox / date / datetime / number / text from the field's DisplayType), add & remove
  - **Filter Logic** input (`(1 AND 2) OR 3`, blank = AND all)
  - **Tie-Break Field** + **Direction** (Descending/Ascending)
- Reuses the operator set and the type-aware-input approach from the #32 keepRecordRules tab.
- Strips UI-only condition keys before dispatching save so the JSON matches the Apex `condition` shape; save goes through the existing `saveMergeFields` → `getMergeFieldFromObject` path.

## Watch on deploy
- `lightning-input type="datetime"` (not `datetime-local`) — used the LWC-valid type this time.
- Open Field Settings → add/edit a Preserve field → choose **Complex Rule**, add a condition, pick a boolean vs date field and confirm the value input changes, set a tie-break, save.

With this merged, **#33 is feature-complete end to end** (engine → persistence → merge integration → UI).

## Holding merge
Please deploy + open the editor to confirm the panel renders and saves.