### PR TITLE
feat: account-merge scan flag + auto batch + manual entry (#35)

### DIFF
--- a/force-app/main/default/classes/MRG_AccountMergeFlow_TEST.cls
+++ b/force-app/main/default/classes/MRG_AccountMergeFlow_TEST.cls
@@ -1,0 +1,107 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for #35c: scan-time flagging, the account-merge auto batch, and the manual
+* controller entry point
+*/
+@isTest
+private class MRG_AccountMergeFlow_TEST {
+
+	private static MRG_KeepRecordRule.condition cond(String field, String op, String val, String agg) {
+		MRG_KeepRecordRule.condition c = new MRG_KeepRecordRule.condition(field, op, val);
+		c.aggregator = agg;
+		return c;
+	}
+
+	// rule: emails differ AND both not opted out, autoMerge = true
+	private static void registerAutoRule(Boolean autoMerge) {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.objectName = 'Contact';
+		rule.autoMerge = autoMerge;
+		rule.filterLogic = '1 AND 2';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{
+			cond('Email', null, null, 'differ'),
+			cond('HasOptedOutOfEmail','equals','false','all')
+		};
+		MRG_AutoMergeAccountsRule.autoMergeAccountsRules = new List<MRG_AutoMergeAccountsRule>{ rule };
+	}
+
+	private static MergeCandidate__c setupTwoContactsOnTwoAccounts(String emailA, Boolean optA, String emailB, Boolean optB) {
+		List<Account> accts = MRG_TestFactory.accounts(2);
+		List<Contact> cons = new List<Contact>{
+			new Contact(FirstName='A', LastName='A', AccountId=accts[0].Id, Email=emailA, HasOptedOutOfEmail=optA),
+			new Contact(FirstName='B', LastName='B', AccountId=accts[1].Id, Email=emailB, HasOptedOutOfEmail=optB)
+		};
+		insert cons;
+		return MRG_TestFactory.mergeCandidate(cons[0].Id, cons[1].Id, 'Contact');
+	}
+
+	static testMethod void testFlagSetWhenRuleMatches() {
+		registerAutoRule(true);
+		MergeCandidate__c mc = setupTwoContactsOnTwoAccounts('a@x.com', false, 'b@x.com', false);
+		List<MergeCandidate__c> candidates = new List<MergeCandidate__c>{ mc };
+
+		Test.startTest();
+		MRG_AccountMerge_SVC.flagAutoMergeAccounts(candidates, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals(true, candidates[0].AutoMergeAccounts__c, 'matching candidate should be flagged');
+	}
+
+	static testMethod void testFlagNotSetWhenRuleDoesNotMatch() {
+		registerAutoRule(true);
+		// same email -> 'differ' fails
+		MergeCandidate__c mc = setupTwoContactsOnTwoAccounts('same@x.com', false, 'same@x.com', false);
+		List<MergeCandidate__c> candidates = new List<MergeCandidate__c>{ mc };
+
+		MRG_AccountMerge_SVC.flagAutoMergeAccounts(candidates, 'Contact');
+		system.assertNotEquals(true, candidates[0].AutoMergeAccounts__c, 'non-matching candidate not flagged');
+	}
+
+	static testMethod void testFlagNotSetWhenRuleIsManualOnly() {
+		registerAutoRule(false); // autoMerge = false
+		MergeCandidate__c mc = setupTwoContactsOnTwoAccounts('a@x.com', false, 'b@x.com', false);
+		List<MergeCandidate__c> candidates = new List<MergeCandidate__c>{ mc };
+
+		MRG_AccountMerge_SVC.flagAutoMergeAccounts(candidates, 'Contact');
+		system.assertNotEquals(true, candidates[0].AutoMergeAccounts__c, 'manual-only rule should not auto-flag');
+	}
+
+	static testMethod void testAutoBatchMergesAccounts() {
+		registerAutoRule(true);
+		MergeCandidate__c mc = setupTwoContactsOnTwoAccounts('a@x.com', false, 'b@x.com', false);
+		// flag it (as the scan would) and persist
+		mc.AutoMergeAccounts__c = true;
+		update mc;
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>();
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		Test.startTest();
+		Database.executeBatch(new MRG_AccountMerge_BATCH());
+		Test.stopTest();
+
+		// one of the two accounts should be merged away
+		system.assertEquals(1, [SELECT count() FROM Account WHERE IsDeleted=true ALL ROWS],
+			'the auto batch should merge one account into the other');
+		// contacts survive
+		system.assertEquals(2, [SELECT count() FROM Contact WHERE IsDeleted=false],
+			'contacts are kept');
+		// candidate marked accounts merged
+		system.assertEquals(MRG_AccountMerge_SVC.STATUS_ACCOUNTS_MERGED,
+			[SELECT Status__c FROM MergeCandidate__c WHERE Id=:mc.Id].Status__c);
+	}
+
+	static testMethod void testManualControllerEntry() {
+		MergeCandidate__c mc = setupTwoContactsOnTwoAccounts('a@x.com', false, 'b@x.com', false);
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>();
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+
+		Test.startTest();
+		String response = MRG_DuplicateMerge_CTRL.mergeAccounts(mc.Id);
+		Test.stopTest();
+
+		system.assertEquals('Accounts merged', response);
+		system.assertEquals(1, [SELECT count() FROM Account WHERE IsDeleted=true ALL ROWS]);
+		system.assertEquals(2, [SELECT count() FROM Contact WHERE IsDeleted=false]);
+	}
+}

--- a/force-app/main/default/classes/MRG_AccountMergeFlow_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AccountMergeFlow_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_AccountMerge_BATCH.cls
+++ b/force-app/main/default/classes/MRG_AccountMerge_BATCH.cls
@@ -1,0 +1,35 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description batch (#35): processes merge candidates flagged AutoMergeAccounts__c by merging the
+* contacts' associated Accounts (the contacts are kept) instead of merging the contacts.
+*/
+public with sharing class MRG_AccountMerge_BATCH implements Database.Batchable<sObject>, Schedulable {
+
+	/*******************************************************************************************************
+	* @description batch start: New, auto-merge-accounts-flagged, not-a-duplicate candidates
+	*/
+	public Database.QueryLocator start(Database.BatchableContext BC) {
+		String soqlQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL();
+		soqlQuery += ' WHERE Status__c=\'New\' AND AutoMergeAccounts__c = true AND NotADuplicate__c = false';
+		return Database.getQueryLocator(soqlQuery);
+	}
+
+	/*******************************************************************************************************
+	* @description batch execute: merge the accounts behind each flagged candidate
+	*/
+	public void execute(Database.BatchableContext BC, List<sObject> scope) {
+		for(MergeCandidate__c candidate:(List<MergeCandidate__c>) scope) {
+			MRG_AccountMerge_SVC.mergeAccounts(candidate);
+		}
+	}
+
+	public void finish(Database.BatchableContext BC) {}
+
+	/*******************************************************************************************************
+	* @description Schedulable execute
+	*/
+	public void execute(SchedulableContext SC) {
+		Database.executeBatch(this, 1);
+	}
+}

--- a/force-app/main/default/classes/MRG_AccountMerge_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AccountMerge_BATCH.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_AccountMerge_SVC.cls
+++ b/force-app/main/default/classes/MRG_AccountMerge_SVC.cls
@@ -14,6 +14,62 @@ public with sharing class MRG_AccountMerge_SVC {
 	public static final String STATUS_ACCOUNTS_MERGED = 'Accounts Merged';
 
 	/*******************************************************************************************************
+	* @description evaluates the auto-merge-accounts rules against each candidate's records and sets
+	* AutoMergeAccounts__c on candidates matched by a rule whose AutoMerge is true. Called at scan time
+	* (does not DML; the caller upserts the candidates). Candidates whose object has no rules are left
+	* untouched.
+	* @param candidates the merge candidates (e.g. Contact candidates)
+	* @param objectType the candidate object api name
+	*/
+	public static void flagAutoMergeAccounts(List<MergeCandidate__c> candidates, String objectType) {
+		List<MRG_AutoMergeAccountsRule> rules = MRG_AutoMergeAccountsRule.getRules(objectType);
+		if(rules.isEmpty() || candidates == null || candidates.isEmpty())
+			return;
+		// gather referenced fields and all candidate record ids
+		Set<String> fields = new Set<String>{'Id'};
+		Boolean anyAuto = false;
+		for(MRG_AutoMergeAccountsRule rule:rules) {
+			fields.addAll(rule.referencedFields());
+			anyAuto = anyAuto || rule.autoMerge == true;
+		}
+		if(!anyAuto)
+			return; // no auto rule could set the flag; manual action remains available
+		Set<Id> recordIds = new Set<Id>();
+		for(MergeCandidate__c c:candidates)
+			recordIds.addAll(candidateRecordIds(c));
+		if(recordIds.isEmpty())
+			return;
+		String soql = 'SELECT ' + String.join(new List<String>(fields), ',') + ' FROM ' + objectType + ' WHERE Id IN :recordIds';
+		Map<Id, SObject> recordsById = new Map<Id, SObject>(Database.query(soql));
+		for(MergeCandidate__c c:candidates) {
+			List<SObject> recordGroup = new List<SObject>();
+			for(Id rid:candidateRecordIds(c)) {
+				if(recordsById.containsKey(rid))
+					recordGroup.add(recordsById.get(rid));
+			}
+			if(recordGroup.size() < 2)
+				continue;
+			for(MRG_AutoMergeAccountsRule rule:rules) {
+				if(rule.autoMerge == true && rule.matches(recordGroup)) {
+					c.AutoMergeAccounts__c = true;
+					break;
+				}
+			}
+		}
+	}
+
+	/*******************************************************************************************************
+	* @description the candidate's record ids (keep/merge/merge2)
+	*/
+	private static List<Id> candidateRecordIds(MergeCandidate__c c) {
+		List<Id> ids = new List<Id>();
+		if(String.isNotBlank(c.KeepRecordId__c)) ids.add((Id) c.KeepRecordId__c);
+		if(String.isNotBlank(c.MergeRecordId__c)) ids.add((Id) c.MergeRecordId__c);
+		if(String.isNotBlank(c.Merge2RecordId__c)) ids.add((Id) c.Merge2RecordId__c);
+		return ids;
+	}
+
+	/*******************************************************************************************************
 	* @description the distinct AccountIds referenced by a contact merge candidate's contacts
 	* @param candidate the contact merge candidate
 	* @return List<Id> account ids (order: keep contact's account first when present)

--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -69,6 +69,23 @@ public with sharing class MRG_DuplicateMerge_CTRL {
     }
 
 	/*******************************************************************************************************
+	* @description merges the Accounts associated with a candidate's contacts (the contacts are kept)
+	* instead of merging the contacts (#35)
+	* @param recordId the merge candidate recordId
+	* @return String response
+	*/
+    @AuraEnabled
+    public static String mergeAccounts(String recordId){
+        String soqlQuery  = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL();
+        soqlQuery+=' WHERE Id=:recordId';
+        List<MergeCandidate__c> mergeCandidates = (List<MergeCandidate__c>) database.query(soqlQuery);
+        if(mergeCandidates.isEmpty())
+            return 'an error occurred';
+        Id keepAccountId = MRG_AccountMerge_SVC.mergeAccounts(mergeCandidates[0]);
+        return keepAccountId != null ? 'Accounts merged' : 'No accounts to merge (records share an account or have none)';
+    }
+
+	/*******************************************************************************************************
 	* @description returns the records for preview
 	* @param recordId recordId to merge
 	* @return String response

--- a/force-app/main/default/classes/MRG_DuplicateScan_BATCH.cls
+++ b/force-app/main/default/classes/MRG_DuplicateScan_BATCH.cls
@@ -51,6 +51,9 @@ public with sharing class MRG_DuplicateScan_BATCH implements Database.Batchable<
 	public void execute(Database.BatchableContext BC, List<sObject> scope) {
         Map<Id, SObject> recordMap = new Map<Id, SObject>(scope);
         List<MergeCandidate__c> mergeCandidates = MRG_Duplicate_SVC.processRecords(recordMap,objectType);
+        // flag candidates whose records match an auto-merge-accounts rule (#35) so the account-merge
+        // pass merges their associated Accounts instead of merging the records
+        MRG_AccountMerge_SVC.flagAutoMergeAccounts(mergeCandidates, objectType);
         if(mergeCandidates.size()>0)
             upsert mergeCandidates KeepRecordId__c;
     }


### PR DESCRIPTION
Third slice of #35. Validated on gsgDEV (5/5).

## Wiring
- **Scan flag** — `MRG_AccountMerge_SVC.flagAutoMergeAccounts` evaluates the auto-merge-accounts rules against each candidate's records and sets `AutoMergeAccounts__c` on candidates matched by an `autoMerge=true` rule. Hooked into `MRG_DuplicateScan_BATCH.execute` before upsert. (Manual-only rules don't auto-flag; the manual action stays available.)
- **Auto batch** — `MRG_AccountMerge_BATCH` queries `New + AutoMergeAccounts__c + not-a-duplicate` candidates and merges each one's accounts (contacts kept).
- **Manual entry** — `MRG_DuplicateMerge_CTRL.mergeAccounts(recordId)` for the UI (35d).

## Tests (5/5)
flag set on match / not on non-match / not for manual-only rules; auto batch merges one account away and keeps both contacts and marks the candidate `Accounts Merged`; manual controller returns 'Accounts merged' and merges.

## Note
Reserved-word fix applied (`group` → `recordGroup`).

## Next
- 35d: UI — a "Merge Accounts" action on a candidate + an Auto-Merge Accounts Rules tab.