### PR TITLE
feat: Fallback Rules UI tab + controller (#34)

### DIFF
--- a/force-app/main/default/classes/MRG_FallbackRules_CTRL.cls
+++ b/force-app/main/default/classes/MRG_FallbackRules_CTRL.cls
@@ -1,0 +1,61 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description controller for the Fallback Rules LWC tab. Loads/saves fallback rules and provides the
+* object field list and operator options for the rule builder.
+*/
+public with sharing class MRG_FallbackRules_CTRL {
+
+	/*******************************************************************************************************
+	* @description the fallback rules configured for an object
+	* @param objectType the SObject api name
+	* @return List<MRG_FallbackRule>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_FallbackRule> getFallbackRules(String objectType) {
+		if(String.isBlank(objectType))
+			return new List<MRG_FallbackRule>();
+		return MRG_FallbackRule.getRules(objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description updateable, accessible fields for an object (label, name, type) for field pickers
+	* @param objectType the SObject api name
+	* @return List<MRG_Merge_SVC.objectField>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_Merge_SVC.objectField> getObjectFields(String objectType) {
+		return MRG_MergeSettings_CTRL.getObjectFields(objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description condition operator options
+	* @return List<MRG_KeepRecordRules_CTRL.operatorOption>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_KeepRecordRules_CTRL.operatorOption> getOperators() {
+		return MRG_KeepRecordRules_CTRL.getOperators();
+	}
+
+	/*******************************************************************************************************
+	* @description saves the fallback rules supplied as JSON from the UI. Validates each complex rule's
+	* filter logic before deploying.
+	* @param jsonData a JSON array of MRG_FallbackRule
+	* @return String the metadata deploy job id
+	*/
+	@auraEnabled
+	public static String saveFallbackRules(String jsonData) {
+		List<MRG_FallbackRule> rules = (List<MRG_FallbackRule>) JSON.deserialize(jsonData, List<MRG_FallbackRule>.class);
+		for(MRG_FallbackRule rule:rules) {
+			if(rule.selectionType == 'complex') {
+				Integer count = rule.conditions == null ? 0 : rule.conditions.size();
+				try {
+					MRG_FilterLogic.validate(rule.filterLogic, count);
+				} catch(MRG_FilterLogic.ParseException e) {
+					throw new AuraHandledException('Invalid filter logic for fallback "' + rule.label + '": ' + e.getMessage());
+				}
+			}
+		}
+		return MRG_FallbackRule.saveFallbackRules(rules);
+	}
+}

--- a/force-app/main/default/classes/MRG_FallbackRules_CTRL.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FallbackRules_CTRL.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_FallbackRules_CTRL_TEST.cls
+++ b/force-app/main/default/classes/MRG_FallbackRules_CTRL_TEST.cls
@@ -1,0 +1,55 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for the Fallback Rules controller
+*/
+@isTest
+private class MRG_FallbackRules_CTRL_TEST {
+
+	static testMethod void testGetFallbackRules() {
+		system.assertEquals(0, MRG_FallbackRules_CTRL.getFallbackRules('').size(), 'blank object -> empty');
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.objectName = 'Contact';
+		MRG_FallbackRule.fallbackRules = new List<MRG_FallbackRule>{ rule };
+		system.assertEquals(1, MRG_FallbackRules_CTRL.getFallbackRules('Contact').size());
+		system.assertEquals(0, MRG_FallbackRules_CTRL.getFallbackRules('Account').size());
+	}
+
+	static testMethod void testGetObjectFieldsAndOperators() {
+		system.assert(MRG_FallbackRules_CTRL.getObjectFields('Contact').size() > 0);
+		system.assertEquals(0, MRG_FallbackRules_CTRL.getObjectFields('').size());
+		system.assert(MRG_FallbackRules_CTRL.getOperators().size() >= 9);
+	}
+
+	static testMethod void testSaveValidSimple() {
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.objectName = 'Contact';
+		rule.label = 'simple fb';
+		rule.selectionType = 'simple';
+		rule.rule = 'Newest';
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+
+		Test.startTest();
+		String jobId = MRG_FallbackRules_CTRL.saveFallbackRules(JSON.serialize(new List<MRG_FallbackRule>{ rule }));
+		Test.stopTest();
+		system.assertEquals('Test Job Id', jobId);
+	}
+
+	static testMethod void testSaveInvalidComplexLogicThrows() {
+		MRG_FallbackRule rule = new MRG_FallbackRule();
+		rule.objectName = 'Contact';
+		rule.label = 'bad fb';
+		rule.selectionType = 'complex';
+		rule.filterLogic = '1 AND 7'; // references condition 7 with only 1 condition
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ new MRG_KeepRecordRule.condition('Email','equals','x@test.com') };
+		rule.fieldPairs = new List<MRG_FallbackRule.fieldPair>{ new MRG_FallbackRule.fieldPair('Email','Description') };
+
+		Boolean threw = false;
+		try {
+			MRG_FallbackRules_CTRL.saveFallbackRules(JSON.serialize(new List<MRG_FallbackRule>{ rule }));
+		} catch(AuraHandledException e) {
+			threw = true;
+		}
+		system.assert(threw, 'invalid complex filter logic should raise an AuraHandledException');
+	}
+}

--- a/force-app/main/default/classes/MRG_FallbackRules_CTRL_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FallbackRules_CTRL_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/fallbackRules/fallbackRules.html
+++ b/force-app/main/default/lwc/fallbackRules/fallbackRules.html
@@ -1,0 +1,138 @@
+<template>
+    <lightning-card title="Fallback Rules" icon-name="standard:flow">
+        <div class="slds-m-horizontal_medium">
+            <p class="slds-m-bottom_small slds-text-color_weak">
+                A fallback rule routes value(s) from a single winning record into different target
+                field(s) on the kept record, only where the target is empty. It applies regardless of
+                track/preserve settings. All pairs in a rule are taken from the same winning record.
+            </p>
+
+            <lightning-combobox label="Object" value={objectType} options={objectOptions}
+                onchange={handleObjectChange}>
+            </lightning-combobox>
+
+            <template if:true={hasObject}>
+                <template for:each={rules} for:item="rule">
+                    <div key={rule.uiKey} class="slds-box slds-m-vertical_small">
+                        <div class="slds-grid slds-grid_align-spread slds-m-bottom_x-small">
+                            <lightning-input class="slds-size_1-of-2" label="Rule Label" value={rule.label}
+                                data-rule={rule.ruleIndex} onchange={handleLabelChange}>
+                            </lightning-input>
+                            <lightning-button-icon icon-name="utility:delete" alternative-text="Remove rule"
+                                title="Remove rule" data-rule={rule.ruleIndex} onclick={removeRule}>
+                            </lightning-button-icon>
+                        </div>
+
+                        <div class="slds-grid slds-gutters slds-m-bottom_x-small">
+                            <div class="slds-col slds-size_1-of-2">
+                                <lightning-combobox label="Source Record Selection" value={rule.selectionType}
+                                    options={selectionOptions} data-rule={rule.ruleIndex}
+                                    onchange={handleSelectionTypeChange}>
+                                </lightning-combobox>
+                            </div>
+                            <div class="slds-col slds-size_1-of-2">
+                                <template if:false={rule.isComplex}>
+                                    <lightning-combobox label="Rule" value={rule.rule} options={ruleOptions}
+                                        data-rule={rule.ruleIndex} onchange={handleSimpleRuleChange}>
+                                    </lightning-combobox>
+                                </template>
+                            </div>
+                        </div>
+
+                        <!-- complex selection: conditions + filter logic + tie-break -->
+                        <template if:true={rule.isComplex}>
+                            <p class="slds-text-title_caps slds-m-vertical_x-small">Conditions</p>
+                            <template for:each={rule.conditions} for:item="condition">
+                                <div key={condition.uiKey} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
+                                    <div class="slds-col slds-size_1-of-12 slds-align-middle">{condition.conditionIndex}</div>
+                                    <div class="slds-col slds-size_4-of-12">
+                                        <lightning-combobox label="Field" value={condition.fieldName} options={fieldOptions}
+                                            data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                            onchange={handleConditionFieldChange}>
+                                        </lightning-combobox>
+                                    </div>
+                                    <div class="slds-col slds-size_3-of-12">
+                                        <lightning-combobox label="Operator" value={condition.operator} options={operatorOptions}
+                                            data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                            onchange={handleConditionOperatorChange}>
+                                        </lightning-combobox>
+                                    </div>
+                                    <div class="slds-col slds-size_3-of-12">
+                                        <template if:true={condition.isCheckbox}>
+                                            <lightning-input type="checkbox" label="Value" checked={condition.checked}
+                                                data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                                onchange={handleConditionValueChange}>
+                                            </lightning-input>
+                                        </template>
+                                        <template if:false={condition.isCheckbox}>
+                                            <lightning-input type={condition.inputType} label="Value" value={condition.value}
+                                                data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                                onchange={handleConditionValueChange}>
+                                            </lightning-input>
+                                        </template>
+                                    </div>
+                                    <div class="slds-col slds-size_1-of-12">
+                                        <lightning-button-icon icon-name="utility:close" alternative-text="Remove condition"
+                                            data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                            onclick={removeCondition}>
+                                        </lightning-button-icon>
+                                    </div>
+                                </div>
+                            </template>
+                            <lightning-button label="Add Condition" icon-name="utility:add" variant="base"
+                                class="slds-m-bottom_x-small" data-rule={rule.ruleIndex} onclick={addCondition}>
+                            </lightning-button>
+                            <lightning-input label="Filter Logic (e.g. (1 AND 2) OR 3 — blank = AND all)"
+                                value={rule.filterLogic} data-rule={rule.ruleIndex} onchange={handleLogicChange}>
+                            </lightning-input>
+                            <div class="slds-grid slds-gutters slds-m-top_x-small">
+                                <div class="slds-col slds-size_1-of-2">
+                                    <lightning-combobox label="Tie-Break Field" value={rule.tieBreakField}
+                                        placeholder="Select Field" options={fieldOptions}
+                                        data-rule={rule.ruleIndex} onchange={handleTieBreakFieldChange}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_1-of-2">
+                                    <lightning-combobox label="Tie-Break Direction" value={rule.tieBreakDirection}
+                                        options={directionOptions} data-rule={rule.ruleIndex}
+                                        onchange={handleTieBreakDirectionChange}>
+                                    </lightning-combobox>
+                                </div>
+                            </div>
+                        </template>
+
+                        <!-- field pairs: source -> target -->
+                        <p class="slds-text-title_caps slds-m-top_small slds-m-bottom_x-small">Field Mappings (source &rarr; target)</p>
+                        <template for:each={rule.fieldPairs} for:item="pair">
+                            <div key={pair.uiKey} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
+                                <div class="slds-col slds-size_5-of-12">
+                                    <lightning-combobox label="Source Field" value={pair.sourceField} options={fieldOptions}
+                                        data-rule={pair.ruleIndex} data-pair={pair.pairIndex} onchange={handlePairSourceChange}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_5-of-12">
+                                    <lightning-combobox label="Target Field" value={pair.targetField} options={fieldOptions}
+                                        data-rule={pair.ruleIndex} data-pair={pair.pairIndex} onchange={handlePairTargetChange}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_2-of-12">
+                                    <lightning-button-icon icon-name="utility:close" alternative-text="Remove mapping"
+                                        data-rule={pair.ruleIndex} data-pair={pair.pairIndex} onclick={removePair}>
+                                    </lightning-button-icon>
+                                </div>
+                            </div>
+                        </template>
+                        <lightning-button label="Add Field Mapping" icon-name="utility:add" variant="base"
+                            data-rule={rule.ruleIndex} onclick={addPair}>
+                        </lightning-button>
+                    </div>
+                </template>
+
+                <div class="slds-grid slds-gutters slds-m-vertical_small">
+                    <lightning-button label="Add Rule" icon-name="utility:add" onclick={addRule} class="slds-m-right_x-small"></lightning-button>
+                    <lightning-button label="Save" variant="brand" onclick={handleSave}></lightning-button>
+                </div>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/fallbackRules/fallbackRules.js
+++ b/force-app/main/default/lwc/fallbackRules/fallbackRules.js
@@ -1,0 +1,305 @@
+import { LightningElement, track, wire } from 'lwc';
+import { subscribe, onError } from 'lightning/empApi';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getFallbackRules from '@salesforce/apex/MRG_FallbackRules_CTRL.getFallbackRules';
+import getObjectFields from '@salesforce/apex/MRG_FallbackRules_CTRL.getObjectFields';
+import getOperators from '@salesforce/apex/MRG_FallbackRules_CTRL.getOperators';
+import saveFallbackRules from '@salesforce/apex/MRG_FallbackRules_CTRL.saveFallbackRules';
+
+export default class FallbackRules extends LightningElement {
+    @track objectType = '';
+    @track rules = [];
+    @track fieldOptions = [];
+    @track operatorOptions = [];
+    fieldTypeByName = {};
+
+    objectOptions = [
+        { label: 'Select an Object', value: '' },
+        { label: 'Account', value: 'Account' },
+        { label: 'Contact', value: 'Contact' }
+    ];
+    selectionOptions = [
+        { label: 'Simple (by record age)', value: 'simple' },
+        { label: 'Complex (conditions + tie-break)', value: 'complex' }
+    ];
+    ruleOptions = [
+        { label: 'Newest record', value: 'Newest' },
+        { label: 'Oldest record', value: 'Oldest' }
+    ];
+    directionOptions = [
+        { label: 'Descending', value: 'DESC' },
+        { label: 'Ascending', value: 'ASC' }
+    ];
+
+    channelName = '/event/MergeRecordSave__e';
+    notificationTitle;
+    notificationBody;
+    notificationStyle;
+
+    connectedCallback() {
+        this.registerErrorListener();
+        this.handleSubscribe();
+    }
+
+    @wire(getOperators)
+    wiredOperators({ data }) {
+        if (data) {
+            this.operatorOptions = data;
+        }
+    }
+
+    get hasObject() {
+        return this.objectType !== '' && this.objectType != null;
+    }
+
+    handleObjectChange(event) {
+        this.objectType = event.detail.value;
+        this.rules = [];
+        if (this.hasObject) {
+            this.loadFields();
+            this.loadRules();
+        }
+    }
+
+    loadFields() {
+        getObjectFields({ objectType: this.objectType })
+            .then((result) => {
+                this.fieldOptions = result.map((f) => ({ label: f.label, value: f.name }));
+                const map = {};
+                result.forEach((f) => { map[f.name] = f.type; });
+                this.fieldTypeByName = map;
+                this.rules = this.decorate(this.rules);
+            })
+            .catch((error) => this.handleError(error));
+    }
+
+    loadRules() {
+        getFallbackRules({ objectType: this.objectType })
+            .then((result) => {
+                this.rules = this.decorate(JSON.parse(JSON.stringify(result)));
+            })
+            .catch((error) => this.handleError(error));
+    }
+
+    decorate(rules) {
+        return (rules || []).map((rule, ri) => {
+            rule.uiKey = 'fb-' + ri + '-' + Date.now();
+            rule.ruleIndex = ri;
+            rule.isComplex = rule.selectionType === 'complex';
+            rule.conditions = (rule.conditions || []).map((c, ci) => this.decorateCondition(c, ri, ci));
+            rule.fieldPairs = (rule.fieldPairs || []).map((p, pi) => {
+                p.ruleIndex = ri;
+                p.pairIndex = pi;
+                p.uiKey = 'pair-' + ri + '-' + pi;
+                return p;
+            });
+            return rule;
+        });
+    }
+
+    decorateCondition(condition, ri, ci) {
+        condition.uiKey = 'cond-' + ri + '-' + ci;
+        condition.ruleIndex = ri;
+        condition.conditionIndex = ci;
+        const type = this.fieldTypeByName[condition.fieldName];
+        condition.inputType = this.inputTypeForFieldType(type);
+        condition.isCheckbox = condition.inputType === 'checkbox';
+        condition.checked = condition.isCheckbox && condition.value === 'true';
+        return condition;
+    }
+
+    inputTypeForFieldType(fieldType) {
+        switch (fieldType) {
+            case 'BOOLEAN': return 'checkbox';
+            case 'DATE': return 'date';
+            case 'DATETIME': return 'datetime';
+            case 'DOUBLE':
+            case 'CURRENCY':
+            case 'INTEGER':
+            case 'LONG':
+            case 'PERCENT': return 'number';
+            default: return 'text';
+        }
+    }
+
+    addRule() {
+        const rule = {
+            id: null,
+            label: this.objectType + ' Fallback ' + (this.rules.length + 1),
+            objectName: this.objectType,
+            selectionType: 'simple',
+            rule: 'Newest',
+            filterLogic: '',
+            conditions: [],
+            tieBreakField: null,
+            tieBreakDirection: 'DESC',
+            fieldPairs: []
+        };
+        this.rules = this.decorate([...this.rules, rule]);
+    }
+
+    removeRule(event) {
+        const idx = parseInt(event.target.dataset.rule, 10);
+        const rules = [...this.rules];
+        rules.splice(idx, 1);
+        this.rules = this.decorate(rules);
+    }
+
+    handleLabelChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].label = event.target.value;
+    }
+
+    handleSelectionTypeChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        this.rules[ri].selectionType = event.detail.value;
+        this.rules = this.decorate(this.rules);
+    }
+
+    handleSimpleRuleChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].rule = event.detail.value;
+    }
+
+    handleLogicChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].filterLogic = event.target.value;
+    }
+
+    handleTieBreakFieldChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].tieBreakField = event.detail.value;
+    }
+
+    handleTieBreakDirectionChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].tieBreakDirection = event.detail.value;
+    }
+
+    // --- conditions ---
+    addCondition(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions = [...rules[ri].conditions, { fieldName: '', operator: 'equals', value: '' }];
+        this.rules = this.decorate(rules);
+    }
+
+    removeCondition(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions.splice(ci, 1);
+        this.rules = this.decorate(rules);
+    }
+
+    handleConditionFieldChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions[ci].fieldName = event.detail.value;
+        this.rules = this.decorate(rules);
+    }
+
+    handleConditionOperatorChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        this.rules[ri].conditions[ci].operator = event.detail.value;
+    }
+
+    handleConditionValueChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const cond = this.rules[ri].conditions[ci];
+        cond.value = cond.isCheckbox ? String(event.target.checked) : event.target.value;
+    }
+
+    // --- field pairs ---
+    addPair(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const rules = [...this.rules];
+        rules[ri].fieldPairs = [...rules[ri].fieldPairs, { sourceField: '', targetField: '' }];
+        this.rules = this.decorate(rules);
+    }
+
+    removePair(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const pi = parseInt(event.target.dataset.pair, 10);
+        const rules = [...this.rules];
+        rules[ri].fieldPairs.splice(pi, 1);
+        this.rules = this.decorate(rules);
+    }
+
+    handlePairSourceChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const pi = parseInt(event.target.dataset.pair, 10);
+        this.rules[ri].fieldPairs[pi].sourceField = event.detail.value;
+    }
+
+    handlePairTargetChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const pi = parseInt(event.target.dataset.pair, 10);
+        this.rules[ri].fieldPairs[pi].targetField = event.detail.value;
+    }
+
+    handleSave() {
+        const payload = this.rules.map((rule) => ({
+            id: rule.id,
+            label: rule.label,
+            objectName: rule.objectName,
+            selectionType: rule.selectionType,
+            rule: rule.rule,
+            filterLogic: rule.filterLogic,
+            conditions: (rule.conditions || []).map((c) => ({ fieldName: c.fieldName, operator: c.operator, value: c.value })),
+            tieBreakField: rule.tieBreakField,
+            tieBreakDirection: rule.tieBreakDirection,
+            fieldPairs: (rule.fieldPairs || []).map((p) => ({ sourceField: p.sourceField, targetField: p.targetField }))
+        }));
+        saveFallbackRules({ jsonData: JSON.stringify(payload) })
+            .then(() => {})
+            .catch((error) => this.handleError(error));
+    }
+
+    // --- platform event + notifications ---
+    handleSubscribe() {
+        const messageCallback = (response) => {
+            if (response && response.data && response.data.payload &&
+                response.data.payload.IsSuccess__c === true) {
+                this.handleSuccess();
+            }
+        };
+        subscribe(this.channelName, -1, messageCallback).then((response) => {
+            this.subscription = response;
+        });
+    }
+
+    registerErrorListener() {
+        onError((error) => this.handleError(error));
+    }
+
+    handleSuccess() {
+        this.notificationTitle = 'Fallback Rules Saved';
+        this.notificationStyle = 'success';
+        this.notificationBody = '';
+        this.showNotification();
+        if (this.hasObject) {
+            this.loadRules();
+        }
+    }
+
+    handleError(error) {
+        this.notificationTitle = 'An error has occurred';
+        this.notificationStyle = 'error';
+        this.notificationBody = 'Unknown error';
+        if (error && error.body) {
+            if (Array.isArray(error.body)) {
+                this.notificationBody = error.body.map((e) => e.message).join(', ');
+            } else if (typeof error.body.message === 'string') {
+                this.notificationBody = error.body.message;
+            }
+        }
+        this.showNotification();
+    }
+
+    showNotification() {
+        this.dispatchEvent(new ShowToastEvent({
+            title: this.notificationTitle,
+            message: this.notificationBody,
+            variant: this.notificationStyle
+        }));
+    }
+}

--- a/force-app/main/default/lwc/fallbackRules/fallbackRules.js-meta.xml
+++ b/force-app/main/default/lwc/fallbackRules/fallbackRules.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/mergeMain/mergeMain.html
+++ b/force-app/main/default/lwc/mergeMain/mergeMain.html
@@ -13,6 +13,9 @@
             <lightning-tab label="Keep Record Rules">
                 <c-keep-record-rules></c-keep-record-rules>
             </lightning-tab>
+            <lightning-tab label="Fallback Rules">
+                <c-fallback-rules></c-fallback-rules>
+            </lightning-tab>
             <lightning-tab label="Global Settings">
                 <c-merge-settings></c-merge-settings>
             </lightning-tab>


### PR DESCRIPTION
Final slice of #34 — the admin UI. Builds on merged 34a/b/c.

## What's here
- **`MRG_FallbackRules_CTRL`** (+ test): `getFallbackRules(objectType)`, `getObjectFields`, `getOperators`, `saveFallbackRules` (validates each complex rule's filter logic via `MRG_FilterLogic.validate`; bad logic → `AuraHandledException`).
- **`fallbackRules` LWC**: object filter + rule cards. Each rule:
  - **Selection type** toggle — *simple* (Newest/Oldest) or *complex* (condition builder + filter logic + tie-break field/direction, reusing the type-aware inputs from the other tabs)
  - **Field mappings** — a list of source → target field pairs (all routed from the same winning record)
- New **"Fallback Rules"** tab in `mergeMain` (between Keep Record Rules and Global Settings).

## Watch on deploy
- `lightning-input type="datetime"` (LWC-valid).
- Open the tab → pick Contact → Add Rule → toggle simple/complex, add a condition (confirm value input type changes by field), add a source→target mapping, save; reopen to confirm round-trip.

With this merged, **#34 is feature-complete end to end** (engine → persistence → merge integration → UI).

## Holding merge
Please deploy + open the tab to confirm it renders and saves.