### PR TITLE
Release 2.0.0 + fix FLS-dependent preservation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ The Merge Control app provides SF Administrators with the following tools relate
 4) a condensed UI where you can see the key differences between records as well as the resulting values post merge
 - admins can control which fields should be hidden from this UI (particularly if you've already defined rules for preservation)
 
+## Installation
+
+Current release: **2.0.0** (unlocked package, `04tKb000000EgyOIAS`)
+
+Install via URL:
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgyOIAS
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgyOIAS
+
+Or with the Salesforce CLI:
+
+```
+sf package install --package 04tKb000000EgyOIAS --target-org <org-alias> --wait 10
+```
+
+After installing, assign the **Merge Control Administrator** permission set to administrators.
+
 ## Documentation
 
 - [Administrator Guide](docs/user-guide.md) — how each functional area works and how to use it

--- a/force-app/main/default/classes/MRG_Preservation_TEST.cls
+++ b/force-app/main/default/classes/MRG_Preservation_TEST.cls
@@ -153,7 +153,10 @@ private class MRG_Preservation_TEST {
 	}
 
 	static testMethod void testContactDefaultBooleanPreserved() {
-		// no setting: a true on the merged record is preserved over false on the kept record
+		// no setting: a true on the merged record is preserved over false on the kept record. The merge
+		// engine derives its field list from FLS-aware isUpdateable(), and HasOptedOutOfEmail defaults to
+		// hidden, so drive the merge as a user explicitly granted FLS on the field (see flsRunner()).
+		User runner = flsRunner();
 		List<Contact> cons = MRG_TestFactory.contacts(2);
 		Id keepId = cons[0].Id;
 		Id mergeId = cons[1].Id;
@@ -165,11 +168,50 @@ private class MRG_Preservation_TEST {
 		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
 
 		Test.startTest();
-		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		System.runAs(runner) {
+			MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		}
 		Test.stopTest();
 
 		system.assertEquals(true, (Boolean) MRG_TestFactory.keptValue(keepId,'Contact','HasOptedOutOfEmail'),
 			'a true boolean on the merged record should be preserved over a false kept value');
+	}
+
+	/*******************************************************************************************************
+	* @description builds a System Administrator user granted FLS read/edit on Contact.HasOptedOutOfEmail
+	* via a permission set, so the merge engine's FLS-aware field list includes the field even in orgs
+	* where it defaults to hidden. Setup-object DML is isolated in a runAs block to avoid
+	* MIXED_DML_OPERATION with the test's Contact DML.
+	* @return User the FLS-granted runner
+	*/
+	private static User flsRunner() {
+		User runner;
+		System.runAs(new User(Id = UserInfo.getUserId())) {
+			Profile p = [SELECT Id FROM Profile WHERE Name = 'System Administrator' LIMIT 1];
+			runner = new User(
+				Alias = 'mrgfls',
+				Email = 'mrgfls@merge.test.example.com',
+				LastName = 'MergeFls',
+				Username = 'mrgfls' + DateTime.now().getTime() + '@merge.test.example.com',
+				EmailEncodingKey = 'UTF-8',
+				LanguageLocaleKey = 'en_US',
+				LocaleSidKey = 'en_US',
+				TimeZoneSidKey = 'America/Los_Angeles',
+				ProfileId = p.Id
+			);
+			insert runner;
+			PermissionSet ps = new PermissionSet(Name = 'MRG_BoolFlsTest', Label = 'MRG Bool FLS Test');
+			insert ps;
+			insert new FieldPermissions(
+				ParentId = ps.Id,
+				SObjectType = 'Contact',
+				Field = 'Contact.HasOptedOutOfEmail',
+				PermissionsRead = true,
+				PermissionsEdit = true
+			);
+			insert new PermissionSetAssignment(AssigneeId = runner.Id, PermissionSetId = ps.Id);
+		}
+		return runner;
 	}
 
 	// ---- Account rules (numeric) --------------------------------------------------------------

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,17 +1,19 @@
 {
-    "packageDirectories": [
-        {
-            "path": "force-app",
-            "default": true,
-            "package": "merge",
-            "versionName": "ver 0.1",
-            "versionNumber": "0.1.0.NEXT"
-        }
-    ],
-    "namespace": "",
-    "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "49.0",
-    "packageAliases": {
-        "merge": "0Ho4W000000TNLiSAO"
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true,
+      "package": "merge",
+      "versionName": "ver 2.0",
+      "versionNumber": "2.0.0.NEXT"
     }
+  ],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "49.0",
+  "packageAliases": {
+    "merge": "0Ho4W000000TNLiSAO",
+    "merge@2.0.0-1": "04tKb000000EgyJIAS",
+    "merge@2.0.0-2": "04tKb000000EgyOIAS"
+  }
 }


### PR DESCRIPTION
## Summary
Builds and releases unlocked package **`merge` 2.0.0.2** (90% coverage, promoted).

- **Test fix:** `MRG_Preservation_TEST.testContactDefaultBooleanPreserved` drove the merge as the running user, whose FLS doesn't include `HasOptedOutOfEmail` in a fresh org. The engine builds its field list from FLS-aware `isUpdateable()`, so the field was dropped and the default boolean-preserve never ran — the test's own DML succeeded in system mode, masking the gap. Now runs the merge as a user explicitly granted FLS on the field (setup DML isolated in a `runAs` block to avoid `MIXED_DML_OPERATION`).
- **Version:** bumped `sfdx-project.json` to `2.0.0` (`ver 2.0` / `2.0.0.NEXT`) + build-generated aliases.

## Released artifact
| | |
|---|---|
| Version | 2.0.0.2 (released) |
| SubscriberPackageVersionId | `04tKb000000EgyOIAS` |
| Coverage | 90% (passed) |

## Verification
All 125 local tests pass at 90% org-wide coverage; package build ran tests in the build org and passed the coverage check before promotion.

## Follow-up (deferred)
A real merge silently skips any field the running user lacks FLS on — possible data loss on the surviving record. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)