### PR TITLE
fix: rule selectors use readable (not updateable) fields

### DIFF
--- a/force-app/main/default/classes/MRG_Duplicate_SVC.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_SVC.cls
@@ -140,9 +140,33 @@ public with sharing class MRG_Duplicate_SVC {
 	* @return String the soql Query
 	********************************************************************************************************/ 
     public static String getMergeSOQLQuery(String objectType) {
-        String soqlQuery = 'SELECT Id, CreatedDate, ';
-        soqlQuery+=getFieldSOQLQuery(objectType);
-        soqlQuery+=' FROM '+objectType;
+        return getMergeSOQLQuery(objectType, null);
+    }
+	/*******************************************************************************************************
+	* @description gets the merge SOQL query, additionally selecting any extra (readable) fields that
+	* rules reference but that aren't updateable (e.g. CreatedDate, formulas), so rule conditions and
+	* tie-breaks can read them
+	* @param objectType
+	* @param extraFields readable field api names to also select (may be null/empty)
+	* @return String the soql query
+	********************************************************************************************************/
+    public static String getMergeSOQLQuery(String objectType, Set<String> extraFields) {
+        Set<String> fields = new Set<String>();
+        for(String f:getFieldSOQLQuery(objectType).split(',')) {
+            if(String.isNotBlank(f)) fields.add(f.trim().toLowerCase());
+        }
+        if(extraFields != null) {
+            for(String f:extraFields) {
+                if(String.isNotBlank(f)) fields.add(f.trim().toLowerCase());
+            }
+        }
+        // Id and CreatedDate are always present; remove to avoid duplicates then prepend
+        fields.remove('id');
+        fields.remove('createddate');
+        String soqlQuery = 'SELECT Id, CreatedDate';
+        if(!fields.isEmpty())
+            soqlQuery += ', ' + String.join(new List<String>(fields), ',');
+        soqlQuery += ' FROM '+objectType;
         return soqlQuery;
     }
 

--- a/force-app/main/default/classes/MRG_KeepRecordRules_CTRL.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRules_CTRL.cls
@@ -26,7 +26,9 @@ public with sharing class MRG_KeepRecordRules_CTRL {
 	*/
 	@auraEnabled(cacheable=true)
 	public static List<MRG_Merge_SVC.objectField> getObjectFields(String objectType) {
-		return MRG_MergeSettings_CTRL.getObjectFields(objectType);
+		// keep-record conditions only READ values to choose a record, so offer all readable fields
+		// (incl. CreatedDate / LastModifiedDate / formulas), not just updateable ones
+		return MRG_MergeSettings_CTRL.getReadableObjectFields(objectType);
 	}
 
 	/*******************************************************************************************************

--- a/force-app/main/default/classes/MRG_MergeSettings_CTRL.cls
+++ b/force-app/main/default/classes/MRG_MergeSettings_CTRL.cls
@@ -203,14 +203,36 @@ public with sharing class MRG_MergeSettings_CTRL {
 	*/
 	@auraEnabled(cacheable=true)
 	public static List<MRG_Merge_SVC.objectField> getObjectFields(String objectType) {
+		return getObjectFields(objectType, false);
+	}
+	/*******************************************************************************************************
+	* @description gets readable (accessible) fields for a specific object, including read-only fields
+	* such as CreatedDate / LastModifiedDate / formulas. Use for rule SELECTORS (conditions, tie-breaks)
+	* that only read values to choose a record; use getObjectFields for targets that get written.
+	* @param objectType the type of object
+	* @return List<MRG_Merge_SVC.objectField>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_Merge_SVC.objectField> getReadableObjectFields(String objectType) {
+		return getObjectFields(objectType, true);
+	}
+	/*******************************************************************************************************
+	* @description gets fields for an object, optionally including read-only (accessible-but-not-
+	* updateable) fields
+	* @param objectType the type of object
+	* @param includeReadOnly when true, require only accessibility (not updateability)
+	* @return List<MRG_Merge_SVC.objectField>
+	*/
+	public static List<MRG_Merge_SVC.objectField> getObjectFields(String objectType, Boolean includeReadOnly) {
 		List<MRG_Merge_SVC.objectField> fields = new List<MRG_Merge_SVC.objectField>();
 		if(String.isBlank(objectType))
 			return fields;
 		SObjectType objType = Schema.getGlobalDescribe().get(objectType);
 		for(SObjectfield objField : objType.getDescribe().fields.getMap().values()) {
-			if(objField.getDescribe().isAccessible() 
-			&& objField.getDescribe().isUpdateable()
-			&& !ignoreFields.contains(objField.getDescribe().getName().toLowerCase())) {
+			Schema.DescribeFieldResult dfr = objField.getDescribe();
+			if(dfr.isAccessible()
+			&& (includeReadOnly || dfr.isUpdateable())
+			&& !ignoreFields.contains(dfr.getName().toLowerCase())) {
 				fields.add(new MRG_Merge_SVC.objectField(objField));
 			}
 		}

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -335,7 +335,12 @@ public with sharing class MRG_Merge_SVC {
 	public static mergeHistoryResult getMergeHistoryResult(List<MergeCandidate__c> records,String objectType){
 		Map<Id, Set<Id>> mergeKeyMap = MRG_Duplicate_SVC.getMergeKeyMap(records);
 		Set<Id> allIds = MRG_Duplicate_SVC.getAllIds(mergeKeyMap);
-		String soqlQuery = MRG_Duplicate_SVC.getMergeSOQLQuery(objectType);
+		// include readable fields the complex rules reference (conditions, tie-breaks) so those rules
+		// can read values that aren't updateable (e.g. CreatedDate, formulas)
+		Set<String> extraFields = new Set<String>();
+		for(MRG_ComplexPreserveRule rule:getComplexPreserveRules(objectType))
+			extraFields.addAll(rule.referencedFields());
+		String soqlQuery = MRG_Duplicate_SVC.getMergeSOQLQuery(objectType, extraFields);
 		soqlQuery+=' WHERE Id in:allIds';
 		Map<Id, SObject> objMap = new Map<Id, SObject>(Database.query(soqlQuery));
 		Map<Id, Map<String, Object>> manualOverrides = getManualOverridesByKeepId(records);

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
@@ -1,6 +1,7 @@
 import { LightningElement, api, track, wire } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getObjectFields from '@salesforce/apex/MRG_MergeSettings_CTRL.getObjectFields';
+import getReadableObjectFields from '@salesforce/apex/MRG_MergeSettings_CTRL.getReadableObjectFields';
 
 export default class mergeSingleRecord extends LightningElement {
     @api set record(value) {
@@ -54,15 +55,10 @@ export default class mergeSingleRecord extends LightningElement {
         value = value === undefined || value == null ? [] : value;
         var options = [];
         var relatedFieldOptions = [];
-        var allOptions = [];
-        var typeMap = {};
         value.forEach(fieldResult=>{
-
                 var option = {};
                 option.label = fieldResult.label;
                 option.value = fieldResult.name;
-                allOptions.push(option);
-                typeMap[fieldResult.name] = fieldResult.type;
             if(!this.usedFields.includes(fieldResult.name)) {
                 options.push(option);
             } else {
@@ -71,10 +67,6 @@ export default class mergeSingleRecord extends LightningElement {
         })
         this.fieldOptions = options;
         this.relatedFieldOptions = relatedFieldOptions;
-        // complex rules can reference any field (conditions + tie-break), not just unused ones
-        this.allFieldOptions = allOptions;
-        this.fieldTypeByName = typeMap;
-        this.refreshConditionInputTypes();
     }
     get fieldResults(){
         return this.fieldOptions;
@@ -131,13 +123,31 @@ export default class mergeSingleRecord extends LightningElement {
     
     @wire(getObjectFields, {objectType:'$objectType'})
         getRowData({error,data}) {
-            console.log('wire');
                 if(data) {
                     this.fieldOptions = undefined;
                     this.fieldResults = JSON.parse(JSON.stringify(data));
                     this.error=undefined;
                 } else if(error){
                     this.fieldResults=undefined;
+                    this.error=error;
+                    this.handleError();
+                }
+    }
+    // readable fields (incl. read-only like CreatedDate) for the complex condition + tie-break pickers,
+    // which only READ values to select a record
+    @wire(getReadableObjectFields, {objectType:'$objectType'})
+        getReadableRowData({error,data}) {
+                if(data) {
+                    var allOptions = [];
+                    var typeMap = {};
+                    data.forEach(f=>{
+                        allOptions.push({ label: f.label, value: f.name });
+                        typeMap[f.name] = f.type;
+                    });
+                    this.allFieldOptions = allOptions;
+                    this.fieldTypeByName = typeMap;
+                    this.refreshConditionInputTypes();
+                } else if(error){
                     this.error=error;
                     this.handleError();
                 }


### PR DESCRIPTION
Rule **selectors** (keep-record conditions, complex conditions/tie-breaks) only *read* values to choose a record — they shouldn't be limited to updateable fields. The prior picker filtered to `isAccessible() && isUpdateable()`, wrongly excluding read-only fields like `CreatedDate`, `LastModifiedDate`, and formulas.

## Changes
- `MRG_MergeSettings_CTRL.getReadableObjectFields(objectType)` (accessible-only) + a `getObjectFields(objectType, includeReadOnly)` overload.
- Keep Record Rules controller → readable fields.
- `mergeSingleRecord` complex **condition + tie-break** pickers → readable (via a new `getReadableObjectFields` wire); the preserve **target** picker stays updateable.
- `getMergeSOQLQuery(objectType, extraFields)` additionally selects the readable fields complex rules reference; `getMergeHistoryResult` gathers them — so conditions/tie-breaks can read non-updateable values at merge time.

## Verified
Deployed to gsgDEV; 58/58 across keep-record, complex, preservation, merge-execution, settings, duplicate, and fallback-merge classes.

## Note
This is a focused correctness fix. The fallback selectors get the same treatment in the upcoming fallback refactor (re-homing fallback into Track/Preserve field settings).