### PR TITLE
chore: grant mergeControlAdmin access to Apex field-keep classes

### DIFF
--- a/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
@@ -96,6 +96,22 @@
         <apexClass>MRG_TriggerHandler_TEST</apexClass>
         <enabled>true</enabled>
     </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_FieldKeepRule</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_FieldKeepContext</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_SampleFieldKeepRule</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_ApexFieldKeepRule_TEST</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
     <customMetadataTypeAccesses>
         <enabled>true</enabled>
         <name>DuplicateRuleSettings__mdt</name>


### PR DESCRIPTION
Adds `classAccesses` for the #63 Apex field-keep classes: `MRG_FieldKeepRule`, `MRG_FieldKeepContext`, `MRG_SampleFieldKeepRule`, `MRG_ApexFieldKeepRule_TEST` — matching this permission set's convention of listing every package class.

**Fields are already covered:** `ConfidenceScore__c`/`Source__c` have FLS; `PairKey__c` is required (FLS not allowed); `ApexClass__c` is a custom-metadata-type field covered by the existing `MergeFieldSetting__mdt` type access.

Verified: full `force-app` check-only deploy vs `gsgDEV` — Succeeded, 0 component errors.

Note: the rule-UI controllers (`MRG_AutoMergeAccounts_CTRL`, `MRG_KeepRecordRules_CTRL`) are handled separately in open PR #59 and intentionally not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)