### PR TITLE
feat: Auto-Merge Accounts Rules UI + Merge Accounts action (#35)

### DIFF
--- a/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL.cls
+++ b/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL.cls
@@ -1,0 +1,70 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description controller for the Auto-Merge Accounts Rules LWC tab (#35). Loads/saves the rules and
+* provides object fields, operators, and aggregator options for the rule builder.
+*/
+public with sharing class MRG_AutoMergeAccounts_CTRL {
+
+	/*******************************************************************************************************
+	* @description the auto-merge-accounts rules configured for an object
+	* @param objectType the SObject api name
+	* @return List<MRG_AutoMergeAccountsRule>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_AutoMergeAccountsRule> getRules(String objectType) {
+		if(String.isBlank(objectType))
+			return new List<MRG_AutoMergeAccountsRule>();
+		return MRG_AutoMergeAccountsRule.getRules(objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description readable fields for the condition pickers (selectors only read values)
+	* @param objectType the SObject api name
+	* @return List<MRG_Merge_SVC.objectField>
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_Merge_SVC.objectField> getObjectFields(String objectType) {
+		return MRG_MergeSettings_CTRL.getReadableObjectFields(objectType);
+	}
+
+	/*******************************************************************************************************
+	* @description condition operator options
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_KeepRecordRules_CTRL.operatorOption> getOperators() {
+		return MRG_KeepRecordRules_CTRL.getOperators();
+	}
+
+	/*******************************************************************************************************
+	* @description cross-record aggregator options
+	*/
+	@auraEnabled(cacheable=true)
+	public static List<MRG_KeepRecordRules_CTRL.operatorOption> getAggregators() {
+		return new List<MRG_KeepRecordRules_CTRL.operatorOption>{
+			new MRG_KeepRecordRules_CTRL.operatorOption('all', 'all records match'),
+			new MRG_KeepRecordRules_CTRL.operatorOption('any', 'any record matches'),
+			new MRG_KeepRecordRules_CTRL.operatorOption('differ', 'values differ'),
+			new MRG_KeepRecordRules_CTRL.operatorOption('same', 'values are the same')
+		};
+	}
+
+	/*******************************************************************************************************
+	* @description saves the rules supplied as JSON; validates each rule's filter logic before deploying
+	* @param jsonData a JSON array of MRG_AutoMergeAccountsRule
+	* @return String the metadata deploy job id
+	*/
+	@auraEnabled
+	public static String saveRules(String jsonData) {
+		List<MRG_AutoMergeAccountsRule> rules = (List<MRG_AutoMergeAccountsRule>) JSON.deserialize(jsonData, List<MRG_AutoMergeAccountsRule>.class);
+		for(MRG_AutoMergeAccountsRule rule:rules) {
+			Integer count = rule.conditions == null ? 0 : rule.conditions.size();
+			try {
+				MRG_FilterLogic.validate(rule.filterLogic, count);
+			} catch(MRG_FilterLogic.ParseException e) {
+				throw new AuraHandledException('Invalid filter logic for rule "' + rule.label + '": ' + e.getMessage());
+			}
+		}
+		return MRG_AutoMergeAccountsRule.saveRules(rules);
+	}
+}

--- a/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL_TEST.cls
+++ b/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL_TEST.cls
@@ -1,0 +1,60 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for the Auto-Merge Accounts Rules controller
+*/
+@isTest
+private class MRG_AutoMergeAccounts_CTRL_TEST {
+
+	static testMethod void testGetRules() {
+		system.assertEquals(0, MRG_AutoMergeAccounts_CTRL.getRules('').size(), 'blank -> empty');
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.objectName = 'Contact';
+		MRG_AutoMergeAccountsRule.autoMergeAccountsRules = new List<MRG_AutoMergeAccountsRule>{ rule };
+		system.assertEquals(1, MRG_AutoMergeAccounts_CTRL.getRules('Contact').size());
+		system.assertEquals(0, MRG_AutoMergeAccounts_CTRL.getRules('Account').size());
+	}
+
+	static testMethod void testFieldOperatorAggregatorOptions() {
+		system.assert(MRG_AutoMergeAccounts_CTRL.getObjectFields('Contact').size() > 0);
+		system.assertEquals(0, MRG_AutoMergeAccounts_CTRL.getObjectFields('').size());
+		system.assert(MRG_AutoMergeAccounts_CTRL.getOperators().size() >= 9);
+		Set<String> aggs = new Set<String>();
+		for(MRG_KeepRecordRules_CTRL.operatorOption o:MRG_AutoMergeAccounts_CTRL.getAggregators())
+			aggs.add(o.value);
+		system.assert(aggs.containsAll(new Set<String>{'all','any','differ','same'}), 'all aggregators offered');
+	}
+
+	static testMethod void testSaveValid() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.objectName = 'Contact';
+		rule.label = 'r';
+		rule.autoMerge = true;
+		rule.filterLogic = '1 AND 2';
+		MRG_KeepRecordRule.condition c1 = new MRG_KeepRecordRule.condition('Email', null, null);
+		c1.aggregator = 'differ';
+		MRG_KeepRecordRule.condition c2 = new MRG_KeepRecordRule.condition('HasOptedOutOfEmail','equals','false');
+		c2.aggregator = 'all';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ c1, c2 };
+
+		Test.startTest();
+		String jobId = MRG_AutoMergeAccounts_CTRL.saveRules(JSON.serialize(new List<MRG_AutoMergeAccountsRule>{ rule }));
+		Test.stopTest();
+		system.assertEquals('Test Job Id', jobId);
+	}
+
+	static testMethod void testSaveInvalidLogicThrows() {
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.objectName = 'Contact';
+		rule.label = 'bad';
+		rule.filterLogic = '1 AND 9';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ new MRG_KeepRecordRule.condition('Email','equals','x') };
+		Boolean threw = false;
+		try {
+			MRG_AutoMergeAccounts_CTRL.saveRules(JSON.serialize(new List<MRG_AutoMergeAccountsRule>{ rule }));
+		} catch(AuraHandledException e) {
+			threw = true;
+		}
+		system.assert(threw, 'invalid filter logic should throw');
+	}
+}

--- a/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.html
+++ b/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.html
@@ -1,0 +1,99 @@
+<template>
+    <lightning-card title="Auto-Merge Accounts Rules" icon-name="standard:account">
+        <div class="slds-m-horizontal_medium">
+            <p class="slds-m-bottom_small slds-text-color_weak">
+                When a merge candidate's records match a rule, their associated Accounts are merged
+                (the records themselves are kept) instead of merging the records. Conditions are
+                evaluated across the candidate's records using an aggregator (all / any / differ /
+                same). Rules with Auto Merge on are processed automatically; otherwise the candidate is
+                flagged for the manual "Merge Accounts" action.
+            </p>
+
+            <lightning-combobox label="Object" value={objectType} options={objectOptions}
+                onchange={handleObjectChange}>
+            </lightning-combobox>
+
+            <template if:true={hasObject}>
+                <template for:each={rules} for:item="rule">
+                    <div key={rule.uiKey} class="slds-box slds-m-vertical_small">
+                        <div class="slds-grid slds-gutters slds-grid_vertical-align-center slds-m-bottom_x-small">
+                            <div class="slds-col slds-size_6-of-12">
+                                <lightning-input label="Rule Label" value={rule.label}
+                                    data-rule={rule.ruleIndex} onchange={handleLabelChange}>
+                                </lightning-input>
+                            </div>
+                            <div class="slds-col slds-size_4-of-12 slds-align-bottom">
+                                <lightning-input type="checkbox" label="Auto Merge" checked={rule.autoMerge}
+                                    data-rule={rule.ruleIndex} onchange={handleAutoMergeChange}>
+                                </lightning-input>
+                            </div>
+                            <div class="slds-col slds-size_2-of-12 slds-text-align_right">
+                                <lightning-button-icon icon-name="utility:delete" alternative-text="Remove rule"
+                                    title="Remove rule" data-rule={rule.ruleIndex} onclick={removeRule}>
+                                </lightning-button-icon>
+                            </div>
+                        </div>
+
+                        <template for:each={rule.conditions} for:item="condition">
+                            <div key={condition.uiKey} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
+                                <div class="slds-col slds-size_1-of-12 slds-align-middle">{condition.conditionIndex}</div>
+                                <div class="slds-col slds-size_3-of-12">
+                                    <lightning-combobox label="Field" value={condition.fieldName} options={fieldOptions}
+                                        data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                        onchange={handleConditionFieldChange}>
+                                    </lightning-combobox>
+                                </div>
+                                <div class="slds-col slds-size_3-of-12">
+                                    <lightning-combobox label="Aggregator" value={condition.aggregator} options={aggregatorOptions}
+                                        data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                        onchange={handleConditionAggregatorChange}>
+                                    </lightning-combobox>
+                                </div>
+                                <template if:true={condition.usesValue}>
+                                    <div class="slds-col slds-size_2-of-12">
+                                        <lightning-combobox label="Operator" value={condition.operator} options={operatorOptions}
+                                            data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                            onchange={handleConditionOperatorChange}>
+                                        </lightning-combobox>
+                                    </div>
+                                    <div class="slds-col slds-size_2-of-12">
+                                        <template if:true={condition.isCheckbox}>
+                                            <lightning-input type="checkbox" label="Value" checked={condition.checked}
+                                                data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                                onchange={handleConditionValueChange}>
+                                            </lightning-input>
+                                        </template>
+                                        <template if:true={condition.isValueInput}>
+                                            <lightning-input type={condition.inputType} label="Value" value={condition.value}
+                                                data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                                onchange={handleConditionValueChange}>
+                                            </lightning-input>
+                                        </template>
+                                    </div>
+                                </template>
+                                <div class="slds-col slds-size_1-of-12">
+                                    <lightning-button-icon icon-name="utility:close" alternative-text="Remove condition"
+                                        data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
+                                        onclick={removeCondition}>
+                                    </lightning-button-icon>
+                                </div>
+                            </div>
+                        </template>
+
+                        <lightning-button label="Add Condition" icon-name="utility:add" variant="base"
+                            class="slds-m-bottom_x-small" data-rule={rule.ruleIndex} onclick={addCondition}>
+                        </lightning-button>
+                        <lightning-input label="Filter Logic (e.g. (1 AND 2) OR 3 — blank = AND all)"
+                            value={rule.filterLogic} data-rule={rule.ruleIndex} onchange={handleLogicChange}>
+                        </lightning-input>
+                    </div>
+                </template>
+
+                <div class="slds-grid slds-gutters slds-m-vertical_small">
+                    <lightning-button label="Add Rule" icon-name="utility:add" onclick={addRule} class="slds-m-right_x-small"></lightning-button>
+                    <lightning-button label="Save" variant="brand" onclick={handleSave}></lightning-button>
+                </div>
+            </template>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.js
+++ b/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.js
@@ -1,0 +1,252 @@
+import { LightningElement, track, wire } from 'lwc';
+import { subscribe, onError } from 'lightning/empApi';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getRules from '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getRules';
+import getObjectFields from '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getObjectFields';
+import getOperators from '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getOperators';
+import getAggregators from '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getAggregators';
+import saveRules from '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.saveRules';
+
+export default class AutoMergeAccountsRules extends LightningElement {
+    @track objectType = '';
+    @track rules = [];
+    @track fieldOptions = [];
+    @track operatorOptions = [];
+    @track aggregatorOptions = [];
+    fieldTypeByName = {};
+
+    objectOptions = [
+        { label: 'Select an Object', value: '' },
+        { label: 'Account', value: 'Account' },
+        { label: 'Contact', value: 'Contact' }
+    ];
+
+    channelName = '/event/MergeRecordSave__e';
+    notificationTitle;
+    notificationBody;
+    notificationStyle;
+
+    connectedCallback() {
+        this.registerErrorListener();
+        this.handleSubscribe();
+    }
+
+    @wire(getOperators)
+    wiredOperators({ data }) { if (data) { this.operatorOptions = data; } }
+
+    @wire(getAggregators)
+    wiredAggregators({ data }) { if (data) { this.aggregatorOptions = data; } }
+
+    get hasObject() {
+        return this.objectType !== '' && this.objectType != null;
+    }
+
+    handleObjectChange(event) {
+        this.objectType = event.detail.value;
+        this.rules = [];
+        if (this.hasObject) {
+            this.loadFields();
+            this.loadRules();
+        }
+    }
+
+    loadFields() {
+        getObjectFields({ objectType: this.objectType })
+            .then((result) => {
+                this.fieldOptions = result.map((f) => ({ label: f.label, value: f.name }));
+                const map = {};
+                result.forEach((f) => { map[f.name] = f.type; });
+                this.fieldTypeByName = map;
+                this.rules = this.decorate(this.rules);
+            })
+            .catch((error) => this.handleError(error));
+    }
+
+    loadRules() {
+        getRules({ objectType: this.objectType })
+            .then((result) => {
+                this.rules = this.decorate(JSON.parse(JSON.stringify(result)));
+            })
+            .catch((error) => this.handleError(error));
+    }
+
+    decorate(rules) {
+        return (rules || []).map((rule, ri) => {
+            rule.uiKey = 'ama-' + ri + '-' + Date.now();
+            rule.ruleIndex = ri;
+            rule.conditions = (rule.conditions || []).map((c, ci) => this.decorateCondition(c, ri, ci));
+            return rule;
+        });
+    }
+
+    decorateCondition(condition, ri, ci) {
+        condition.uiKey = 'cond-' + ri + '-' + ci;
+        condition.ruleIndex = ri;
+        condition.conditionIndex = ci;
+        condition.aggregator = condition.aggregator || 'all';
+        // value/operator only apply to all/any; differ/same compare the field across records
+        condition.usesValue = condition.aggregator === 'all' || condition.aggregator === 'any';
+        const type = this.fieldTypeByName[condition.fieldName];
+        condition.inputType = this.inputTypeForFieldType(type);
+        condition.isCheckbox = condition.usesValue && condition.inputType === 'checkbox';
+        condition.isValueInput = condition.usesValue && !condition.isCheckbox;
+        condition.checked = condition.isCheckbox && condition.value === 'true';
+        return condition;
+    }
+
+    inputTypeForFieldType(fieldType) {
+        switch (fieldType) {
+            case 'BOOLEAN': return 'checkbox';
+            case 'DATE': return 'date';
+            case 'DATETIME': return 'datetime';
+            case 'DOUBLE':
+            case 'CURRENCY':
+            case 'INTEGER':
+            case 'LONG':
+            case 'PERCENT': return 'number';
+            default: return 'text';
+        }
+    }
+
+    addRule() {
+        const rule = {
+            id: null,
+            label: this.objectType + ' Auto Merge Accounts ' + (this.rules.length + 1),
+            objectName: this.objectType,
+            autoMerge: false,
+            filterLogic: '',
+            conditions: []
+        };
+        this.rules = this.decorate([...this.rules, rule]);
+    }
+
+    removeRule(event) {
+        const idx = parseInt(event.target.dataset.rule, 10);
+        const rules = [...this.rules];
+        rules.splice(idx, 1);
+        this.rules = this.decorate(rules);
+    }
+
+    handleLabelChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].label = event.target.value;
+    }
+
+    handleAutoMergeChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].autoMerge = event.target.checked;
+    }
+
+    handleLogicChange(event) {
+        this.rules[parseInt(event.target.dataset.rule, 10)].filterLogic = event.target.value;
+    }
+
+    addCondition(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions = [...rules[ri].conditions, { fieldName: '', operator: 'equals', value: '', aggregator: 'all' }];
+        this.rules = this.decorate(rules);
+    }
+
+    removeCondition(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions.splice(ci, 1);
+        this.rules = this.decorate(rules);
+    }
+
+    handleConditionFieldChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions[ci].fieldName = event.detail.value;
+        this.rules = this.decorate(rules);
+    }
+
+    handleConditionAggregatorChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const rules = [...this.rules];
+        rules[ri].conditions[ci].aggregator = event.detail.value;
+        this.rules = this.decorate(rules);
+    }
+
+    handleConditionOperatorChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        this.rules[ri].conditions[ci].operator = event.detail.value;
+    }
+
+    handleConditionValueChange(event) {
+        const ri = parseInt(event.target.dataset.rule, 10);
+        const ci = parseInt(event.target.dataset.condition, 10);
+        const cond = this.rules[ri].conditions[ci];
+        cond.value = cond.isCheckbox ? String(event.target.checked) : event.target.value;
+    }
+
+    handleSave() {
+        const payload = this.rules.map((rule) => ({
+            id: rule.id,
+            label: rule.label,
+            objectName: rule.objectName,
+            autoMerge: rule.autoMerge,
+            filterLogic: rule.filterLogic,
+            conditions: (rule.conditions || []).map((c) => ({
+                fieldName: c.fieldName,
+                operator: c.operator,
+                value: c.value,
+                aggregator: c.aggregator
+            }))
+        }));
+        saveRules({ jsonData: JSON.stringify(payload) })
+            .then(() => {})
+            .catch((error) => this.handleError(error));
+    }
+
+    handleSubscribe() {
+        const messageCallback = (response) => {
+            if (response && response.data && response.data.payload &&
+                response.data.payload.IsSuccess__c === true) {
+                this.handleSuccess();
+            }
+        };
+        subscribe(this.channelName, -1, messageCallback).then((response) => {
+            this.subscription = response;
+        });
+    }
+
+    registerErrorListener() {
+        onError((error) => this.handleError(error));
+    }
+
+    handleSuccess() {
+        this.notificationTitle = 'Auto-Merge Accounts Rules Saved';
+        this.notificationStyle = 'success';
+        this.notificationBody = '';
+        this.showNotification();
+        if (this.hasObject) {
+            this.loadRules();
+        }
+    }
+
+    handleError(error) {
+        this.notificationTitle = 'An error has occurred';
+        this.notificationStyle = 'error';
+        this.notificationBody = 'Unknown error';
+        if (error && error.body) {
+            if (Array.isArray(error.body)) {
+                this.notificationBody = error.body.map((e) => e.message).join(', ');
+            } else if (typeof error.body.message === 'string') {
+                this.notificationBody = error.body.message;
+            }
+        }
+        this.showNotification();
+    }
+
+    showNotification() {
+        this.dispatchEvent(new ShowToastEvent({
+            title: this.notificationTitle,
+            message: this.notificationBody,
+            variant: this.notificationStyle
+        }));
+    }
+}

--- a/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.js-meta.xml
+++ b/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/dupeList/dupeList.html
+++ b/force-app/main/default/lwc/dupeList/dupeList.html
@@ -111,7 +111,8 @@
                             
                            <lightning-button variant="neutral" label="Preview" onclick={handlePreview} class="slds-m-right_x-small" data-record={row.id}></lightning-button>
                            <lightning-button variant="destructive" label="Remove" onclick={handleRemove} class="slds-m-right_x-small" data-record={row.id}></lightning-button>
-                           <lightning-button variant="success" label="Merge" onclick={handleMerge} class="slds-m-right_x-small" data-record={row.id}></lightning-button>                     
+                           <lightning-button variant="success" label="Merge" onclick={handleMerge} class="slds-m-right_x-small" data-record={row.id}></lightning-button>
+                           <lightning-button variant="neutral" label="Merge Accounts" onclick={handleMergeAccounts} class="slds-m-right_x-small" data-record={row.id}></lightning-button>
                         </lightning-layout-item>
                     </lightning-layout>
                 </template>

--- a/force-app/main/default/lwc/dupeList/dupeList.js
+++ b/force-app/main/default/lwc/dupeList/dupeList.js
@@ -5,6 +5,7 @@ import getDuplicateRules from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getRules
 import getCount from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getCount';
 import doMergeRecord from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecord';
 import doRemoveRecord from '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecord';
+import doMergeAccounts from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccounts';
 import doPreviewRecord from '@salesforce/apex/MRG_DuplicateMerge_CTRL.previewRecord';
 
 export default class DupeList extends LightningElement {
@@ -215,6 +216,25 @@ export default class DupeList extends LightningElement {
         this.selectedRecordId = event.currentTarget.dataset.record;
         this.mergeRecord();
 
+    }
+    handleMergeAccounts(event){
+        this.showSpinner=true;
+        this.selectedRecordId = event.currentTarget.dataset.record;
+        this.mergeAccounts();
+    }
+    mergeAccounts() {
+        doMergeAccounts({recordId:this.selectedRecordId})
+        .then(response=>{
+            this.removeSelectedRecordFromRows();
+            this.notificationBody = response;
+            this.handleSuccess();
+            this.showSpinner=false;
+        })
+        .catch(error => {
+            this.error = error;
+            this.handleError();
+            this.showSpinner=false;
+        })
     }
     mergeRecord() {
         console.log('merge: '+this.selectedRecordId);

--- a/force-app/main/default/lwc/mergeMain/mergeMain.html
+++ b/force-app/main/default/lwc/mergeMain/mergeMain.html
@@ -13,6 +13,9 @@
             <lightning-tab label="Keep Record Rules">
                 <c-keep-record-rules></c-keep-record-rules>
             </lightning-tab>
+            <lightning-tab label="Auto-Merge Accounts Rules">
+                <c-auto-merge-accounts-rules></c-auto-merge-accounts-rules>
+            </lightning-tab>
             <lightning-tab label="Global Settings">
                 <c-merge-settings></c-merge-settings>
             </lightning-tab>


### PR DESCRIPTION
Final slice of #35. Validated on gsgDEV: controller 4/4; **full suite 125/125**.

## What's here
- **`MRG_AutoMergeAccounts_CTRL`** (+ test): `getRules`, `getObjectFields` (readable), `getOperators`, `getAggregators` (all/any/differ/same), `saveRules` (filter-logic validation).
- **`autoMergeAccountsRules` LWC tab**: object filter + rule cards, each with an **Auto Merge** toggle and an **aggregator-aware** condition builder (operator + value shown only for `all`/`any`; hidden for `differ`/`same`) + filter logic. Added as a new tab in `mergeMain`.
- **`dupeList`**: a **"Merge Accounts"** action per candidate row → `MRG_DuplicateMerge_CTRL.mergeAccounts` (merges the contacts' accounts, keeps the contacts).

With this merged, **#35 is feature-complete end to end** (service → metadata/model → scan flag + auto batch + manual entry → UI).