### PR TITLE
feat: apply Fallback rules in the group-wide merge pass (#34)

### DIFF
--- a/force-app/main/default/classes/MRG_FallbackMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_FallbackMerge_TEST.cls
@@ -1,0 +1,89 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description integration test: Fallback rules applied through the production merge path
+*/
+@isTest
+private class MRG_FallbackMerge_TEST {
+
+	private static MRG_KeepRecordRule.condition cond(String field, String op, String val) {
+		return new MRG_KeepRecordRule.condition(field, op, val);
+	}
+
+	static testMethod void testFallbackRoutesLostEmailToTargetField() {
+		// ticket spirit: keep one contact, but route the lost record's Email into the kept record's
+		// Description (an otherwise-empty target). Complex selection: from the opted-out record.
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, Email='keep@test.com', Description=null, HasOptedOutOfEmail=false),
+			new Contact(Id=mergeId, Email='lost@test.com', HasOptedOutOfEmail=true)
+		};
+
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>();
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.objectName = 'Contact';
+		rule.selectionType = 'complex';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+		MRG_FallbackRule.fallbackRules = new List<MRG_FallbackRule>{ rule };
+
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals('lost@test.com', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'Description'),
+			'fallback should route the lost (opted-out) record email into the empty Description target');
+		// kept email itself is untouched by the fallback
+		system.assertEquals('keep@test.com', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'Email'),
+			'fallback writes only the target field, not the source field on keep');
+
+		// tracking-aware history: source field recorded with the target it was routed to
+		List<MergeFieldHistory__c> history = [
+			SELECT MergeValueType__c, TargetField__c, KeptValue__c FROM MergeFieldHistory__c WHERE KeptRecordId__c=:keepId
+		];
+		Boolean found = false;
+		for(MergeFieldHistory__c h:history) {
+			if(h.MergeValueType__c == 'Email' && h.TargetField__c == 'Description') {
+				found = true;
+				system.assertEquals('lost@test.com', h.KeptValue__c);
+			}
+		}
+		system.assert(found, 'history should record Email routed to Description');
+	}
+
+	static testMethod void testFallbackSkipsWhenTargetNotEmpty() {
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, Description='already set', HasOptedOutOfEmail=false),
+			new Contact(Id=mergeId, Email='lost@test.com', HasOptedOutOfEmail=true)
+		};
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>();
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.objectName = 'Contact';
+		rule.selectionType = 'complex';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+		MRG_FallbackRule.fallbackRules = new List<MRG_FallbackRule>{ rule };
+
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals('already set', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'Description'),
+			'fallback must not overwrite a populated target');
+	}
+}

--- a/force-app/main/default/classes/MRG_FallbackMerge_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FallbackMerge_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -535,6 +535,15 @@ public with sharing class MRG_Merge_SVC {
 	* @param objectType the SObject api name
 	* @return List<MRG_ComplexPreserveRule>
 	*/
+	public static List<MRG_FallbackRule> getFallbackRules(String objectType) {
+		return MRG_FallbackRule.getRules(objectType);
+	}
+	/*******************************************************************************************************
+	* @description the Complex preservation rules for an object: enabled Preserve fields whose rule is
+	* 'Complex', converted to MRG_ComplexPreserveRule for group-wide evaluation
+	* @param objectType the SObject api name
+	* @return List<MRG_ComplexPreserveRule>
+	*/
 	public static List<MRG_ComplexPreserveRule> getComplexPreserveRules(String objectType) {
 		List<MRG_ComplexPreserveRule> complexRules = new List<MRG_ComplexPreserveRule>();
 		for(mergeFieldWrap mfw:getPreserveMergeFields()) {
@@ -849,11 +858,10 @@ public with sharing class MRG_Merge_SVC {
 					updateRecordMap.put(keptRec.Id,keptRec);
 			}
 		}
-		// --- group-wide Complex-rule pass (#33) ---------------------------------------------------
-		// For each kept record, gather its full group (kept + merged) and, per Complex rule, preserve
-		// the value from the rule's winning record (condition match + tie-break). Emits field history
-		// when the kept value changes.
-		if(!complexRules.isEmpty()) {
+		// --- group-wide passes (#33 Complex, #34 Fallback) ----------------------------------------
+		// Both operate on the full per-keep group (kept + merged), so build that grouping once.
+		List<MRG_FallbackRule> fallbackRules = getFallbackRules(objectType);
+		if(!complexRules.isEmpty() || !fallbackRules.isEmpty()) {
 			Map<Id, List<SObject>> mergedByKeepId = new Map<Id, List<SObject>>();
 			for(SObject obj:mergedRecords) {
 				Id mId = (Id) obj.get('Id');
@@ -870,7 +878,8 @@ public with sharing class MRG_Merge_SVC {
 				List<SObject> recordGroup = new List<SObject>{ keptRec };
 				if(mergedByKeepId.containsKey(keepId))
 					recordGroup.addAll(mergedByKeepId.get(keepId));
-				Boolean complexChange = false;
+				Boolean groupChange = false;
+				// Complex preserve (#33): preserve the winning record's value onto the same field
 				for(MRG_ComplexPreserveRule complexRule:complexRules) {
 					Object winning = complexRule.winningValue(recordGroup);
 					if(winning == null)
@@ -879,10 +888,18 @@ public with sharing class MRG_Merge_SVC {
 					if(valuesAreEqual(current, winning))
 						continue;
 					keptRec.put(complexRule.fieldName, winning);
-					complexChange = true;
+					groupChange = true;
 					mergeRecords.add(getMergeRecord(winning, current, keptRec, String.valueOf(keepId), complexRule.fieldName));
 				}
-				if(complexChange)
+				// Fallback (#34): route the winning record's source value(s) into target field(s), only
+				// where the target is empty. Records where each value ended up (tracking-aware history).
+				for(MRG_FallbackRule fallbackRule:fallbackRules) {
+					for(MRG_FallbackRule.applied a:fallbackRule.apply(keptRec, recordGroup)) {
+						groupChange = true;
+						mergeRecords.add(getFallbackMergeRecord(a.value, keptRec.Id, a.sourceRecordId, a.sourceField, a.targetField));
+					}
+				}
+				if(groupChange)
 					updateRecordMap.put(keptRec.Id, keptRec);
 			}
 		}
@@ -931,6 +948,26 @@ public with sharing class MRG_Merge_SVC {
 			MergeValueType__c = fieldName
 		);
 		return mergeRecord;
+	}
+	/*******************************************************************************************************
+	* @description history record for a fallback-routed value: the source value (from the winning
+	* record) written to a different target field on the kept record
+	* @param value the routed value
+	* @param keptRecordId the kept record id
+	* @param sourceRecordId the record the value came from
+	* @param sourceField the source field api name
+	* @param targetField the target field api name on the kept record
+	* @return MergeFieldHistory__c
+	*/
+	public static MergeFieldHistory__c getFallbackMergeRecord(Object value, Id keptRecordId, Id sourceRecordId, String sourceField, String targetField) {
+		return new MergeFieldHistory__c(
+			KeptRecordId__c = keptRecordId,
+			MergedRecordId__c = sourceRecordId,
+			KeptValue__c = String.valueOf(value),
+			MergeValue__c = String.valueOf(value),
+			MergeValueType__c = sourceField,
+			TargetField__c = targetField
+		);
 	}
 	/*******************************************************************************************************
 	* @description gets writeable fields for a contact record

--- a/force-app/main/default/objects/MergeFieldHistory__c/fields/TargetField__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldHistory__c/fields/TargetField__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TargetField__c</fullName>
+    <externalId>false</externalId>
+    <inlineHelpText>For a fallback-routed value: the field on the kept record the value was written to (when different from the source field).</inlineHelpText>
+    <label>Target Field</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Third slice of #34 — the behavior change. Builds on merged 34a/34b.

## What changed in `getMergesFromDeletedRecords`
- The group-wide section now handles **both** the Complex preserve pass (#33) and the new **Fallback pass**, sharing one kept+merged grouping.
- Per kept record, for each fallback rule: `MRG_FallbackRule.apply(keptRec, group)` routes the winning record's source value(s) into the target field(s) **only where the target is empty**.
- Each routed value emits a **tracking-aware** `MergeFieldHistory__c`: `MergeValueType__c` = source field, **`TargetField__c`** = where it landed.

## New
- `MergeFieldHistory__c.TargetField__c` (Text) — records the fallback target.
- `MRG_Merge_SVC.getFallbackMergeRecord(...)` helper + `getFallbackRules(objectType)` bridge.

## Tests
`MRG_FallbackMerge_TEST` drives real merges:
- complex-selected fallback routes a lost (opted-out) record's Email into the empty `Description` target; asserts the value, that the source field on keep is untouched, and the tracking-aware history (`Email` → `Description`)
- a populated target is not overwritten

## Known limitation (consistent with #33)
Source/tie-break/condition fields that are read-only won't be in the merge query; the 34d picker will offer only queryable fields. Target fields are updateable so they're always queried.

## Holding merge
Please compile/deploy + run tests before I merge.