### PR TITLE
feat: FallbackRuleSettings__mdt + load/save service (#34)

### DIFF
--- a/force-app/main/default/classes/MRG_FallbackRule.cls
+++ b/force-app/main/default/classes/MRG_FallbackRule.cls
@@ -37,6 +37,27 @@ public with sharing class MRG_FallbackRule {
 	}
 
 	/*******************************************************************************************************
+	* @description builds a fallback rule wrapper from a FallbackRuleSettings__mdt record
+	* @param setting the metadata record (with Object__r / TieBreakField__r selected)
+	*/
+	public MRG_FallbackRule(FallbackRuleSettings__mdt setting) {
+		this.id = setting.Id;
+		this.label = setting.Label;
+		this.objectName = setting.Object__r != null ? setting.Object__r.QualifiedAPIName : null;
+		this.selectionType = String.isNotBlank(setting.SelectionType__c) ? setting.SelectionType__c : 'simple';
+		this.rule = String.isNotBlank(setting.Rule__c) ? setting.Rule__c : 'Newest';
+		this.filterLogic = setting.FilterLogic__c;
+		this.conditions = String.isNotBlank(setting.Conditions__c)
+			? (List<MRG_KeepRecordRule.condition>) JSON.deserialize(setting.Conditions__c, List<MRG_KeepRecordRule.condition>.class)
+			: new List<MRG_KeepRecordRule.condition>();
+		this.tieBreakField = setting.TieBreakField__r != null ? setting.TieBreakField__r.QualifiedAPIName : null;
+		this.tieBreakDirection = String.isNotBlank(setting.TieBreakDirection__c) ? setting.TieBreakDirection__c : 'DESC';
+		this.fieldPairs = String.isNotBlank(setting.FieldPairs__c)
+			? (List<fieldPair>) JSON.deserialize(setting.FieldPairs__c, List<fieldPair>.class)
+			: new List<fieldPair>();
+	}
+
+	/*******************************************************************************************************
 	* @description a source -> target field mapping for the fallback
 	*/
 	public class fieldPair {
@@ -163,5 +184,90 @@ public with sharing class MRG_FallbackRule {
 		if(value == null) return true;
 		if(value instanceof String) return String.isBlank((String) value);
 		return false;
+	}
+
+	/*******************************************************************************************************
+	* @description all configured fallback rules, lazily queried from custom metadata
+	*/
+	public static List<MRG_FallbackRule> fallbackRules {
+		get {
+			if(fallbackRules == null) {
+				List<MRG_FallbackRule> rules = new List<MRG_FallbackRule>();
+				for(FallbackRuleSettings__mdt setting:[
+					SELECT Id, Label, QualifiedAPIName, Object__c, Object__r.QualifiedAPIName,
+						SelectionType__c, Rule__c, FilterLogic__c, Conditions__c,
+						TieBreakField__r.QualifiedAPIName, TieBreakDirection__c, FieldPairs__c
+					FROM FallbackRuleSettings__mdt
+				]) {
+					rules.add(new MRG_FallbackRule(setting));
+				}
+				fallbackRules = rules;
+			}
+			return fallbackRules;
+		}
+		set;
+	}
+
+	/*******************************************************************************************************
+	* @description the fallback rules configured for a single object
+	* @param objectType the SObject api name
+	* @return List<MRG_FallbackRule> (may be empty)
+	*/
+	public static List<MRG_FallbackRule> getRules(String objectType) {
+		List<MRG_FallbackRule> rules = new List<MRG_FallbackRule>();
+		for(MRG_FallbackRule rule:fallbackRules) {
+			if(String.isNotBlank(rule.objectName) && rule.objectName.equalsIgnoreCase(objectType))
+				rules.add(rule);
+		}
+		return rules;
+	}
+
+	/*******************************************************************************************************
+	* @description saves a list of fallback rules via the Metadata API
+	* @param rules the rules to save
+	* @return String the metadata deploy job id
+	*/
+	public static String saveFallbackRules(List<MRG_FallbackRule> rules) {
+		MRG_Metadata_SVC mdService = new MRG_Metadata_SVC();
+		List<Metadata.CustomMetadata> mdRecords = new List<Metadata.CustomMetadata>();
+		for(MRG_FallbackRule rule:rules) {
+			mdRecords.add(mdService.getMetaDataRecord(toSetting(rule)));
+		}
+		return mdService.deployMetadataRecords(mdRecords);
+	}
+
+	/*******************************************************************************************************
+	* @description converts a fallback rule wrapper into a FallbackRuleSettings__mdt record, populating
+	* the read-only Object__r / TieBreakField__r relationships via JSON injection
+	* @param rule the rule wrapper
+	* @return FallbackRuleSettings__mdt the metadata record
+	*/
+	public static FallbackRuleSettings__mdt toSetting(MRG_FallbackRule rule) {
+		FallbackRuleSettings__mdt setting = new FallbackRuleSettings__mdt(
+			Label = String.isNotBlank(rule.label) ? rule.label : (rule.objectName + ' Fallback'),
+			SelectionType__c = rule.selectionType,
+			Rule__c = rule.rule,
+			FilterLogic__c = rule.filterLogic,
+			Conditions__c = rule.conditions != null && !rule.conditions.isEmpty() ? JSON.serialize(rule.conditions) : null,
+			TieBreakDirection__c = rule.tieBreakDirection,
+			FieldPairs__c = rule.fieldPairs != null && !rule.fieldPairs.isEmpty() ? JSON.serialize(rule.fieldPairs) : null
+		);
+		String devName = (rule.objectName == null ? 'Obj' : rule.objectName.replace('__','').replace('_','')) + 'Fallback'
+			+ (String.isNotBlank(rule.label) ? rule.label.replaceAll('[^a-zA-Z0-9]','') : '');
+		setting.QualifiedAPIName = devName;
+		Map<String, Object> settingJSON = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(setting));
+		settingJSON.put('Object__r', new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' },
+			'QualifiedAPIName' => rule.objectName
+		});
+		if(String.isNotBlank(rule.tieBreakField)) {
+			settingJSON.put('TieBreakField__r', new Map<String, Object>{
+				'attributes' => new Map<String, Object>{ 'type' => 'EntityParticle' },
+				'QualifiedAPIName' => rule.tieBreakField
+			});
+		}
+		if(String.isNotBlank(rule.id))
+			settingJSON.put('Id', rule.id);
+		return (FallbackRuleSettings__mdt) JSON.deserialize(JSON.serialize(settingJSON), FallbackRuleSettings__mdt.class);
 	}
 }

--- a/force-app/main/default/classes/MRG_FallbackSettings_TEST.cls
+++ b/force-app/main/default/classes/MRG_FallbackSettings_TEST.cls
@@ -1,0 +1,93 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for loading/saving fallback rules from/to FallbackRuleSettings__mdt
+*/
+@isTest
+private class MRG_FallbackSettings_TEST {
+
+	private static FallbackRuleSettings__mdt buildSetting(String objectName, String selectionType, String fieldPairsJson, String tieBreakField) {
+		FallbackRuleSettings__mdt s = new FallbackRuleSettings__mdt();
+		Map<String, Object> m = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(s));
+		m.put(FallbackRuleSettings__mdt.Label.getDescribe().getName(), objectName+' fallback');
+		m.put(FallbackRuleSettings__mdt.DeveloperName.getDescribe().getName(), objectName+'Fallback');
+		m.put(FallbackRuleSettings__mdt.SelectionType__c.getDescribe().getName(), selectionType);
+		m.put(FallbackRuleSettings__mdt.Rule__c.getDescribe().getName(), 'Newest');
+		m.put(FallbackRuleSettings__mdt.TieBreakDirection__c.getDescribe().getName(), 'DESC');
+		m.put(FallbackRuleSettings__mdt.FieldPairs__c.getDescribe().getName(), fieldPairsJson);
+		m.put('Object__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' }, 'QualifiedAPIName' => objectName });
+		if(String.isNotBlank(tieBreakField))
+			m.put('TieBreakField__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityParticle' }, 'QualifiedAPIName' => tieBreakField });
+		return (FallbackRuleSettings__mdt) JSON.deserialize(JSON.serialize(m), FallbackRuleSettings__mdt.class);
+	}
+
+	private static String pairsJson() {
+		return JSON.serialize(new List<MRG_FallbackRule.fieldPair>{
+			new MRG_FallbackRule.fieldPair('Email','Description'),
+			new MRG_FallbackRule.fieldPair('MailingState','OtherCity')
+		});
+	}
+
+	static testMethod void testConstructorParsesSetting() {
+		FallbackRuleSettings__mdt setting = buildSetting('Contact', 'complex', pairsJson(), 'Birthdate');
+		MRG_FallbackRule rule = new MRG_FallbackRule(setting);
+		system.assertEquals('Contact', rule.objectName);
+		system.assertEquals('complex', rule.selectionType);
+		system.assertEquals('Birthdate', rule.tieBreakField);
+		system.assertEquals('DESC', rule.tieBreakDirection);
+		system.assertEquals(2, rule.fieldPairs.size());
+		system.assertEquals('Email', rule.fieldPairs[0].sourceField);
+		system.assertEquals('OtherCity', rule.fieldPairs[1].targetField);
+	}
+
+	static testMethod void testConstructorHandlesBlankCollections() {
+		FallbackRuleSettings__mdt setting = buildSetting('Account', 'simple', null, null);
+		MRG_FallbackRule rule = new MRG_FallbackRule(setting);
+		system.assertEquals(0, rule.fieldPairs.size());
+		system.assertEquals(0, rule.conditions.size());
+		system.assertEquals('simple', rule.selectionType);
+	}
+
+	static testMethod void testGetRulesFiltersByObject() {
+		MRG_FallbackRule c = new MRG_FallbackRule(); c.objectName = 'Contact';
+		MRG_FallbackRule a = new MRG_FallbackRule(); a.objectName = 'Account';
+		MRG_FallbackRule.fallbackRules = new List<MRG_FallbackRule>{ c, a };
+		system.assertEquals(1, MRG_FallbackRule.getRules('Contact').size());
+		system.assertEquals(1, MRG_FallbackRule.getRules('Account').size());
+		system.assertEquals(0, MRG_FallbackRule.getRules('Lead').size());
+	}
+
+	static testMethod void testToSettingRoundTrip() {
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.objectName = 'Contact';
+		rule.label = 'Email Fallback';
+		rule.selectionType = 'complex';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ new MRG_KeepRecordRule.condition('HasOptedOutOfEmail','equals','true') };
+		rule.tieBreakField = 'Birthdate';
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+
+		FallbackRuleSettings__mdt setting = MRG_FallbackRule.toSetting(rule);
+		system.assertEquals('Contact', setting.Object__r.QualifiedAPIName);
+		system.assertEquals('complex', setting.SelectionType__c);
+		system.assertEquals('Birthdate', setting.TieBreakField__r.QualifiedAPIName);
+		system.assert(setting.FieldPairs__c.contains('Email'));
+		system.assert(setting.Conditions__c.contains('HasOptedOutOfEmail'));
+
+		MRG_FallbackRule roundTrip = new MRG_FallbackRule(setting);
+		system.assertEquals(1, roundTrip.fieldPairs.size());
+		system.assertEquals('Email', roundTrip.fieldPairs[0].sourceField);
+		system.assertEquals(1, roundTrip.conditions.size());
+	}
+
+	static testMethod void testSaveFallbackRules() {
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.objectName = 'Contact';
+		rule.label = 'F1';
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+		Test.startTest();
+		String jobId = MRG_FallbackRule.saveFallbackRules(new List<MRG_FallbackRule>{ rule });
+		Test.stopTest();
+		system.assertEquals('Test Job Id', jobId);
+	}
+}

--- a/force-app/main/default/classes/MRG_FallbackSettings_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FallbackSettings_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_Metadata_SVC.cls
+++ b/force-app/main/default/classes/MRG_Metadata_SVC.cls
@@ -112,6 +112,36 @@ public with sharing class MRG_Metadata_SVC {
 	* @param integrationProcessToSave the integration process we're saving
 	* @return the Job Id of the deployment job
 	*/ 		
+	public Metadata.CustomMetadata getMetaDataRecord(FallbackRuleSettings__mdt fallbackSetting) {
+		Metadata.CustomMetadata mdRecord = new Metadata.CustomMetadata();
+		List<String> mdRecordNames = new List<String>();
+		Map<String, Object> fieldKeyValues = new Map<String, Object>();
+		fieldKeyValues.put('Object__c', fallbackSetting.Object__r.QualifiedAPIName);
+		fieldKeyValues.put('SelectionType__c', fallbackSetting.SelectionType__c);
+		fieldKeyValues.put('Rule__c', fallbackSetting.Rule__c);
+		fieldKeyValues.put('FilterLogic__c', fallbackSetting.FilterLogic__c);
+		fieldKeyValues.put('Conditions__c', fallbackSetting.Conditions__c);
+		fieldKeyValues.put('TieBreakDirection__c', fallbackSetting.TieBreakDirection__c);
+		fieldKeyValues.put('TieBreakField__c', fallbackSetting.TieBreakField__r != null ? fallbackSetting.TieBreakField__r.QualifiedAPIName : null);
+		fieldKeyValues.put('FieldPairs__c', fallbackSetting.FieldPairs__c);
+		String qualifiedName = !fallbackSetting.QualifiedAPIName.contains('.') ? 'FallbackRuleSettings__mdt.'+fallbackSetting.QualifiedAPIName : fallbackSetting.QualifiedAPIName;
+		mdRecordNames.add(qualifiedName);
+
+		List<Metadata.Metadata> metadataRecords = getMetadataRecords(mdRecordNames);
+		if(metadataRecords.size()>0) {
+			mdRecord = (Metadata.CustomMetadata) metadataRecords.get(0).clone();
+		} else {
+			mdRecord.fullName = qualifiedName;
+		}
+		mdRecord.Label = fallbackSetting.Label;
+		mdRecord = updateMetadataObjectFields(mdRecord, fieldKeyValues);
+		return mdRecord;
+	}
+	/*******************************************************************************************************
+	* @description saves an integration process via metadata deployment
+	* @param keepRuleSetting the keep-record rule setting to save
+	* @return the Job Id of the deployment job
+	*/
 	public Metadata.CustomMetadata getMetaDataRecord(KeepRecordRuleSettings__mdt keepRuleSetting) {
 		   	// create metadata container
 		Metadata.CustomMetadata mdRecord = new Metadata.CustomMetadata();

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/FallbackRuleSettings__mdt.object-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/FallbackRuleSettings__mdt.object-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Fallback Rule Setting</label>
+    <pluralLabel>Fallback Rule Settings</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/Conditions__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/Conditions__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Conditions__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>For complex selection: JSON array of the conditions (field, operator, value) a source record must satisfy. Maintained by the Fallback Rules UI.</inlineHelpText>
+    <label>Conditions</label>
+    <required>false</required>
+    <type>LongTextArea</type>
+    <length>131072</length>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/FieldPairs__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/FieldPairs__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FieldPairs__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>JSON array of source-to-target field mappings, all routed from the same winning record. Maintained by the Fallback Rules UI.</inlineHelpText>
+    <label>Field Pairs</label>
+    <required>false</required>
+    <type>LongTextArea</type>
+    <length>131072</length>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/FilterLogic__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/FilterLogic__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FilterLogic__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>For complex selection: report-style logic combining the numbered conditions, e.g. (1 AND 2) OR 3. Leave blank to AND all conditions.</inlineHelpText>
+    <label>Filter Logic</label>
+    <required>false</required>
+    <type>Text</type>
+    <length>255</length>
+</CustomField>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/Object__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/Object__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Object__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Object</label>
+    <referenceTo>EntityDefinition</referenceTo>
+    <relationshipLabel>FallbackRuleSettings</relationshipLabel>
+    <relationshipName>FallbackRuleSettings</relationshipName>
+    <required>true</required>
+    <type>MetadataRelationship</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/Rule__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/Rule__c.field-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Rule__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>For simple selection: which record's value to route (by record age).</inlineHelpText>
+    <label>Rule</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Newest</fullName>
+                <default>true</default>
+                <label>Newest</label>
+            </value>
+            <value>
+                <fullName>Oldest</fullName>
+                <default>false</default>
+                <label>Oldest</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/SelectionType__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/SelectionType__c.field-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SelectionType__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>How the source record is chosen: simple (by record age) or complex (conditions + tie-break).</inlineHelpText>
+    <label>Selection Type</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>simple</fullName>
+                <default>true</default>
+                <label>Simple</label>
+            </value>
+            <value>
+                <fullName>complex</fullName>
+                <default>false</default>
+                <label>Complex</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/TieBreakDirection__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/TieBreakDirection__c.field-meta.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TieBreakDirection__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Tie Break Direction</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>DESC</fullName>
+                <default>true</default>
+                <label>Descending</label>
+            </value>
+            <value>
+                <fullName>ASC</fullName>
+                <default>false</default>
+                <label>Ascending</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/TieBreakField__c.field-meta.xml
+++ b/force-app/main/default/objects/FallbackRuleSettings__mdt/fields/TieBreakField__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TieBreakField__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>For complex selection: when more than one source record matches, the field used to rank them.</inlineHelpText>
+    <label>Tie Break Field</label>
+    <referenceTo>EntityParticle</referenceTo>
+    <relationshipLabel>Fallback_Tie_Break_Field</relationshipLabel>
+    <relationshipName>Fallback_Tie_Break_Field</relationshipName>
+    <required>false</required>
+    <type>MetadataRelationship</type>
+    <metadataRelationshipControllingField>Object__c</metadataRelationshipControllingField>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Second slice of #34 — configuration + persistence. Builds on merged 34a.

## Metadata — `FallbackRuleSettings__mdt`
- `Object__c` (MetadataRelationship → EntityDefinition)
- `SelectionType__c` (simple / complex)
- `Rule__c` (Newest / Oldest — simple selection)
- `FilterLogic__c`, `Conditions__c` (JSON — complex selection)
- `TieBreakField__c` (MetadataRelationship → EntityParticle), `TieBreakDirection__c`
- `FieldPairs__c` (LongTextArea JSON — source→target pairs)

## Apex
- `MRG_FallbackRule` constructor from the mdt; `fallbackRules` lazily-queried property (test-injectable); `getRules(objectType)`; `toSetting(rule)` with JSON-injected `Object__r` / `TieBreakField__r` and serialized conditions + pairs; `saveFallbackRules`
- `MRG_Metadata_SVC.getMetaDataRecord(FallbackRuleSettings__mdt)` deploy (null-safe tie-break)

## Tests
`MRG_FallbackSettings_TEST` — constructor parse (incl. blank collections), `getRules` filter, `toSetting` round-trip, save (`Test Job Id`).

## Holding merge
Please compile/deploy + run tests before I merge.