### PR TITLE
feat: auto-merge-accounts rule model + metadata (#35)

### DIFF
--- a/force-app/main/default/classes/MRG_AutoMergeAccountsRule.cls
+++ b/force-app/main/default/classes/MRG_AutoMergeAccountsRule.cls
@@ -1,0 +1,169 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description model + group-level evaluation for an auto-merge-accounts rule (#35).
+*
+* Evaluated against the set of records in a merge candidate (e.g. the contacts in a Contact merge
+* candidate) to decide whether, on the auto pass, their associated Accounts should be merged instead
+* of merging the contacts. Conditions use a cross-record aggregator so rules can express things like
+* "Email values differ" or "all records have HasOptedOutOfEmail = false", combined with report-style
+* filter logic.
+*/
+public with sharing class MRG_AutoMergeAccountsRule {
+
+	@auraEnabled public String id;
+	@auraEnabled public String label;
+	@auraEnabled public String objectName;
+	@auraEnabled public String filterLogic;
+	@auraEnabled public Boolean autoMerge;     // when true, the auto pass merges accounts for matches
+	@auraEnabled public List<MRG_KeepRecordRule.condition> conditions;
+
+	public MRG_AutoMergeAccountsRule() {
+		this.conditions = new List<MRG_KeepRecordRule.condition>();
+		this.autoMerge = false;
+	}
+
+	public MRG_AutoMergeAccountsRule(AutoMergeAccountsRule__mdt setting) {
+		this.id = setting.Id;
+		this.label = setting.Label;
+		this.objectName = setting.Object__r != null ? setting.Object__r.QualifiedAPIName : null;
+		this.filterLogic = setting.FilterLogic__c;
+		this.autoMerge = setting.AutoMerge__c;
+		this.conditions = String.isNotBlank(setting.Conditions__c)
+			? (List<MRG_KeepRecordRule.condition>) JSON.deserialize(setting.Conditions__c, List<MRG_KeepRecordRule.condition>.class)
+			: new List<MRG_KeepRecordRule.condition>();
+	}
+
+	/*******************************************************************************************************
+	* @description the fields this rule reads, so the caller can ensure they are queried
+	* @return Set<String>
+	*/
+	public Set<String> referencedFields() {
+		Set<String> fields = new Set<String>();
+		if(conditions != null) {
+			for(MRG_KeepRecordRule.condition c:conditions) {
+				if(String.isNotBlank(c.fieldName))
+					fields.add(c.fieldName);
+			}
+		}
+		return fields;
+	}
+
+	/*******************************************************************************************************
+	* @description whether the candidate's records satisfy this rule. Each condition is reduced across
+	* the records by its aggregator (all/any/differ/same; default all), then combined by filter logic.
+	* @param records the candidate's records (e.g. the contacts in a merge candidate)
+	* @return Boolean
+	*/
+	public Boolean matches(List<SObject> records) {
+		if(conditions == null || conditions.isEmpty() || records == null || records.isEmpty())
+			return false;
+		Map<Integer, Boolean> results = new Map<Integer, Boolean>();
+		Integer i = 1;
+		for(MRG_KeepRecordRule.condition c:conditions) {
+			results.put(i, evaluateAggregate(c, records));
+			i++;
+		}
+		return MRG_FilterLogic.evaluate(filterLogic, results);
+	}
+
+	/*******************************************************************************************************
+	* @description reduces a single condition across the records using its aggregator
+	*/
+	private Boolean evaluateAggregate(MRG_KeepRecordRule.condition c, List<SObject> records) {
+		String agg = String.isBlank(c.aggregator) ? 'all' : c.aggregator.toLowerCase();
+		if(agg == 'differ' || agg == 'same') {
+			Set<String> distinct = new Set<String>();
+			for(SObject record:records) {
+				Object v = record.get(c.fieldName);
+				distinct.add(v == null ? '' : String.valueOf(v));
+			}
+			Boolean allSame = distinct.size() <= 1;
+			return agg == 'same' ? allSame : !allSame;
+		}
+		// all / any: per-record condition evaluation
+		Boolean anyTrue = false;
+		Boolean allTrue = true;
+		for(SObject record:records) {
+			Boolean r = c.evaluate(record);
+			anyTrue = anyTrue || r;
+			allTrue = allTrue && r;
+		}
+		return agg == 'any' ? anyTrue : allTrue;
+	}
+
+	/*******************************************************************************************************
+	* @description all configured auto-merge-accounts rules, lazily queried from custom metadata
+	*/
+	public static List<MRG_AutoMergeAccountsRule> autoMergeAccountsRules {
+		get {
+			if(autoMergeAccountsRules == null) {
+				List<MRG_AutoMergeAccountsRule> rules = new List<MRG_AutoMergeAccountsRule>();
+				for(AutoMergeAccountsRule__mdt setting:[
+					SELECT Id, Label, QualifiedAPIName, Object__c, Object__r.QualifiedAPIName,
+						FilterLogic__c, AutoMerge__c, Conditions__c
+					FROM AutoMergeAccountsRule__mdt
+				]) {
+					rules.add(new MRG_AutoMergeAccountsRule(setting));
+				}
+				autoMergeAccountsRules = rules;
+			}
+			return autoMergeAccountsRules;
+		}
+		set;
+	}
+
+	/*******************************************************************************************************
+	* @description the rules for a single object
+	* @param objectType the SObject api name (the candidate's object, e.g. Contact)
+	* @return List<MRG_AutoMergeAccountsRule>
+	*/
+	public static List<MRG_AutoMergeAccountsRule> getRules(String objectType) {
+		List<MRG_AutoMergeAccountsRule> rules = new List<MRG_AutoMergeAccountsRule>();
+		for(MRG_AutoMergeAccountsRule rule:autoMergeAccountsRules) {
+			if(String.isNotBlank(rule.objectName) && rule.objectName.equalsIgnoreCase(objectType))
+				rules.add(rule);
+		}
+		return rules;
+	}
+
+	/*******************************************************************************************************
+	* @description saves a list of rules via the Metadata API
+	* @param rules the rules to save
+	* @return String the metadata deploy job id
+	*/
+	public static String saveRules(List<MRG_AutoMergeAccountsRule> rules) {
+		MRG_Metadata_SVC mdService = new MRG_Metadata_SVC();
+		List<Metadata.CustomMetadata> mdRecords = new List<Metadata.CustomMetadata>();
+		for(MRG_AutoMergeAccountsRule rule:rules) {
+			mdRecords.add(mdService.getMetaDataRecord(toSetting(rule)));
+		}
+		return mdService.deployMetadataRecords(mdRecords);
+	}
+
+	/*******************************************************************************************************
+	* @description converts a rule wrapper into an AutoMergeAccountsRule__mdt with the read-only
+	* Object__r relationship injected and conditions serialized
+	* @param rule the rule wrapper
+	* @return AutoMergeAccountsRule__mdt
+	*/
+	public static AutoMergeAccountsRule__mdt toSetting(MRG_AutoMergeAccountsRule rule) {
+		AutoMergeAccountsRule__mdt setting = new AutoMergeAccountsRule__mdt(
+			Label = String.isNotBlank(rule.label) ? rule.label : (rule.objectName + ' Auto Merge Accounts'),
+			FilterLogic__c = rule.filterLogic,
+			AutoMerge__c = rule.autoMerge == true,
+			Conditions__c = rule.conditions != null && !rule.conditions.isEmpty() ? JSON.serialize(rule.conditions) : null
+		);
+		String devName = (rule.objectName == null ? 'Obj' : rule.objectName.replace('__','').replace('_','')) + 'AutoMergeAccounts'
+			+ (String.isNotBlank(rule.label) ? rule.label.replaceAll('[^a-zA-Z0-9]','') : '');
+		setting.QualifiedAPIName = devName;
+		Map<String, Object> settingJSON = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(setting));
+		settingJSON.put('Object__r', new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' },
+			'QualifiedAPIName' => rule.objectName
+		});
+		if(String.isNotBlank(rule.id))
+			settingJSON.put('Id', rule.id);
+		return (AutoMergeAccountsRule__mdt) JSON.deserialize(JSON.serialize(settingJSON), AutoMergeAccountsRule__mdt.class);
+	}
+}

--- a/force-app/main/default/classes/MRG_AutoMergeAccountsRule.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AutoMergeAccountsRule.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_AutoMergeAccountsRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_AutoMergeAccountsRule_TEST.cls
@@ -1,0 +1,147 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for the auto-merge-accounts rule model: cross-record aggregator evaluation and
+* load/save
+*/
+@isTest
+private class MRG_AutoMergeAccountsRule_TEST {
+
+	private static MRG_KeepRecordRule.condition cond(String field, String op, String val, String agg) {
+		MRG_KeepRecordRule.condition c = new MRG_KeepRecordRule.condition(field, op, val);
+		c.aggregator = agg;
+		return c;
+	}
+
+	private static List<Contact> twoContacts(String emailA, Boolean optA, String emailB, Boolean optB) {
+		return new List<Contact>{
+			new Contact(LastName='A', Email=emailA, HasOptedOutOfEmail=optA),
+			new Contact(LastName='B', Email=emailB, HasOptedOutOfEmail=optB)
+		};
+	}
+
+	static testMethod void testAggregatorAll() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','false','all') };
+		// all not opted out -> matches
+		system.assert(rule.matches(twoContacts('a@x.com', false, 'b@x.com', false)), 'all=false satisfies');
+		// one opted out -> all fails
+		system.assert(!rule.matches(twoContacts('a@x.com', false, 'b@x.com', true)), 'one true breaks all=false');
+	}
+
+	static testMethod void testAggregatorAny() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true','any') };
+		system.assert(rule.matches(twoContacts('a@x.com', false, 'b@x.com', true)), 'any opted out satisfies');
+		system.assert(!rule.matches(twoContacts('a@x.com', false, 'b@x.com', false)), 'none opted out -> any fails');
+	}
+
+	static testMethod void testAggregatorDiffer() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('Email', null, null, 'differ') };
+		system.assert(rule.matches(twoContacts('a@x.com', false, 'b@x.com', false)), 'different emails -> differ true');
+		system.assert(!rule.matches(twoContacts('same@x.com', false, 'same@x.com', false)), 'same emails -> differ false');
+	}
+
+	static testMethod void testAggregatorSame() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('Email', null, null, 'same') };
+		system.assert(rule.matches(twoContacts('same@x.com', false, 'same@x.com', false)), 'same emails -> same true');
+		system.assert(!rule.matches(twoContacts('a@x.com', false, 'b@x.com', false)), 'different emails -> same false');
+	}
+
+	static testMethod void testTicketExample() {
+		// emails differ AND both not opted out
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.filterLogic = '1 AND 2';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			cond('Email', null, null, 'differ'),
+			cond('HasOptedOutOfEmail','equals','false','all')
+		};
+		system.assert(rule.matches(twoContacts('a@x.com', false, 'b@x.com', false)), 'emails differ + both not opted out');
+		system.assert(!rule.matches(twoContacts('a@x.com', false, 'b@x.com', true)), 'one opted out fails');
+		system.assert(!rule.matches(twoContacts('same@x.com', false, 'same@x.com', false)), 'same email fails');
+	}
+
+	static testMethod void testDefaultAggregatorIsAll() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.filterLogic = '1';
+		// no aggregator -> defaults to all
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','false', null) };
+		system.assert(rule.matches(twoContacts('a@x.com', false, 'b@x.com', false)));
+		system.assert(!rule.matches(twoContacts('a@x.com', false, 'b@x.com', true)));
+	}
+
+	static testMethod void testReferencedFields() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			cond('Email', null, null, 'differ'),
+			cond('HasOptedOutOfEmail','equals','false','all')
+		};
+		Set<String> f = rule.referencedFields();
+		system.assert(f.contains('Email') && f.contains('HasOptedOutOfEmail'));
+	}
+
+	// ---- persistence ----
+
+	private static AutoMergeAccountsRule__mdt buildSetting(String objectName, Boolean autoMerge, String conditionsJson) {
+		AutoMergeAccountsRule__mdt s = new AutoMergeAccountsRule__mdt();
+		Map<String, Object> m = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(s));
+		m.put(AutoMergeAccountsRule__mdt.Label.getDescribe().getName(), objectName+' ama');
+		m.put(AutoMergeAccountsRule__mdt.DeveloperName.getDescribe().getName(), objectName+'Ama');
+		m.put(AutoMergeAccountsRule__mdt.FilterLogic__c.getDescribe().getName(), '1 AND 2');
+		m.put(AutoMergeAccountsRule__mdt.AutoMerge__c.getDescribe().getName(), autoMerge);
+		m.put(AutoMergeAccountsRule__mdt.Conditions__c.getDescribe().getName(), conditionsJson);
+		m.put('Object__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' }, 'QualifiedAPIName' => objectName });
+		return (AutoMergeAccountsRule__mdt) JSON.deserialize(JSON.serialize(m), AutoMergeAccountsRule__mdt.class);
+	}
+
+	static testMethod void testConstructorAndGetRules() {
+		String condJson = JSON.serialize(new List<MRG_KeepRecordRule.condition>{
+			cond('Email', null, null, 'differ')
+		});
+		MRG_AutoMergeAccountsRule.autoMergeAccountsRules = new List<MRG_AutoMergeAccountsRule>{
+			new MRG_AutoMergeAccountsRule(buildSetting('Contact', true, condJson)),
+			new MRG_AutoMergeAccountsRule(buildSetting('Account', false, null))
+		};
+		List<MRG_AutoMergeAccountsRule> contactRules = MRG_AutoMergeAccountsRule.getRules('Contact');
+		system.assertEquals(1, contactRules.size());
+		system.assertEquals(true, contactRules[0].autoMerge);
+		system.assertEquals(1, contactRules[0].conditions.size());
+		system.assertEquals('differ', contactRules[0].conditions[0].aggregator);
+		system.assertEquals(0, MRG_AutoMergeAccountsRule.getRules('Lead').size());
+	}
+
+	static testMethod void testToSettingRoundTrip() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.objectName = 'Contact';
+		rule.label = 'Diff Email';
+		rule.autoMerge = true;
+		rule.filterLogic = '1 AND 2';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			cond('Email', null, null, 'differ'),
+			cond('HasOptedOutOfEmail','equals','false','all')
+		};
+		AutoMergeAccountsRule__mdt setting = MRG_AutoMergeAccountsRule.toSetting(rule);
+		system.assertEquals('Contact', setting.Object__r.QualifiedAPIName);
+		system.assertEquals(true, setting.AutoMerge__c);
+		system.assert(setting.Conditions__c.contains('differ'));
+		MRG_AutoMergeAccountsRule rt = new MRG_AutoMergeAccountsRule(setting);
+		system.assertEquals(2, rt.conditions.size());
+	}
+
+	static testMethod void testSaveRules() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.objectName = 'Contact';
+		rule.label = 'R1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('Email', null, null, 'differ') };
+		Test.startTest();
+		String jobId = MRG_AutoMergeAccountsRule.saveRules(new List<MRG_AutoMergeAccountsRule>{ rule });
+		Test.stopTest();
+		system.assertEquals('Test Job Id', jobId);
+	}
+}

--- a/force-app/main/default/classes/MRG_AutoMergeAccountsRule_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AutoMergeAccountsRule_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_KeepRecordRule.cls
+++ b/force-app/main/default/classes/MRG_KeepRecordRule.cls
@@ -85,6 +85,8 @@ public with sharing class MRG_KeepRecordRule implements Comparable {
 		@auraEnabled public String fieldName;
 		@auraEnabled public String operator;   // equals, notEquals, lessThan, lessOrEqual, greaterThan, greaterOrEqual, contains, startsWith, endsWith
 		@auraEnabled public String value;      // raw string value; typed via the record's field type
+		@auraEnabled public String aggregator; // optional cross-record aggregator (all/any/differ/same)
+		                                       // used by group-level rules; ignored by single-record use
 
 		public condition() {}
 

--- a/force-app/main/default/classes/MRG_Metadata_SVC.cls
+++ b/force-app/main/default/classes/MRG_Metadata_SVC.cls
@@ -112,6 +112,32 @@ public with sharing class MRG_Metadata_SVC {
 	* @param keepRuleSetting the keep-record rule setting to save
 	* @return the Job Id of the deployment job
 	*/
+	public Metadata.CustomMetadata getMetaDataRecord(AutoMergeAccountsRule__mdt amaSetting) {
+		Metadata.CustomMetadata mdRecord = new Metadata.CustomMetadata();
+		List<String> mdRecordNames = new List<String>();
+		Map<String, Object> fieldKeyValues = new Map<String, Object>();
+		fieldKeyValues.put('Object__c', amaSetting.Object__r.QualifiedAPIName);
+		fieldKeyValues.put('FilterLogic__c', amaSetting.FilterLogic__c);
+		fieldKeyValues.put('AutoMerge__c', amaSetting.AutoMerge__c);
+		fieldKeyValues.put('Conditions__c', amaSetting.Conditions__c);
+		String qualifiedName = !amaSetting.QualifiedAPIName.contains('.') ? 'AutoMergeAccountsRule__mdt.'+amaSetting.QualifiedAPIName : amaSetting.QualifiedAPIName;
+		mdRecordNames.add(qualifiedName);
+
+		List<Metadata.Metadata> metadataRecords = getMetadataRecords(mdRecordNames);
+		if(metadataRecords.size()>0) {
+			mdRecord = (Metadata.CustomMetadata) metadataRecords.get(0).clone();
+		} else {
+			mdRecord.fullName = qualifiedName;
+		}
+		mdRecord.Label = amaSetting.Label;
+		mdRecord = updateMetadataObjectFields(mdRecord, fieldKeyValues);
+		return mdRecord;
+	}
+	/*******************************************************************************************************
+	* @description saves an integration process via metadata deployment
+	* @param keepRuleSetting the keep-record rule setting to save
+	* @return the Job Id of the deployment job
+	*/
 	public Metadata.CustomMetadata getMetaDataRecord(KeepRecordRuleSettings__mdt keepRuleSetting) {
 		   	// create metadata container
 		Metadata.CustomMetadata mdRecord = new Metadata.CustomMetadata();

--- a/force-app/main/default/objects/AutoMergeAccountsRule__mdt/AutoMergeAccountsRule__mdt.object-meta.xml
+++ b/force-app/main/default/objects/AutoMergeAccountsRule__mdt/AutoMergeAccountsRule__mdt.object-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Auto Merge Accounts Rule</label>
+    <pluralLabel>Auto Merge Accounts Rules</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/AutoMerge__c.field-meta.xml
+++ b/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/AutoMerge__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AutoMerge__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <inlineHelpText>When checked, matching candidates have their associated Accounts merged automatically by the auto pass. When unchecked, the candidate is flagged but left for manual action.</inlineHelpText>
+    <label>Auto Merge</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/Conditions__c.field-meta.xml
+++ b/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/Conditions__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Conditions__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>JSON array of conditions (field, operator, value, aggregator). The aggregator reduces a condition across the candidate's records: all / any / differ / same. Maintained by the Auto-Merge Accounts Rules UI.</inlineHelpText>
+    <label>Conditions</label>
+    <required>false</required>
+    <type>LongTextArea</type>
+    <length>131072</length>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/FilterLogic__c.field-meta.xml
+++ b/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/FilterLogic__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FilterLogic__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Report-style logic combining the numbered conditions, e.g. (1 AND 2) OR 3. Leave blank to AND all conditions.</inlineHelpText>
+    <label>Filter Logic</label>
+    <required>false</required>
+    <type>Text</type>
+    <length>255</length>
+</CustomField>

--- a/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/Object__c.field-meta.xml
+++ b/force-app/main/default/objects/AutoMergeAccountsRule__mdt/fields/Object__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Object__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Object</label>
+    <referenceTo>EntityDefinition</referenceTo>
+    <relationshipLabel>AutoMergeAccountsRules</relationshipLabel>
+    <relationshipName>AutoMergeAccountsRules</relationshipName>
+    <required>true</required>
+    <type>MetadataRelationship</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/MergeCandidate__c/fields/AutoMergeAccounts__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeCandidate__c/fields/AutoMergeAccounts__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AutoMergeAccounts__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <inlineHelpText>Set by the scan when an Auto-Merge Accounts rule matches this candidate's records. When true, the auto pass merges the contacts' associated Accounts (the contacts are kept) instead of merging the contacts.</inlineHelpText>
+    <label>Auto Merge Accounts</label>
+    <type>Checkbox</type>
+</CustomField>


### PR DESCRIPTION
Second slice of #35. Configuration for the rules-based account merge. Validated on gsgDEV (10/10).

## Added
- **`MergeCandidate__c.AutoMergeAccounts__c`** — flag set by the scan when a rule matches; the auto pass merges the contacts' Accounts (keeping the contacts) instead of merging the contacts.
- **`AutoMergeAccountsRule__mdt`** — `Object__c`, `FilterLogic__c`, `Conditions__c` (JSON), `AutoMerge__c`.
- **`condition.aggregator`** (optional) — cross-record aggregator: `all` / `any` / `differ` / `same`. Lets a rule express the ticket examples ("Email values differ", "all not opted out") which compare the candidate's records to each other.
- **`MRG_AutoMergeAccountsRule`** — `matches(records)` reduces each condition across the candidate's records by its aggregator, then combines via filter logic; lazily-queried `autoMergeAccountsRules`, `getRules(objectType)`, `toSetting`, `saveRules`.
- `MRG_Metadata_SVC` deploy overload.

## Tests (10/10)
aggregator all/any/differ/same, the ticket example (emails differ AND both not opted out), default-aggregator-is-all, referencedFields, constructor+getRules filter, toSetting round-trip, save.

## Next
- 35c: scan-time flag evaluation + account-merge auto pass + manual entry
- 35d: UI (Merge Accounts action + Auto-Merge Accounts Rules tab)