### PR TITLE
fix: Auto-Merge Accounts Rules save silently fails on metadata deploy

### DIFF
--- a/force-app/main/default/classes/MRG_AutoMergeAccountsRule.cls
+++ b/force-app/main/default/classes/MRG_AutoMergeAccountsRule.cls
@@ -154,8 +154,17 @@ public with sharing class MRG_AutoMergeAccountsRule {
 			AutoMerge__c = rule.autoMerge == true,
 			Conditions__c = rule.conditions != null && !rule.conditions.isEmpty() ? JSON.serialize(rule.conditions) : null
 		);
-		String devName = (rule.objectName == null ? 'Obj' : rule.objectName.replace('__','').replace('_','')) + 'AutoMergeAccounts'
-			+ (String.isNotBlank(rule.label) ? rule.label.replaceAll('[^a-zA-Z0-9]','') : '');
+		// developer/qualified name: derived from the (object-scoped) label, sanitized to a valid custom
+		// metadata DeveloperName — alphanumeric, leading letter, max 40 chars. Previously this prefixed
+		// objectName + 'AutoMergeAccounts' onto the label; because the default label already contains
+		// both, the result overflowed the 40-char limit and the metadata deploy silently failed.
+		String devName = String.isNotBlank(rule.label) ? rule.label.replaceAll('[^a-zA-Z0-9]','') : '';
+		if(String.isBlank(devName))
+			devName = (rule.objectName == null ? 'Obj' : rule.objectName.replace('__','').replace('_','')) + 'AutoMergeAccounts';
+		if(!devName.substring(0,1).isAlpha())
+			devName = 'X' + devName;
+		if(devName.length() > 40)
+			devName = devName.substring(0,40);
 		setting.QualifiedAPIName = devName;
 		Map<String, Object> settingJSON = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(setting));
 		settingJSON.put('Object__r', new Map<String, Object>{

--- a/force-app/main/default/classes/MRG_AutoMergeAccountsRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_AutoMergeAccountsRule_TEST.cls
@@ -134,6 +134,35 @@ private class MRG_AutoMergeAccountsRule_TEST {
 		system.assertEquals(2, rt.conditions.size());
 	}
 
+	static testMethod void testToSettingDeveloperNameWithinLimit() {
+		// the default UI label is "<Object> Auto Merge Accounts <n>"; the generated DeveloperName must
+		// stay within the 40-char custom metadata limit, start with a letter, and be alphanumeric, or
+		// the metadata deploy fails (and the failure is not surfaced to the user)
+		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
+		rule.objectName = 'Account';
+		rule.label = 'Account Auto Merge Accounts 1';
+		AutoMergeAccountsRule__mdt setting = MRG_AutoMergeAccountsRule.toSetting(rule);
+		String devName = setting.QualifiedAPIName;
+		system.assert(devName.length() <= 40, 'DeveloperName must be <= 40 chars, was ' + devName.length() + ': ' + devName);
+		system.assert(devName.substring(0,1).isAlpha(), 'DeveloperName must start with a letter: ' + devName);
+		system.assert(devName.isAlphanumeric(), 'DeveloperName must be alphanumeric: ' + devName);
+	}
+
+	static testMethod void testToSettingDeveloperNameFallbackAndLeadingDigit() {
+		// blank label falls back to an object-based name; a numeric-leading label is prefixed so the
+		// DeveloperName still starts with a letter
+		MRG_AutoMergeAccountsRule blank = new MRG_AutoMergeAccountsRule();
+		blank.objectName = 'Contact';
+		blank.label = '   ';
+		system.assert(MRG_AutoMergeAccountsRule.toSetting(blank).QualifiedAPIName.isAlphanumeric(), 'fallback name must be valid');
+
+		MRG_AutoMergeAccountsRule numeric = new MRG_AutoMergeAccountsRule();
+		numeric.objectName = 'Contact';
+		numeric.label = '123 rule';
+		String devName = MRG_AutoMergeAccountsRule.toSetting(numeric).QualifiedAPIName;
+		system.assert(devName.substring(0,1).isAlpha(), 'leading digit must be prefixed: ' + devName);
+	}
+
 	static testMethod void testSaveRules() {
 		MRG_AutoMergeAccountsRule rule = new MRG_AutoMergeAccountsRule();
 		rule.objectName = 'Contact';

--- a/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.js
+++ b/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.js
@@ -204,9 +204,14 @@ export default class AutoMergeAccountsRules extends LightningElement {
 
     handleSubscribe() {
         const messageCallback = (response) => {
-            if (response && response.data && response.data.payload &&
-                response.data.payload.IsSuccess__c === true) {
+            const payload = response && response.data && response.data.payload;
+            if (!payload) {
+                return;
+            }
+            if (payload.IsSuccess__c === true) {
                 this.handleSuccess();
+            } else {
+                this.handleError({ body: { message: payload.Message__c || 'Metadata deploy failed' } });
             }
         };
         subscribe(this.channelName, -1, messageCallback).then((response) => {


### PR DESCRIPTION
## Problem
Clicking **Save** on the Auto-Merge Accounts Rules tab did nothing — the rule was not persisted.

## Root cause
`MRG_AutoMergeAccountsRule.toSetting()` generated the custom metadata `DeveloperName` as `objectName + 'AutoMergeAccounts' + sanitizedLabel`. The default label is already `"<Object> Auto Merge Accounts <n>"`, so a newly-added rule produced a ~49-char name — over the **40-char** `DeveloperName` limit — and the async Metadata API deploy failed. The LWC callback only handled `IsSuccess__c === true`, so the failure was swallowed.

Apex tests didn't catch it: `deployMetadataRecords()` returns `'Test Job Id'` in test context without validating the metadata.

## Fix
- Derive `DeveloperName` from the (object-scoped) label, sanitized to a valid name: alphanumeric, leading letter, capped at 40 chars — same approach as Keep Record Rules.
- LWC now raises an error toast on a non-success deploy event instead of ignoring it.
- Regression tests assert the generated `DeveloperName` is ≤ 40 chars, starts with a letter, and is alphanumeric.

## Verification
Check-only deploy vs `gsgDEV`: **0 component errors, 16/16 tests pass** (incl. new regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)