### PR TITLE
chore: grant mergeControlAdmin access to rule-UI controllers

### DIFF
--- a/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
@@ -5,6 +5,10 @@
         <visible>true</visible>
     </applicationVisibilities>
     <classAccesses>
+        <apexClass>MRG_AutoMergeAccounts_CTRL</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>MRG_DupeSettings_CTRL</apexClass>
         <enabled>true</enabled>
     </classAccesses>
@@ -38,6 +42,10 @@
     </classAccesses>
     <classAccesses>
         <apexClass>MRG_Duplicate_TEST</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_KeepRecordRules_CTRL</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>


### PR DESCRIPTION
## Summary
Fixes a **pre-existing** permission-set gap (unrelated to the 2.1.0 external-provider feature). `mergeControlAdmin` was missing `classAccesses` for two `@AuraEnabled` controllers:

| Class | Powers |
|---|---|
| `MRG_AutoMergeAccounts_CTRL` | Auto-Merge Accounts Rules UI (#35) |
| `MRG_KeepRecordRules_CTRL` | Keep Record Rules UI (#32) |

Without class access, a user holding only this permission set is blocked from those admin screens.

## Scope
Only the two entry-point controllers are added — Salesforce requires class access on the class the LWC invokes; internally-called classes (`MRG_AccountMerge_SVC`, `MRG_KeepRecordRule`, `MRG_AutoMergeAccountsRule`, etc.) don't need it, and test-class access is a runtime no-op.

## Verification
Full `force-app` check-only deploy against `gsgDEV`: **Succeeded, 0 component errors**; permission set + both controllers validated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)