### PR TITLE
feat: account-merge service from a contact merge candidate (#35)

### DIFF
--- a/force-app/main/default/classes/MRG_AccountMerge_SVC.cls
+++ b/force-app/main/default/classes/MRG_AccountMerge_SVC.cls
@@ -1,0 +1,125 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description Service for #35: from a Contact merge candidate, merge the contacts' associated
+* Accounts (the contacts themselves survive) instead of merging the contacts.
+*
+* The surviving Account is chosen by the keep-record rules (#32) applied to the associated Accounts,
+* falling back to the lowest sorted Id when no rule yields a unique winner. The actual merge reuses
+* the existing Account merge machinery by constructing a synthetic Account MergeCandidate and running
+* it through MRG_Merge_SVC.processMergesFromBatch.
+*/
+public with sharing class MRG_AccountMerge_SVC {
+
+	public static final String STATUS_ACCOUNTS_MERGED = 'Accounts Merged';
+
+	/*******************************************************************************************************
+	* @description the distinct AccountIds referenced by a contact merge candidate's contacts
+	* @param candidate the contact merge candidate
+	* @return List<Id> account ids (order: keep contact's account first when present)
+	*/
+	public static List<Id> getAccountIds(MergeCandidate__c candidate) {
+		List<Id> contactIds = new List<Id>();
+		if(String.isNotBlank(candidate.KeepRecordId__c)) contactIds.add((Id) candidate.KeepRecordId__c);
+		if(String.isNotBlank(candidate.MergeRecordId__c)) contactIds.add((Id) candidate.MergeRecordId__c);
+		if(String.isNotBlank(candidate.Merge2RecordId__c)) contactIds.add((Id) candidate.Merge2RecordId__c);
+
+		Map<Id, Id> accountByContact = new Map<Id, Id>();
+		for(Contact c:[SELECT Id, AccountId FROM Contact WHERE Id IN :contactIds]) {
+			if(c.AccountId != null)
+				accountByContact.put(c.Id, c.AccountId);
+		}
+		// preserve contact order, de-duplicate accounts
+		List<Id> accountIds = new List<Id>();
+		Set<Id> seen = new Set<Id>();
+		for(Id contactId:contactIds) {
+			Id acctId = accountByContact.get(contactId);
+			if(acctId != null && !seen.contains(acctId)) {
+				accountIds.add(acctId);
+				seen.add(acctId);
+			}
+		}
+		return accountIds;
+	}
+
+	/*******************************************************************************************************
+	* @description chooses the surviving Account id from a set of account ids: keep-record rules first,
+	* then the lowest sorted id as a default
+	* @param accountIds the candidate accounts
+	* @return Id the surviving account id, or null when fewer than two distinct accounts
+	*/
+	public static Id selectKeepAccountId(List<Id> accountIds) {
+		if(accountIds == null || accountIds.size() < 2)
+			return null;
+		List<MRG_KeepRecordRule> rules = MRG_KeepRecordRule.getRules('Account');
+		if(!rules.isEmpty()) {
+			Set<String> fields = new Set<String>{'Id'};
+			for(MRG_KeepRecordRule rule:rules)
+				fields.addAll(rule.referencedFields());
+			Set<Id> ids = new Set<Id>(accountIds);
+			List<SObject> accounts = Database.query(
+				'SELECT ' + String.join(new List<String>(fields), ',') + ' FROM Account WHERE Id IN :ids');
+			Id ruleKeep = MRG_KeepRecordRule.selectKeepId(rules, accounts);
+			if(ruleKeep != null)
+				return ruleKeep;
+		}
+		// default: lowest sorted id
+		List<String> sorted = new List<String>();
+		for(Id a:accountIds) sorted.add(String.valueOf(a));
+		sorted.sort();
+		return (Id) sorted[0];
+	}
+
+	/*******************************************************************************************************
+	* @description builds an Account MergeCandidate from a list of account ids, with keepId first, so the
+	* existing Account merge machinery can process it. Populates the required KeepName__c from the keep
+	* Account's Name. Not inserted here.
+	* @param accountIds the accounts (keepId chosen by selectKeepAccountId)
+	* @param keepAccountId the surviving account id
+	* @return MergeCandidate__c an Account candidate
+	*/
+	public static MergeCandidate__c buildAccountCandidate(List<Id> accountIds, Id keepAccountId) {
+		List<Id> ordered = new List<Id>{ keepAccountId };
+		for(Id a:accountIds) {
+			if(a != keepAccountId)
+				ordered.add(a);
+		}
+		Map<Id, Account> accountsById = new Map<Id, Account>([SELECT Id, Name FROM Account WHERE Id IN :accountIds]);
+		MergeCandidate__c accountCandidate = new MergeCandidate__c(
+			KeepRecordId__c = ordered[0],
+			KeepName__c = accountsById.containsKey(keepAccountId) ? accountsById.get(keepAccountId).Name : 'Account',
+			MergeRecordId__c = ordered.size() > 1 ? ordered[1] : null,
+			MergeName__c = ordered.size() > 1 && accountsById.containsKey(ordered[1]) ? accountsById.get(ordered[1]).Name : null,
+			Merge2RecordId__c = ordered.size() > 2 ? ordered[2] : null,
+			Merge2Name__c = ordered.size() > 2 && accountsById.containsKey(ordered[2]) ? accountsById.get(ordered[2]).Name : null,
+			Object__c = 'Account',
+			Rule__c = 'Contact Account Merge',
+			Status__c = 'New'
+		);
+		return accountCandidate;
+	}
+
+	/*******************************************************************************************************
+	* @description merges the Accounts associated with a contact merge candidate's contacts. The contacts
+	* are left unmerged; the candidate is marked STATUS_ACCOUNTS_MERGED. Returns the surviving account id,
+	* or null when there is nothing to merge (fewer than two distinct accounts).
+	* @param candidate the contact merge candidate
+	* @return Id the surviving account id, or null
+	*/
+	public static Id mergeAccounts(MergeCandidate__c candidate) {
+		List<Id> accountIds = getAccountIds(candidate);
+		Id keepAccountId = selectKeepAccountId(accountIds);
+		if(keepAccountId == null)
+			return null;
+		MergeCandidate__c accountCandidate = buildAccountCandidate(accountIds, keepAccountId);
+		// insert a real Account candidate so the merge is auditable and the existing machinery can
+		// map/update it by Id, then reuse the full Account merge (preserve/complex/fallback/history)
+		insert accountCandidate;
+		MRG_Merge_SVC.processMergesFromBatch(new List<MergeCandidate__c>{ accountCandidate }, 'Account');
+		// mark the originating contact candidate; contacts are intentionally not merged
+		candidate.Status__c = STATUS_ACCOUNTS_MERGED;
+		candidate.MergeProcessDate__c = Date.today();
+		update candidate;
+		return keepAccountId;
+	}
+}

--- a/force-app/main/default/classes/MRG_AccountMerge_SVC.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AccountMerge_SVC.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_AccountMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_AccountMerge_TEST.cls
@@ -1,0 +1,108 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for #35: merging the Accounts behind a Contact merge candidate (contacts survive)
+*/
+@isTest
+private class MRG_AccountMerge_TEST {
+
+	static testMethod void testMergeAccountsKeepsContactsMergesAccounts() {
+		List<Account> accts = MRG_TestFactory.accounts(2);
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', AccountId=accts[0].Id),
+			new Contact(FirstName='B', LastName='B', AccountId=accts[1].Id)
+		};
+		insert cons;
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>();
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		MergeCandidate__c candidate = MRG_TestFactory.mergeCandidate(cons[0].Id, cons[1].Id, 'Contact');
+
+		Test.startTest();
+		Id keepAccountId = MRG_AccountMerge_SVC.mergeAccounts(candidate);
+		Test.stopTest();
+
+		system.assertNotEquals(null, keepAccountId, 'an account should survive');
+
+		// both contacts survive (account merge, not contact merge)
+		system.assertEquals(2, [SELECT count() FROM Contact WHERE Id IN (:cons[0].Id, :cons[1].Id) AND IsDeleted=false],
+			'both contacts should survive');
+
+		// exactly one account survives; the other is merged into it
+		system.assertEquals(1, [SELECT count() FROM Account WHERE Id=:keepAccountId AND IsDeleted=false],
+			'kept account survives');
+		Id otherAccountId = keepAccountId == accts[0].Id ? accts[1].Id : accts[0].Id;
+		Account loser = [SELECT IsDeleted, MasterRecordId FROM Account WHERE Id=:otherAccountId ALL ROWS];
+		system.assertEquals(true, loser.IsDeleted, 'the other account is merged/deleted');
+		system.assertEquals(keepAccountId, loser.MasterRecordId, 'loser points at the surviving account');
+
+		// the originating contact candidate is marked Accounts Merged
+		MergeCandidate__c reloaded = [SELECT Status__c, MergeProcessDate__c FROM MergeCandidate__c WHERE Id=:candidate.Id];
+		system.assertEquals(MRG_AccountMerge_SVC.STATUS_ACCOUNTS_MERGED, reloaded.Status__c);
+		system.assertEquals(Date.today(), reloaded.MergeProcessDate__c);
+	}
+
+	static testMethod void testKeepRecordRulesChooseSurvivingAccount() {
+		// a keep-record rule on Account picks the survivor regardless of id order
+		List<Account> accts = new List<Account>{
+			new Account(Name='Keeper', Type='Customer - Direct'),
+			new Account(Name='Other', Type='Prospect')
+		};
+		insert accts;
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', AccountId=accts[0].Id),
+			new Contact(FirstName='B', LastName='B', AccountId=accts[1].Id)
+		};
+		insert cons;
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>();
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		MRG_KeepRecordRule rule = new MRG_KeepRecordRule();
+		rule.objectName = 'Account';
+		rule.order = 1;
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			new MRG_KeepRecordRule.condition('Type','equals','Customer - Direct')
+		};
+		MRG_KeepRecordRule.keepRecordRules = new List<MRG_KeepRecordRule>{ rule };
+
+		MergeCandidate__c candidate = MRG_TestFactory.mergeCandidate(cons[0].Id, cons[1].Id, 'Contact');
+
+		Test.startTest();
+		Id keepAccountId = MRG_AccountMerge_SVC.mergeAccounts(candidate);
+		Test.stopTest();
+
+		system.assertEquals(accts[0].Id, keepAccountId, 'the keep-record rule should select the Customer account');
+	}
+
+	static testMethod void testSingleAccountNothingToMerge() {
+		// both contacts on the SAME account -> fewer than two distinct accounts -> no merge
+		List<Account> accts = MRG_TestFactory.accounts(1);
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', AccountId=accts[0].Id),
+			new Contact(FirstName='B', LastName='B', AccountId=accts[0].Id)
+		};
+		insert cons;
+		MergeCandidate__c candidate = MRG_TestFactory.mergeCandidate(cons[0].Id, cons[1].Id, 'Contact');
+
+		Test.startTest();
+		Id keepAccountId = MRG_AccountMerge_SVC.mergeAccounts(candidate);
+		Test.stopTest();
+
+		system.assertEquals(null, keepAccountId, 'nothing to merge when there is only one distinct account');
+		// candidate status unchanged
+		system.assertEquals('New', [SELECT Status__c FROM MergeCandidate__c WHERE Id=:candidate.Id].Status__c);
+	}
+
+	static testMethod void testGetAccountIdsDeduplicatesAndOrders() {
+		List<Account> accts = MRG_TestFactory.accounts(2);
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', AccountId=accts[0].Id),
+			new Contact(FirstName='B', LastName='B', AccountId=accts[1].Id)
+		};
+		insert cons;
+		MergeCandidate__c candidate = MRG_TestFactory.mergeCandidate(cons[0].Id, cons[1].Id, 'Contact');
+		List<Id> accountIds = MRG_AccountMerge_SVC.getAccountIds(candidate);
+		system.assertEquals(2, accountIds.size());
+		system.assertEquals(accts[0].Id, accountIds[0], 'keep contact account first');
+	}
+}

--- a/force-app/main/default/classes/MRG_AccountMerge_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AccountMerge_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
First slice of #35. Deployed to gsgDEV; `MRG_AccountMerge_TEST` 4/4.

## What it does
`MRG_AccountMerge_SVC.mergeAccounts(contactCandidate)` merges the Accounts behind a Contact merge candidate **instead of** the contacts — the contacts survive and end up on one account.

- resolves the candidate contacts' distinct `AccountId`s (keep contact's account first)
- picks the surviving Account via the **keep-record rules (#32)**, defaulting to lowest sorted id
- inserts a **real Account `MergeCandidate__c`** (auditable; required `KeepName__c` populated) and runs it through the existing Account merge machinery (preserve / complex / fallback / history)
- marks the originating contact candidate **`Accounts Merged`**; contacts are left unmerged
- returns null (no-op) when there are fewer than two distinct accounts

## Why insert a real candidate
Per discussion: `processMergesFromBatch` maps/updates candidates by Id, so a synthetic uninserted candidate breaks it. Inserting a real Account candidate is also audit-friendly (the account merge shows in the list).

## Tests
accounts merge while both contacts survive; keep-record rule selects the survivor; single-account no-op; account-id dedup/order.

## Next slices
- 35b: `MergeCandidate__c` fields (`AutoMergeAccounts__c`, status value) + `AutoMergeAccountsRule__mdt` + load/save
- 35c: scan flag + account-merge auto pass + manual entry point
- 35d: UI (Merge Accounts action + Auto-Merge Accounts Rules tab)