### PR TITLE
chore: release 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The Merge Control app provides SF Administrators with the following tools relate
 
 ## Installation
 
-Current release: **2.1.0** (unlocked package, `04tKb000000EgydIAC`)
+Current release: **2.2.0** (unlocked package, `04tKb000000EgynIAC`)
 
 Install via URL:
-- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgydIAC
-- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgydIAC
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgynIAC
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgynIAC
 
 Or with the Salesforce CLI:
 
 ```
-sf package install --package 04tKb000000EgydIAC --target-org <org-alias> --wait 10
+sf package install --package 04tKb000000EgynIAC --target-org <org-alias> --wait 10
 ```
 
 After installing, assign the **Merge Control Administrator** permission set to administrators.

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.1",
-      "versionNumber": "2.1.0.NEXT"
+      "versionName": "ver 2.2",
+      "versionNumber": "2.2.0.NEXT"
     }
   ],
   "namespace": "",
@@ -15,6 +15,7 @@
     "merge": "0Ho4W000000TNLiSAO",
     "merge@2.0.0-1": "04tKb000000EgyJIAS",
     "merge@2.0.0-2": "04tKb000000EgyOIAS",
-    "merge@2.1.0-1": "04tKb000000EgydIAC"
+    "merge@2.1.0-1": "04tKb000000EgydIAC",
+    "merge@2.2.0-1": "04tKb000000EgynIAC"
   }
 }


### PR DESCRIPTION
Release **2.2.0** (unlocked package, promoted): `04tKb000000EgynIAC`.

- Bumps `versionNumber` to `2.2.0.NEXT`, records alias `merge@2.2.0-1`.
- Updates README install instructions to 2.2.0.

Bundles since 2.1.0: auto-merge save fix (#60) and the one-row-per-(keep,merge)-pair rearchitecture (#61). Built with code coverage (90%); promoted to released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)