### PR TITLE
feat: support external duplicate-candidate provider (2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The Merge Control app provides SF Administrators with the following tools relate
 
 ## Installation
 
-Current release: **2.0.0** (unlocked package, `04tKb000000EgyOIAS`)
+Current release: **2.1.0** (unlocked package, `04tKb000000EgydIAC`)
 
 Install via URL:
-- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgyOIAS
-- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgyOIAS
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgydIAC
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgydIAC
 
 Or with the Salesforce CLI:
 
 ```
-sf package install --package 04tKb000000EgyOIAS --target-org <org-alias> --wait 10
+sf package install --package 04tKb000000EgydIAC --target-org <org-alias> --wait 10
 ```
 
 After installing, assign the **Merge Control Administrator** permission set to administrators.

--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -45,7 +45,7 @@ public with sharing class MRG_DuplicateMerge_CTRL {
 	*/
     @AuraEnabled(cacheable=TRUE)
     public static List<MRG_Duplicate_SVC.dupeRule> getRules(String objectType){
-        return MRG_Duplicate_SVC.getActiveDuplicateRules(objectType);
+        return MRG_Duplicate_SVC.getMergeCandidateRules(objectType);
     }
 	/*******************************************************************************************************
 	* @description Returns the merge fields
@@ -204,7 +204,11 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         @AuraEnabled
         public Boolean autoMerge;
         @AuraEnabled
-        public Datetime createdDate; 
+        public Decimal confidenceScore;
+        @AuraEnabled
+        public String source;
+        @AuraEnabled
+        public Datetime createdDate;
         @AuraEnabled
         public Datetime lastModifiedDate;  
         @AuraEnabled
@@ -251,6 +255,8 @@ public with sharing class MRG_DuplicateMerge_CTRL {
             this.rule = mergeCandidate.Rule__c;
             this.status = mergeCandidate.Status__c;
             this.autoMerge = mergeCandidate.AutoMerge__c;
+            this.confidenceScore = mergeCandidate.ConfidenceScore__c;
+            this.source = mergeCandidate.Source__c;
             this.createdDate = mergeCandidate.CreatedDate;
             this.lastModifiedDate = mergeCandidate.LastModifiedDate;
             this.recordIds = new List<String>();

--- a/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
@@ -72,6 +72,29 @@ private class MRG_DuplicateMerge_TEST {
         test.stopTest();
     }
 
+    static testMethod void testGetRulesIncludesCandidateRules(){
+        // the candidate's Rule__c ('test') maps to no Salesforce duplicate rule (the external-provider
+        // case); it must still appear in the merge-review rule filter
+        List<MRG_Duplicate_SVC.dupeRule> rules = MRG_DuplicateMerge_CTRL.getRules('Contact');
+        Boolean found = false;
+        for(MRG_Duplicate_SVC.dupeRule rule:rules){
+            if(rule.ruleName == 'test')
+                found = true;
+        }
+        system.assert(found, 'a candidate Rule__c value with no Salesforce duplicate rule should appear in the filter');
+    }
+
+    static testMethod void testMergeGroupExposesConfidenceAndSource(){
+        MergeCandidate__c mc = [SELECT Id FROM MergeCandidate__c LIMIT 1];
+        mc.ConfidenceScore__c = 95.50;
+        mc.Source__c = 'External';
+        update mc;
+        List<MRG_DuplicateMerge_CTRL.mergeGroup> groups = MRG_DuplicateMerge_CTRL.getMergeGroups('Contact','test',100,0);
+        system.assertEquals(1, groups.size(), 'the candidate should be returned');
+        system.assertEquals(95.50, groups[0].confidenceScore, 'confidence score should flow through to the wrapper');
+        system.assertEquals('External', groups[0].source, 'source should flow through to the wrapper');
+    }
+
     static testMethod void testBatch(){
 
         test.startTest();

--- a/force-app/main/default/classes/MRG_Duplicate_SVC.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_SVC.cls
@@ -124,10 +124,43 @@ public with sharing class MRG_Duplicate_SVC {
         return dupeRulesByName.values();
     }
 	/*******************************************************************************************************
+	* @description returns the rule values to filter the merge-review list by for an object: the active
+	* Salesforce duplicate rules (internal scan) unioned with any distinct Rule__c values present on
+	* existing candidates. External-provider candidates map to no Salesforce duplicate rule, so without
+	* this union their Rule__c values would be missing from the filter and those candidates unfilterable.
+	* @param objectType the candidate object api name
+	* @return List<dupeRule> rule wrappers (ruleName drives the UI filter)
+	********************************************************************************************************/
+    public static List<dupeRule> getMergeCandidateRules(String objectType){
+        Map<String, dupeRule> rulesByName = new Map<String, dupeRule>();
+        for(dupeRule dr:getActiveDuplicateRules(objectType)){
+            rulesByName.put(dr.ruleName, dr);
+        }
+        for(AggregateResult ar:[
+            SELECT Rule__c ruleName
+            FROM MergeCandidate__c
+            WHERE Object__c =:objectType
+            AND Status__c = 'New'
+            AND NotADuplicate__c = false
+            GROUP BY Rule__c
+        ]){
+            String ruleName = (String) ar.get('ruleName');
+            if(String.isNotBlank(ruleName) && !rulesByName.containsKey(ruleName)){
+                dupeRule dr = new dupeRule();
+                dr.name = ruleName;
+                dr.ruleName = ruleName;
+                dr.objectType = objectType;
+                dr.autoMerge = false;
+                rulesByName.put(ruleName, dr);
+            }
+        }
+        return rulesByName.values();
+    }
+	/*******************************************************************************************************
 	* @description gets the SOQL query for the duplicate scan batch
 	* @param objectType
 	* @return String the soql Query
-	********************************************************************************************************/  
+	********************************************************************************************************/
     public static String getScanSOQLQuery(String objectType) {
         String soqlQuery = 'SELECT Id, Name';
         soqlQuery+=' FROM '+objectType;

--- a/force-app/main/default/lwc/dupeList/dupeList.html
+++ b/force-app/main/default/lwc/dupeList/dupeList.html
@@ -61,6 +61,9 @@
                         Auto Merge?
                     </lightning-layout-item>
                     <lightning-layout-item padding="around-small" size="1">
+                        Confidence
+                    </lightning-layout-item>
+                    <lightning-layout-item padding="around-small" size="1">
                         Actions
                     </lightning-layout-item>
                 </lightning-layout>
@@ -103,12 +106,17 @@
                                                 
                         </lightning-layout-item>
                         <lightning-layout-item padding="around-small" size="1">
-                            
+
                             {row.autoMerge}
-                                                
+
+                        </lightning-layout-item>
+                        <lightning-layout-item padding="around-small" size="1">
+
+                            {row.confidenceScore}
+
                         </lightning-layout-item>
                         <lightning-layout-item padding="around-small" size="2">
-                            
+
                            <lightning-button variant="neutral" label="Preview" onclick={handlePreview} class="slds-m-right_x-small" data-record={row.id}></lightning-button>
                            <lightning-button variant="destructive" label="Remove" onclick={handleRemove} class="slds-m-right_x-small" data-record={row.id}></lightning-button>
                            <lightning-button variant="success" label="Merge" onclick={handleMerge} class="slds-m-right_x-small" data-record={row.id}></lightning-button>

--- a/force-app/main/default/objects/MergeCandidate__c/fields/ConfidenceScore__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeCandidate__c/fields/ConfidenceScore__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ConfidenceScore__c</fullName>
+    <externalId>false</externalId>
+    <label>Confidence Score</label>
+    <precision>4</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/MergeCandidate__c/fields/Source__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeCandidate__c/fields/Source__c.field-meta.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Source__c</fullName>
+    <externalId>false</externalId>
+    <label>Source</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Internal</fullName>
+                <default>true</default>
+                <label>Internal</label>
+            </value>
+            <value>
+                <fullName>External</fullName>
+                <default>false</default>
+                <label>External</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
@@ -164,6 +164,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>MergeCandidate__c.ConfidenceScore__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>MergeCandidate__c.Source__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>MergeFieldHistory__c.KeptRecordId__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.0",
-      "versionNumber": "2.0.0.NEXT"
+      "versionName": "ver 2.1",
+      "versionNumber": "2.1.0.NEXT"
     }
   ],
   "namespace": "",
@@ -14,6 +14,7 @@
   "packageAliases": {
     "merge": "0Ho4W000000TNLiSAO",
     "merge@2.0.0-1": "04tKb000000EgyJIAS",
-    "merge@2.0.0-2": "04tKb000000EgyOIAS"
+    "merge@2.0.0-2": "04tKb000000EgyOIAS",
+    "merge@2.1.0-1": "04tKb000000EgydIAC"
   }
 }


### PR DESCRIPTION
## Summary
Enables an **external system** to supply `MergeCandidate__c` records (Keep/Merge/Merge2 ids) instead of relying solely on Salesforce duplicate rules.

- Add `ConfidenceScore__c` (Number 4,2) and `Source__c` (picklist Internal/External, default Internal) to `MergeCandidate__c`.
- `getRules` now unions active Salesforce duplicate rules with distinct `Rule__c` values present on candidates, so external candidates (which map to no Salesforce duplicate rule) remain filterable in the review UI.
- Expose `confidenceScore`/`source` on the `mergeGroup` wrapper and add a **Confidence** column to `dupeList`.
- Grant FLS on both new fields to **Merge Control Administrator**.
- The merge executor and AutoMerge-via-Flow need no change: the merge batch only reads `AutoMerge__c`, regardless of how the candidate was created.

## Release
- Built and **promoted** unlocked package version **2.1.0** (`04tKb000000EgydIAC`), 90% coverage.
- README install instructions updated to 2.1.0.

## Verification
- Check-only deploy against `gsgDEV` with the full 25-class `MRG_*` test suite: **121/121 pass**, 0 component errors.
- Coverage on changed classes: `MRG_DuplicateMerge_CTRL` 91.2%, `MRG_Duplicate_SVC` 79.6%.

## Not included (optional follow-ups)
Untrusted-input validation trigger, `flagAutoMergeAccounts` re-wiring for external candidates, disabling the internal scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)