### PR TITLE
feat: Apex Defined field keep-value rule

### DIFF
--- a/force-app/main/default/classes/MRG_ApexFieldKeepRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_ApexFieldKeepRule_TEST.cls
@@ -1,0 +1,81 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for the Apex Defined field-keep rule: the resolver runs after the built-in rules,
+* its value is applied to the kept record and tracked, a bad class name is skipped (not fatal), and
+* the shipped example resolver behaves as documented.
+*/
+@isTest
+private class MRG_ApexFieldKeepRule_TEST {
+
+	// build a Preserve MergeFieldSetting whose rule delegates to an Apex resolver class
+	private static MergeFieldSetting__mdt apexSetting(String objectName, String fieldName, String apexClass) {
+		MergeFieldSetting__mdt setting = new MergeFieldSetting__mdt(
+			Label = fieldName,
+			Type__c = 'Preserve',
+			PreservationRule__c = 'Apex Defined',
+			ApexClass__c = apexClass,
+			Disable__c = false
+		);
+		Map<String, Object> m = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(setting));
+		m.put('Field__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityParticle' }, 'QualifiedAPIName' => fieldName });
+		m.put('Object__r', new Map<String, Object>{ 'attributes' => new Map<String, Object>{ 'type' => 'EntityDefinition' }, 'QualifiedAPIName' => objectName });
+		return (MergeFieldSetting__mdt) JSON.deserialize(JSON.serialize(m), MergeFieldSetting__mdt.class);
+	}
+
+	static testMethod void testApexDefinedRuleKeepsResolvedValue() {
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, MailingStreet='short'),
+			new Contact(Id=mergeId, MailingStreet='a much longer street value')
+		};
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>{
+			apexSetting('Contact', 'MailingStreet', 'MRG_SampleFieldKeepRule')
+		};
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals('a much longer street value', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'MailingStreet'),
+			'the Apex Defined resolver should keep the longest value');
+		Map<String, MergeFieldHistory__c> history = MRG_TestFactory.historyByField(keepId);
+		system.assert(history.containsKey('mailingstreet'), 'the Apex-decided change should be tracked in history');
+	}
+
+	static testMethod void testApexDefinedRuleInvalidClassIsSkipped() {
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, MailingState='TX'),
+			new Contact(Id=mergeId, MailingState='CA')
+		};
+		MRG_Merge_SVC.mergeFields = new List<MergeFieldSetting__mdt>{
+			apexSetting('Contact', 'MailingState', 'Not_A_Real_Class_XYZ')
+		};
+		MRG_Merge_SVC.previewFields = new List<PreviewFields__mdt>();
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		// a missing/invalid resolver class must be skipped, not throw
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals('TX', (String) MRG_TestFactory.keptValue(keepId, 'Contact', 'MailingState'),
+			'an invalid resolver class should leave the kept value unchanged');
+	}
+
+	static testMethod void testSampleResolverKeepsLongest() {
+		Contact keep = new Contact(LastName='K', MailingStreet='ab');
+		Contact merged = new Contact(LastName='M', MailingStreet='abcd');
+		MRG_FieldKeepContext ctx = new MRG_FieldKeepContext('Contact', 'MailingStreet', keep, keep, new List<SObject>{ merged });
+		Object result = new MRG_SampleFieldKeepRule().resolveValue(ctx);
+		system.assertEquals('abcd', (String) result, 'sample resolver keeps the longest value');
+		system.assertEquals('ab', (String) ctx.currentValue, 'context exposes the rule-decided current value');
+	}
+}

--- a/force-app/main/default/classes/MRG_ApexFieldKeepRule_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_ApexFieldKeepRule_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_FieldKeepContext.cls
+++ b/force-app/main/default/classes/MRG_FieldKeepContext.cls
@@ -1,0 +1,34 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description Context passed to an MRG_FieldKeepRule. Carries the target field, the surviving record
+* with every value resolved so far (after preserve / related / complex / manual override), the
+* surviving record's pre-merge values, and the losing (merged) records, so custom logic can make
+* cross-field and cross-record decisions.
+*/
+global class MRG_FieldKeepContext {
+	/*** @description the SObject api name being merged */
+	global String objectType;
+	/*** @description the field the resolver is deciding */
+	global String fieldName;
+	/*** @description the surviving record with values resolved so far (mutable; only fieldName is read back) */
+	global SObject keepRecord;
+	/*** @description the surviving record's pre-merge values */
+	global SObject keepOriginal;
+	/*** @description the losing records (original values) */
+	global List<SObject> mergeRecords;
+	/*** @description the value the built-in rules chose for fieldName */
+	global Object currentValue;
+
+	/*******************************************************************************************************
+	* @description constructor
+	*/
+	global MRG_FieldKeepContext(String objectType, String fieldName, SObject keepRecord, SObject keepOriginal, List<SObject> mergeRecords) {
+		this.objectType = objectType;
+		this.fieldName = fieldName;
+		this.keepRecord = keepRecord;
+		this.keepOriginal = keepOriginal;
+		this.mergeRecords = mergeRecords == null ? new List<SObject>() : mergeRecords;
+		this.currentValue = keepRecord != null ? keepRecord.get(fieldName) : null;
+	}
+}

--- a/force-app/main/default/classes/MRG_FieldKeepContext.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FieldKeepContext.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_FieldKeepRule.cls
+++ b/force-app/main/default/classes/MRG_FieldKeepRule.cls
@@ -1,0 +1,21 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description Extension point for custom field keep-value decisions during a merge. Implement this
+* interface in your own Apex, then register it per field by setting that field's Merge Field Setting
+* Preservation Rule to "Apex Defined" and naming the implementing class in ApexClass__c.
+*
+* The resolver runs AFTER all built-in rules (preserve / related / complex / manual override) have
+* run, so it sees the value those rules chose plus the full record context, and returns the final
+* value to keep. Because the merge preview uses the same engine, the resolver's decision is reflected
+* in the preview before the merge is committed.
+*/
+global interface MRG_FieldKeepRule {
+	/*******************************************************************************************************
+	* @description decide the value to keep for context.fieldName on the surviving record
+	* @param context the decision context (target field, surviving record so far, original surviving
+	*        record, and the losing records)
+	* @return Object the value to keep; return context.currentValue to leave the rule-decided value as-is
+	*/
+	Object resolveValue(MRG_FieldKeepContext context);
+}

--- a/force-app/main/default/classes/MRG_FieldKeepRule.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_FieldKeepRule.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -171,6 +171,8 @@ public with sharing class MRG_Merge_SVC {
 		@auraEnabled public String tieBreakDirection;
 		// optional fallback target: the losing value for this field is written here (if empty)
 		@auraEnabled public String fallbackField;
+		// for rule == 'Apex Defined': the MRG_FieldKeepRule implementation that decides this field
+		@auraEnabled public String apexClass;
 
 		public mergeFieldWrap(MergeFieldSetting__mdt mergeField) {
 			this.id = mergeField.Id;
@@ -189,6 +191,7 @@ public with sharing class MRG_Merge_SVC {
 			this.tieBreakField = mergeField.TieBreakField__r != null ? mergeField.TieBreakField__r.QualifiedAPIName : null;
 			this.tieBreakDirection = mergeField.TieBreakDirection__c;
 			this.fallbackField = mergeField.FallbackField__r != null ? mergeField.FallbackField__r.QualifiedAPIName : null;
+			this.apexClass = mergeField.ApexClass__c;
 		}
 		public Integer compareTo(Object compareTo) {
 			mergeFieldWrap sortObj = (mergeFieldWrap) compareTo;
@@ -244,7 +247,8 @@ public with sharing class MRG_Merge_SVC {
 			Disable__c = mfw.disable,
 			FilterLogic__c = mfw.filterLogic,
 			Conditions__c = mfw.conditions != null && !mfw.conditions.isEmpty() ? JSON.serialize(mfw.conditions) : null,
-			TieBreakDirection__c = mfw.tieBreakDirection
+			TieBreakDirection__c = mfw.tieBreakDirection,
+			ApexClass__c = mfw.apexClass
 		);
 		mergeField.Type__c = mfw.type == 't' ? 'Track' : 'Preserve';
 		if(String.isNotBlank(mfw.id))
@@ -331,7 +335,8 @@ public with sharing class MRG_Merge_SVC {
 					Conditions__c,
 					Type__c,
 					Disable__c,
-					PreservationRule__c
+					PreservationRule__c,
+					ApexClass__c
 					FROM MergeFieldSetting__mdt
 				]);
 			}
@@ -548,6 +553,48 @@ public with sharing class MRG_Merge_SVC {
 		return preserveMergeFields;
 	}
 	/*******************************************************************************************************
+	* @description enabled Preserve fields for an object whose rule is 'Apex Defined' with a class set
+	* @param objectType the SObject api name
+	* @return List<mergeFieldWrap>
+	*/
+	public static List<mergeFieldWrap> getApexKeepFields(String objectType) {
+		List<mergeFieldWrap> apexFields = new List<mergeFieldWrap>();
+		for(mergeFieldWrap mfw:getPreserveMergeFields()) {
+			if(!mfw.disable
+				&& mfw.rule != null && mfw.rule.equalsIgnoreCase('Apex Defined')
+				&& String.isNotBlank(mfw.apexClass)
+				&& mfw.objectName != null && mfw.objectName.equalsIgnoreCase(objectType))
+				apexFields.add(mfw);
+		}
+		return apexFields;
+	}
+	/*******************************************************************************************************
+	* @description instantiates (and caches) an MRG_FieldKeepRule by class name; returns null when the
+	* class can't be found or doesn't implement the interface (so a bad config skips, not breaks)
+	* @param className the Apex class name
+	* @param cache instances keyed by class name (null entries cached to avoid retrying)
+	* @return MRG_FieldKeepRule or null
+	*/
+	private static MRG_FieldKeepRule getFieldKeepResolver(String className, Map<String, MRG_FieldKeepRule> cache) {
+		if(String.isBlank(className))
+			return null;
+		if(cache.containsKey(className))
+			return cache.get(className);
+		MRG_FieldKeepRule resolver = null;
+		try {
+			Type resolverType = Type.forName(className);
+			Object instance = resolverType != null ? resolverType.newInstance() : null;
+			if(instance instanceof MRG_FieldKeepRule)
+				resolver = (MRG_FieldKeepRule) instance;
+			else
+				System.debug(LoggingLevel.ERROR, 'Apex Defined rule class ' + className + ' does not implement MRG_FieldKeepRule');
+		} catch(Exception e) {
+			System.debug(LoggingLevel.ERROR, 'Could not instantiate Apex Defined rule class ' + className + ': ' + e.getMessage());
+		}
+		cache.put(className, resolver);
+		return resolver;
+	}
+	/*******************************************************************************************************
 	* @description the Complex preservation rules for an object: enabled Preserve fields whose rule is
 	* 'Complex', converted to MRG_ComplexPreserveRule for group-wide evaluation
 	* @param objectType the SObject api name
@@ -759,6 +806,16 @@ public with sharing class MRG_Merge_SVC {
 				complexFields.add(complexRule.fieldName.toLowerCase());
 			}
 		}
+		// Apex Defined rule fields are resolved in a final group-wide pass below; like Complex, remove
+		// them from the pairwise preserve map and skip them in the pairwise loop.
+		List<mergeFieldWrap> apexFieldSettings = getApexKeepFields(objectType);
+		Set<String> apexFields = new Set<String>();
+		for(mergeFieldWrap apexFieldSetting:apexFieldSettings) {
+			if(String.isNotBlank(apexFieldSetting.fieldName)) {
+				preserveFieldMap.remove(apexFieldSetting.fieldName.toLowerCase());
+				apexFields.add(apexFieldSetting.fieldName.toLowerCase());
+			}
+		}
 		/****
 		*	a map of child field to master field keyed by child field
 		***/
@@ -799,8 +856,8 @@ public with sharing class MRG_Merge_SVC {
 				Boolean keptRecordIsOlder = (Datetime) keptRec.get('CreatedDate') < (Datetime) obj.get('CreatedDate');
 				Boolean hasChange = false;
 				for(String fieldName:fieldsToCheck) {
-					// Complex-rule fields are handled in the group-wide pass; skip them here
-					if(complexFields.contains(fieldName))
+					// Complex-rule and Apex Defined fields are handled in group-wide passes; skip here
+					if(complexFields.contains(fieldName) || apexFields.contains(fieldName))
 						continue;
 					Boolean isMaster = masterFields.contains(fieldName);
 					Boolean isChild = masterChildFields.containsKey(fieldName);
@@ -928,6 +985,49 @@ public with sharing class MRG_Merge_SVC {
 					mergeRecords.add(getMergeRecord(winning, current, keptRec, String.valueOf(keepId), complexRule.fieldName));
 				}
 				if(groupChange)
+					updateRecordMap.put(keptRec.Id, keptRec);
+			}
+		}
+		// --- Apex Defined rule pass ------------------------------------------------------------------
+		// Delegate field keep-value decisions to custom code AFTER every built-in rule has run. The
+		// resolver sees the rule-decided value (ctx.currentValue) plus the full record context and
+		// returns the final value. A faulty resolver is logged and skipped so it never breaks a merge.
+		if(!apexFieldSettings.isEmpty()) {
+			Map<String, MRG_FieldKeepRule> resolverByClass = new Map<String, MRG_FieldKeepRule>();
+			Map<Id, List<SObject>> apexMergedByKeepId = new Map<Id, List<SObject>>();
+			for(SObject obj:mergedRecords) {
+				Id mId = (Id) obj.get('Id');
+				Id kId = keepIdMap.containsKey(mId) ? keepIdMap.get(mId) : null;
+				if(kId == null) continue;
+				if(!apexMergedByKeepId.containsKey(kId))
+					apexMergedByKeepId.put(kId, new List<SObject>());
+				apexMergedByKeepId.get(kId).add(obj);
+			}
+			for(Id keepId:mergeKeyMap.keyset()) {
+				if(!keptRecordMap.containsKey(keepId))
+					continue;
+				SObject keptRec = keptRecordMap.get(keepId);
+				SObject keptOriginal = keptOriginalById.containsKey(keepId) ? keptOriginalById.get(keepId) : keptRec;
+				List<SObject> recordGroup = apexMergedByKeepId.containsKey(keepId) ? apexMergedByKeepId.get(keepId) : new List<SObject>();
+				Boolean apexChange = false;
+				for(mergeFieldWrap apexFieldSetting:apexFieldSettings) {
+					MRG_FieldKeepRule resolver = getFieldKeepResolver(apexFieldSetting.apexClass, resolverByClass);
+					if(resolver == null)
+						continue;
+					try {
+						MRG_FieldKeepContext ctx = new MRG_FieldKeepContext(objectType, apexFieldSetting.fieldName, keptRec, keptOriginal, recordGroup);
+						Object current = ctx.currentValue;
+						Object resolved = resolver.resolveValue(ctx);
+						if(!valuesAreEqual(current, resolved)) {
+							keptRec.put(apexFieldSetting.fieldName, resolved);
+							apexChange = true;
+							mergeRecords.add(getMergeRecord(resolved, current, keptRec, String.valueOf(keepId), apexFieldSetting.fieldName));
+						}
+					} catch(Exception e) {
+						System.debug(LoggingLevel.ERROR, 'Apex Defined rule ' + apexFieldSetting.apexClass + ' failed for ' + apexFieldSetting.fieldName + ': ' + e.getMessage());
+					}
+				}
+				if(apexChange)
 					updateRecordMap.put(keptRec.Id, keptRec);
 			}
 		}

--- a/force-app/main/default/classes/MRG_Metadata_SVC.cls
+++ b/force-app/main/default/classes/MRG_Metadata_SVC.cls
@@ -226,6 +226,8 @@ public with sharing class MRG_Metadata_SVC {
 		fieldKeyValues.put('TieBreakField__c', mergeField.TieBreakField__r != null ? mergeField.TieBreakField__r.QualifiedAPIName : null);
 		// fallback field (re-homed #34)
 		fieldKeyValues.put('FallbackField__c', mergeField.FallbackField__r != null ? mergeField.FallbackField__r.QualifiedAPIName : null);
+		// Apex Defined rule: the resolver class name
+		fieldKeyValues.put('ApexClass__c', mergeField.ApexClass__c);
 		String qualifiedName = !mergeField.QualifiedAPIName.contains('.') ? 'MergeFieldSetting__mdt.'+mergeField.QualifiedAPIName : mergeField.QualifiedAPIName;	   	
 		mdRecordNames.add(qualifiedName);
 		

--- a/force-app/main/default/classes/MRG_SampleFieldKeepRule.cls
+++ b/force-app/main/default/classes/MRG_SampleFieldKeepRule.cls
@@ -1,0 +1,22 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description Example MRG_FieldKeepRule: keep the longest non-blank text value across the surviving
+* and losing records. Ships as a reference implementation; register it on a field by setting the
+* field's Preservation Rule to "Apex Defined" with ApexClass__c = MRG_SampleFieldKeepRule.
+*/
+global class MRG_SampleFieldKeepRule implements MRG_FieldKeepRule {
+	global Object resolveValue(MRG_FieldKeepContext context) {
+		Object best = context.currentValue;
+		Integer bestLen = best == null ? -1 : String.valueOf(best).length();
+		for(SObject record:context.mergeRecords) {
+			Object value = record.get(context.fieldName);
+			Integer len = value == null ? -1 : String.valueOf(value).length();
+			if(len > bestLen) {
+				best = value;
+				bestLen = len;
+			}
+		}
+		return best;
+	}
+}

--- a/force-app/main/default/classes/MRG_SampleFieldKeepRule.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_SampleFieldKeepRule.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
@@ -201,6 +201,20 @@
                         </div>
                     </div>
                 </template>
+
+                <template if:true={isApex}>
+                    <div class="slds-box slds-m-horizontal_small slds-m-bottom_medium">
+                        <p class="slds-text-title_caps slds-m-bottom_x-small">Apex Defined Rule</p>
+                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
+                            This field's kept value is decided by a custom Apex class implementing
+                            MRG_FieldKeepRule, run after the built-in rules. Enter the class name
+                            (e.g. MRG_SampleFieldKeepRule).
+                        </p>
+                        <lightning-input label="Apex Class" value={mergeRecord.apexClass}
+                            onchange={handleApexClassChange}>
+                        </lightning-input>
+                    </div>
+                </template>
             </template>
         </template>
 </template>

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
@@ -33,7 +33,7 @@ export default class mergeSingleRecord extends LightningElement {
         return type;
     }
     trackOptions = [{label:'Track Fields',value:'t'},{label:'Preserve Fields',value:'p'}];
-    ruleOptions = [{label:'Oldest Record',value:'Oldest'},{label:'Newest Record',value:'Newest'},{label:'Largest Field Value',value:'Largest'},{label:'Smallest Field Value',value:'Smallest'},{label:'Related Field Value',value:'Related Field'},{label:'Complex Rule',value:'Complex'}];
+    ruleOptions = [{label:'Oldest Record',value:'Oldest'},{label:'Newest Record',value:'Newest'},{label:'Largest Field Value',value:'Largest'},{label:'Smallest Field Value',value:'Smallest'},{label:'Related Field Value',value:'Related Field'},{label:'Complex Rule',value:'Complex'},{label:'Apex Defined Rule',value:'Apex Defined'}];
     operatorOptions = [
         {label:'equals',value:'equals'},
         {label:'not equals',value:'notEquals'},
@@ -87,6 +87,10 @@ export default class mergeSingleRecord extends LightningElement {
 
     get isComplex(){
         return this.mergeRecord !== undefined && this.mergeRecord != null && this.preserve && this.mergeRecord.rule == 'Complex';
+    }
+
+    get isApex(){
+        return this.mergeRecord !== undefined && this.mergeRecord != null && this.preserve && this.mergeRecord.rule == 'Apex Defined';
     }
 
     // re-derive each condition's value input type from its selected field, and add row indices
@@ -231,6 +235,9 @@ export default class mergeSingleRecord extends LightningElement {
 
     handleFilterLogicChange(event){
         this.mergeRecord.filterLogic = event.target.value;
+    }
+    handleApexClassChange(event){
+        this.mergeRecord.apexClass = event.target.value;
     }
     doEdit(event){
         this.isEdit=true;

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/ApexClass__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/ApexClass__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ApexClass__c</fullName>
+    <description>For Preservation Rule = Apex Defined: the Apex class implementing MRG_FieldKeepRule that decides this field's kept value.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Apex Class</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PreservationRule__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PreservationRule__c.field-meta.xml
@@ -40,6 +40,11 @@
                 <default>false</default>
                 <label>Complex</label>
             </value>
+            <value>
+                <fullName>Apex Defined</fullName>
+                <default>false</default>
+                <label>Apex Defined</label>
+            </value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>


### PR DESCRIPTION
## Summary
Adds an Apex extension point for field keep-value decisions during a merge — for logic more complex than the rule UI allows. Custom code runs **after** the built-in preserve/related/complex/override rules and returns the final value to keep.

## How it works
- **`MRG_FieldKeepRule`** (global interface) + **`MRG_FieldKeepContext`** (target field, surviving record so far, pre-merge surviving record, losing records, and the rule-decided `currentValue`).
- Register per field: set the Merge Field Setting **Preservation Rule = "Apex Defined"** (new dropdown option) and name the class in the new **`ApexClass__c`** field.
- `MRG_Merge_SVC`: Apex-Defined fields are skipped in the pairwise loop and resolved in a final group-wide pass (mirrors the #33 Complex pass). The resolver is instantiated via `Type.forName` (cached + interface-checked); a missing/faulty class is logged and skipped — never breaks the merge. Decisions are written to `MergeFieldHistory__c`.
- **Preview parity:** the preview uses the same engine, so an Apex decision shows in the preview before committing.
- `MRG_SampleFieldKeepRule`: shipped reference implementation (keep the longest text value across records).
- UI: `mergeSingleRecord` gains the "Apex Defined Rule" option + an Apex Class input.

## Verification
Check-only deploy vs `gsgDEV`, full `MRG_*` suite: **0 component errors, 128/128 tests pass**. Coverage: `MRG_Merge_SVC` 93.3%, `MRG_FieldKeepContext` 100%, `MRG_SampleFieldKeepRule` 100%, `MRG_Metadata_SVC` 88.3%.

## Notes
- The resolver runs inside the merge (and preview) transaction — avoid SOQL/DML inside `resolveValue`; instances are cached per merge.
- `ApexClass__c` is `required=false`; a save-time guard / validation rule requiring it when rule = Apex Defined could be added if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)