### PR TITLE
fix: group-wide passes evaluate original (pre-merge) values (#34)

### DIFF
--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -767,6 +767,12 @@ public with sharing class MRG_Merge_SVC {
 
 		List<MergeFieldHistory__c> mergeRecords = new List<MergeFieldHistory__c>();
 		Map<Id, SObject> updateRecordMap = new Map<Id, SObject>();
+		// snapshot the kept records' ORIGINAL field values before the pairwise loop mutates them, so the
+		// group-wide passes (Complex/Fallback) evaluate conditions against pre-merge values rather than
+		// values the pairwise loop may have already changed (e.g. a default boolean preserve).
+		Map<Id, SObject> keptOriginalById = new Map<Id, SObject>();
+		for(Id keepId:keptRecordMap.keyset())
+			keptOriginalById.put(keepId, keptRecordMap.get(keepId).clone(true, false, false, false));
 		for(Sobject obj:mergedRecords) {
 			String mergedRecordId = (String) obj.get('Id'); 
 			String masterRecordId = keepIdMap.containsKey(Id.valueOf(mergedRecordId)) ? keepIdMap.get(Id.valueOf(mergedRecordId)) : null;
@@ -875,7 +881,11 @@ public with sharing class MRG_Merge_SVC {
 				if(!keptRecordMap.containsKey(keepId))
 					continue;
 				SObject keptRec = keptRecordMap.get(keepId);
-				List<SObject> recordGroup = new List<SObject>{ keptRec };
+				// evaluate winner/conditions against the ORIGINAL kept values (+ unmutated merged
+				// records), not the keptRec the pairwise loop may have already changed; writes still
+				// target the live keptRec.
+				SObject keptOriginal = keptOriginalById.containsKey(keepId) ? keptOriginalById.get(keepId) : keptRec;
+				List<SObject> recordGroup = new List<SObject>{ keptOriginal };
 				if(mergedByKeepId.containsKey(keepId))
 					recordGroup.addAll(mergedByKeepId.get(keepId));
 				Boolean groupChange = false;


### PR DESCRIPTION
Fixes the failing `MRG_FallbackMerge_TEST.testFallbackRoutesLostEmailToTargetField` (full-suite run: 115/116, this was the 1 failure).

## Root cause
The pairwise merge loop mutates `keptRec` in place. The default **boolean-preserve** rule flipped the kept contact's `HasOptedOutOfEmail` from `false`→`true` *before* the group-wide Complex/Fallback passes ran. A fallback condition `HasOptedOutOfEmail = true` then matched the kept record too → the winner resolved to **keep**, and keep's own `Email` was routed to the target (`keep@test.com` instead of `lost@test.com`).

## Fix
Snapshot each kept record's original field values (`clone`) before the pairwise loop; the group-wide passes evaluate winner/conditions against that snapshot plus the unmutated merged records. Writes still target the live `keptRec`. Complex fields are already excluded from the pairwise loop, so this only changes evaluation inputs, not write behavior.

## Verified
Deployed to gsgDEV; the fallback + complex merge/engine classes run 11/11. Running the full suite before merge.