### PR TITLE
feat: Fallback rule model + evaluation (#34)

### DIFF
--- a/force-app/main/default/classes/MRG_FallbackRule.cls
+++ b/force-app/main/default/classes/MRG_FallbackRule.cls
@@ -1,0 +1,167 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description model + evaluation for a standalone Fallback rule (#34).
+*
+* A fallback rule routes value(s) from a single winning record in a merge group into different
+* target field(s) on the kept record, only where the target field is currently empty. It fires
+* independently of track/preserve rules (it may apply to a field that has neither).
+*
+* Winner selection is either:
+*   - simple: by record age (Oldest / Newest), or
+*   - complex: conditions (MRG_KeepRecordRule.condition) + filter logic + tie-break ordering,
+*     reusing the #33 group-wide selection.
+*
+* All source values for one rule come from the SAME winning record, so a set of related fields
+* (e.g. a fallback email plus its subscription-preference fields) stay consistent.
+*/
+public with sharing class MRG_FallbackRule {
+
+	@auraEnabled public String id;
+	@auraEnabled public String label;
+	@auraEnabled public String objectName;
+	@auraEnabled public String selectionType;   // 'simple' | 'complex'
+	@auraEnabled public String rule;             // simple selection: 'Oldest' | 'Newest'
+	@auraEnabled public String filterLogic;      // complex selection
+	@auraEnabled public List<MRG_KeepRecordRule.condition> conditions; // complex selection
+	@auraEnabled public String tieBreakField;    // complex selection
+	@auraEnabled public String tieBreakDirection;// complex selection
+	@auraEnabled public List<fieldPair> fieldPairs;
+
+	public MRG_FallbackRule() {
+		this.selectionType = 'simple';
+		this.rule = 'Newest';
+		this.conditions = new List<MRG_KeepRecordRule.condition>();
+		this.fieldPairs = new List<fieldPair>();
+		this.tieBreakDirection = 'DESC';
+	}
+
+	/*******************************************************************************************************
+	* @description a source -> target field mapping for the fallback
+	*/
+	public class fieldPair {
+		@auraEnabled public String sourceField;
+		@auraEnabled public String targetField;
+		public fieldPair() {}
+		public fieldPair(String sourceField, String targetField) {
+			this.sourceField = sourceField;
+			this.targetField = targetField;
+		}
+	}
+
+	/*******************************************************************************************************
+	* @description the result of applying a fallback: which target field got which value, from which
+	* source field and record. Returned so the merge engine can update the record and write history.
+	*/
+	public class applied {
+		public String sourceField;
+		public String targetField;
+		public Object value;
+		public Id sourceRecordId;
+		public applied(String sourceField, String targetField, Object value, Id sourceRecordId) {
+			this.sourceField = sourceField;
+			this.targetField = targetField;
+			this.value = value;
+			this.sourceRecordId = sourceRecordId;
+		}
+	}
+
+	/*******************************************************************************************************
+	* @description all fields this rule reads/writes, so the caller can ensure they are queried
+	* @return Set<String> field api names
+	*/
+	public Set<String> referencedFields() {
+		Set<String> fields = new Set<String>();
+		if(String.isNotBlank(tieBreakField))
+			fields.add(tieBreakField);
+		if(conditions != null) {
+			for(MRG_KeepRecordRule.condition c:conditions) {
+				if(String.isNotBlank(c.fieldName))
+					fields.add(c.fieldName);
+			}
+		}
+		if(fieldPairs != null) {
+			for(fieldPair p:fieldPairs) {
+				if(String.isNotBlank(p.sourceField)) fields.add(p.sourceField);
+				if(String.isNotBlank(p.targetField)) fields.add(p.targetField);
+			}
+		}
+		return fields;
+	}
+
+	/*******************************************************************************************************
+	* @description selects the winning record for this fallback across a group
+	* @param records the full merge group (kept + merged), each with CreatedDate populated for 'simple'
+	* @return SObject the winning record, or null when none qualifies
+	*/
+	public SObject selectWinner(List<SObject> records) {
+		if(records == null || records.isEmpty())
+			return null;
+		if(selectionType == 'complex')
+			return toComplexRule().selectWinner(records);
+		// simple: Oldest / Newest by CreatedDate
+		SObject winner = null;
+		for(SObject record:records) {
+			if(winner == null) { winner = record; continue; }
+			Datetime rc = (Datetime) record.get('CreatedDate');
+			Datetime wc = (Datetime) winner.get('CreatedDate');
+			if(rc == null || wc == null) continue;
+			Boolean isNewest = rule == null || rule.equalsIgnoreCase('Newest');
+			if(isNewest ? rc > wc : rc < wc)
+				winner = record;
+		}
+		return winner;
+	}
+
+	/*******************************************************************************************************
+	* @description builds the equivalent complex-selection rule (for the 'complex' selection path)
+	*/
+	private MRG_ComplexPreserveRule toComplexRule() {
+		MRG_ComplexPreserveRule complexRule = new MRG_ComplexPreserveRule();
+		complexRule.filterLogic = this.filterLogic;
+		complexRule.conditions = this.conditions == null ? new List<MRG_KeepRecordRule.condition>() : this.conditions;
+		complexRule.tieBreakField = this.tieBreakField;
+		complexRule.tieBreakDirection = this.tieBreakDirection;
+		// fieldName isn't used by selectWinner, only winningValue; leave null
+		return complexRule;
+	}
+
+	/*******************************************************************************************************
+	* @description applies the fallback to a kept record given the full group: routes each pair's source
+	* value (from the winning record) into the target field on the kept record, only where the target is
+	* currently empty and the source value is present. Mutates keptRecord and returns what was applied.
+	* @param keptRecord the surviving record to write target fields onto
+	* @param records the full merge group (kept + merged)
+	* @return List<applied> the applied mappings (empty when nothing was routed)
+	*/
+	public List<applied> apply(SObject keptRecord, List<SObject> records) {
+		List<applied> results = new List<applied>();
+		if(keptRecord == null || fieldPairs == null || fieldPairs.isEmpty())
+			return results;
+		SObject winner = selectWinner(records);
+		if(winner == null)
+			return results;
+		Id winnerId = (Id) winner.get('Id');
+		for(fieldPair pair:fieldPairs) {
+			if(String.isBlank(pair.sourceField) || String.isBlank(pair.targetField))
+				continue;
+			Object targetVal = keptRecord.get(pair.targetField);
+			Object sourceVal = winner.get(pair.sourceField);
+			// only fill an empty target, and only from a present source value
+			if(isEmpty(targetVal) && !isEmpty(sourceVal)) {
+				keptRecord.put(pair.targetField, sourceVal);
+				results.add(new applied(pair.sourceField, pair.targetField, sourceVal, winnerId));
+			}
+		}
+		return results;
+	}
+
+	/*******************************************************************************************************
+	* @description treats null and blank string as empty
+	*/
+	private Boolean isEmpty(Object value) {
+		if(value == null) return true;
+		if(value instanceof String) return String.isBlank((String) value);
+		return false;
+	}
+}

--- a/force-app/main/default/classes/MRG_FallbackRule.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FallbackRule.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_FallbackRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_FallbackRule_TEST.cls
@@ -1,0 +1,133 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description unit tests for the standalone Fallback rule model + evaluation
+*/
+@isTest
+private class MRG_FallbackRule_TEST {
+
+	private static MRG_KeepRecordRule.condition cond(String field, String op, String val) {
+		return new MRG_KeepRecordRule.condition(field, op, val);
+	}
+
+	static testMethod void testReferencedFields() {
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.selectionType = 'complex';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.tieBreakField = 'Birthdate';
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{
+			new MRG_FallbackRule.fieldPair('Email', 'Description')
+		};
+		Set<String> fields = rule.referencedFields();
+		system.assert(fields.contains('Email') && fields.contains('Description'), 'pair fields');
+		system.assert(fields.contains('Birthdate'), 'tie-break field');
+		system.assert(fields.contains('HasOptedOutOfEmail'), 'condition field');
+	}
+
+	static testMethod void testSimpleNewestSelectionAndApply() {
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='Old', LastName='A', Email='old@test.com'),
+			new Contact(FirstName='New', LastName='B', Email='new@test.com')
+		};
+		insert cons;
+		Test.setCreatedDate(cons[0].Id, Datetime.now().addDays(-30));
+		Test.setCreatedDate(cons[1].Id, Datetime.now().addDays(-1));
+		List<Contact> recs = [SELECT Id, CreatedDate, Email, Description FROM Contact];
+
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.selectionType = 'simple';
+		rule.rule = 'Newest';
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+
+		// kept record has an empty Description target
+		Contact kept = new Contact(Id=cons[0].Id, Description=null);
+		List<MRG_FallbackRule.applied> applied = rule.apply(kept, recs);
+
+		system.assertEquals(1, applied.size(), 'one pair applied');
+		system.assertEquals('new@test.com', (String) kept.get('Description'), 'newest record email routed to Description');
+		system.assertEquals('Email', applied[0].sourceField);
+		system.assertEquals('Description', applied[0].targetField);
+	}
+
+	static testMethod void testTargetMustBeEmpty() {
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', Email='a@test.com')
+		};
+		insert cons;
+		List<Contact> recs = [SELECT Id, CreatedDate, Email, Description FROM Contact];
+
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.selectionType = 'simple';
+		rule.rule = 'Newest';
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+
+		// target already populated -> not overwritten
+		Contact kept = new Contact(Id=cons[0].Id, Description='already here');
+		List<MRG_FallbackRule.applied> applied = rule.apply(kept, recs);
+		system.assertEquals(0, applied.size(), 'non-empty target is not overwritten');
+		system.assertEquals('already here', (String) kept.get('Description'));
+	}
+
+	static testMethod void testComplexSelectionRoutesFromWinningRecord() {
+		// among opted-out records, prefer the newest birthdate; route its Email to Description
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', Email='nope@test.com', HasOptedOutOfEmail=false, Birthdate=Date.newInstance(2010,1,1)),
+			new Contact(FirstName='B', LastName='B', Email='older@test.com', HasOptedOutOfEmail=true, Birthdate=Date.newInstance(1980,1,1)),
+			new Contact(FirstName='C', LastName='C', Email='win@test.com', HasOptedOutOfEmail=true, Birthdate=Date.newInstance(2000,1,1))
+		};
+		insert cons;
+		List<Contact> recs = [SELECT Id, CreatedDate, Email, Description, HasOptedOutOfEmail, Birthdate FROM Contact];
+
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.selectionType = 'complex';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.tieBreakField = 'Birthdate';
+		rule.tieBreakDirection = 'DESC';
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+
+		Contact kept = new Contact(Id=cons[0].Id, Description=null);
+		List<MRG_FallbackRule.applied> applied = rule.apply(kept, recs);
+		system.assertEquals('win@test.com', (String) kept.get('Description'),
+			'complex winner (opted-out, newest birthdate) email routed to target');
+	}
+
+	static testMethod void testMultiPairSameRecord() {
+		// two pairs from the SAME winning record stay consistent
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='Win', LastName='W', Email='win@test.com', MailingState='WA', HasOptedOutOfEmail=true),
+			new Contact(FirstName='Lose', LastName='L', Email='lose@test.com', MailingState='CA', HasOptedOutOfEmail=false)
+		};
+		insert cons;
+		List<Contact> recs = [SELECT Id, CreatedDate, Email, Description, MailingState, OtherCity, HasOptedOutOfEmail FROM Contact];
+
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.selectionType = 'complex';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{
+			new MRG_FallbackRule.fieldPair('Email','Description'),
+			new MRG_FallbackRule.fieldPair('MailingState','OtherCity')
+		};
+
+		Contact kept = new Contact(Id=cons[1].Id, Description=null, OtherCity=null);
+		List<MRG_FallbackRule.applied> applied = rule.apply(kept, recs);
+		system.assertEquals(2, applied.size(), 'both pairs applied from the same winner');
+		system.assertEquals('win@test.com', (String) kept.get('Description'));
+		system.assertEquals('WA', (String) kept.get('OtherCity'));
+		// both came from the same winning record
+		system.assertEquals(applied[0].sourceRecordId, applied[1].sourceRecordId, 'same winning record for all pairs');
+	}
+
+	static testMethod void testNoWinnerNoApply() {
+		List<Contact> cons = new List<Contact>{ new Contact(FirstName='A', LastName='A', HasOptedOutOfEmail=false) };
+		insert cons;
+		List<Contact> recs = [SELECT Id, CreatedDate, Email, Description, HasOptedOutOfEmail FROM Contact];
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.selectionType = 'complex';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+		Contact kept = new Contact(Id=cons[0].Id);
+		system.assertEquals(0, rule.apply(kept, recs).size(), 'no condition match -> nothing applied');
+	}
+}

--- a/force-app/main/default/classes/MRG_FallbackRule_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FallbackRule_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
First slice of #34 (standalone Fallback rules). Pure engine; reuses the merged #33 complex selection. No DML/UI, fully unit-tested.

Design (confirmed): a **standalone** rule type (independent of track/preserve); winner selection is **simple (Oldest/Newest) or complex (conditions + tie-break)**; a **list of source→target pairs** all taken from the **same** winning record; applied **only when the target is empty**.

## What's here — `MRG_FallbackRule`
- `selectWinner(records)` — simple path = Oldest/Newest by CreatedDate; complex path delegates to `MRG_ComplexPreserveRule.selectWinner`
- `apply(keptRecord, group)` — for each pair, if the target field is empty and the winner's source value is present, write it onto the kept record; returns `applied{sourceField, targetField, value, sourceRecordId}` entries (so 34c can update + write history, including tracking-aware "routed to target")
- `referencedFields()` — pair + condition + tie-break fields, for SOQL
- `fieldPair` / `applied` inner types

## Tests
`MRG_FallbackRule_TEST` — simple Newest selection + apply, target-must-be-empty, complex selection routes from the winning record, multi-pair same-record consistency, no-winner.

## Next slices
- 34b: `FallbackRuleSettings__mdt` + load/save
- 34c: wire a fallback pass into the merge engine (+ history, tracking-aware)
- 34d: Fallback Rules UI tab + controller

## Holding merge
Net-new Apex — please compile/deploy + run tests before I merge.