### PR TITLE
feat: bulk-suppress preview fields from a comma-delimited list

### DIFF
--- a/force-app/main/default/classes/MRG_MergeSettings_CTRL.cls
+++ b/force-app/main/default/classes/MRG_MergeSettings_CTRL.cls
@@ -252,6 +252,46 @@ public with sharing class MRG_MergeSettings_CTRL {
 		return MRG_Merge_SVC.savePreviewFields(pFields);
 	}
 	/*******************************************************************************************************
+	* @description bulk-suppresses a comma-delimited list of field api names from the merge preview for
+	* an object: validates each against the object, builds a hidden PreviewFields setting per valid field
+	* and bulk-deploys them via the existing metadata path
+	* @param objectType the SObject api name (required)
+	* @param fieldNames a comma-delimited list of field api names
+	* @return String the metadata deploy job id
+	*/
+	@AuraEnabled
+	public static String suppressPreviewFields(String objectType, String fieldNames) {
+		if(String.isBlank(objectType))
+			throw new AuraHandledException('Select an object.');
+		if(String.isBlank(fieldNames))
+			throw new AuraHandledException('Enter at least one field API name.');
+		Schema.SObjectType sObjType = Schema.getGlobalDescribe().get(objectType);
+		if(sObjType == null)
+			throw new AuraHandledException('Unknown object: ' + objectType);
+		Map<String, Schema.SObjectField> fieldMap = sObjType.getDescribe().fields.getMap();
+		List<previewField> pFields = new List<previewField>();
+		List<String> invalid = new List<String>();
+		Set<String> seen = new Set<String>();
+		for(String raw:fieldNames.split(',')) {
+			String fieldName = raw == null ? '' : raw.trim();
+			if(String.isBlank(fieldName) || seen.contains(fieldName.toLowerCase()))
+				continue;
+			seen.add(fieldName.toLowerCase());
+			if(!fieldMap.containsKey(fieldName.toLowerCase())) {
+				invalid.add(fieldName);
+				continue;
+			}
+			// use the field's true api name (correct casing) so the deployed record name is stable
+			String apiName = fieldMap.get(fieldName.toLowerCase()).getDescribe().getName();
+			pFields.add(new previewField(objectType, apiName, true));
+		}
+		if(!invalid.isEmpty())
+			throw new AuraHandledException('Unknown field(s) on ' + objectType + ': ' + String.join(invalid, ', '));
+		if(pFields.isEmpty())
+			throw new AuraHandledException('No valid fields to suppress.');
+		return MRG_Merge_SVC.savePreviewFields(pFields);
+	}
+	/*******************************************************************************************************
 	* @description handles save
 	* @param String the JSON string to save
 	* @return String 
@@ -279,6 +319,13 @@ public with sharing class MRG_MergeSettings_CTRL {
 			this.objectName = pField.Object__r.QualifiedAPIName;
 			this.fieldName = pField.Field__r.QualifiedAPIName;
 			this.hidden = pField.Disable__c;
+		}
+		public previewField(String objectName, String fieldName, Boolean hidden){
+			this.objectName = objectName;
+			this.fieldName = fieldName;
+			this.hidden = hidden;
+			this.name = fieldName + objectName;
+			this.label = fieldName;
 		}
 		public Integer compareTo(Object compareTo) {
 			previewField sortObj = (previewField) compareTo;

--- a/force-app/main/default/classes/MRG_SuppressPreviewFields_TEST.cls
+++ b/force-app/main/default/classes/MRG_SuppressPreviewFields_TEST.cls
@@ -1,0 +1,45 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description tests for bulk suppression of merge-preview fields from a comma-delimited list:
+* valid fields enqueue a metadata deploy, unknown fields are rejected, and an object is required.
+*/
+@isTest
+private class MRG_SuppressPreviewFields_TEST {
+
+	static testMethod void testSuppressValidFields() {
+		Test.startTest();
+		// mixed casing + spaces + a duplicate; all resolve to valid Contact fields
+		String jobId = MRG_MergeSettings_CTRL.suppressPreviewFields('Contact', 'Phone, email ,MailingStreet, phone');
+		Test.stopTest();
+		system.assertEquals('Test Job Id', jobId, 'valid fields should enqueue a bulk metadata deploy');
+	}
+
+	static testMethod void testSuppressInvalidFieldThrows() {
+		Boolean threw = false;
+		try {
+			MRG_MergeSettings_CTRL.suppressPreviewFields('Contact', 'Phone, Not_A_Field_X');
+		} catch(Exception e) {
+			threw = true;
+		}
+		system.assert(threw, 'an unknown field should be rejected before deploying');
+	}
+
+	static testMethod void testSuppressRequiresObjectAndFields() {
+		Boolean threwNoObject = false;
+		try {
+			MRG_MergeSettings_CTRL.suppressPreviewFields('', 'Phone');
+		} catch(Exception e) {
+			threwNoObject = true;
+		}
+		system.assert(threwNoObject, 'an object is required');
+
+		Boolean threwNoFields = false;
+		try {
+			MRG_MergeSettings_CTRL.suppressPreviewFields('Contact', '   ');
+		} catch(Exception e) {
+			threwNoFields = true;
+		}
+		system.assert(threwNoFields, 'at least one field is required');
+	}
+}

--- a/force-app/main/default/classes/MRG_SuppressPreviewFields_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_SuppressPreviewFields_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/previewFields/previewFields.html
+++ b/force-app/main/default/lwc/previewFields/previewFields.html
@@ -33,7 +33,8 @@
         <lightning-layout vertical-align="end" pull-to-boundary="small">
             <template if:false={disabled}>
                 <lightning-layout-item padding="around-small" size="4">
-                    <lightning-button onclick={addRow} variant="brand" title="Hide New Field" label="Hide New Field"></lightning-button> 
+                    <lightning-button onclick={addRow} variant="brand" title="Hide New Field" label="Hide New Field" class="slds-m-right_x-small"></lightning-button>
+                    <lightning-button onclick={openSuppressModal} title="Suppress a List of Fields" label="Suppress a List of Fields"></lightning-button>
                 </lightning-layout-item>
                 <lightning-layout-item padding="around-small" size="4">
                     <template if:true={hasChanged}>
@@ -46,4 +47,43 @@
             </template>
         </lightning-layout>
     </div>
+    <template if:true={isSuppressModalOpen}>
+        <section role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="suppress-heading" class="slds-modal slds-fade-in-open">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse" title="Close" onclick={closeSuppressModal}>
+                        <lightning-icon icon-name="utility:close" alternative-text="close" variant="inverse" size="small"></lightning-icon>
+                        <span class="slds-assistive-text">Close</span>
+                    </button>
+                    <h2 id="suppress-heading" class="slds-text-heading_medium">Suppress a List of Fields</h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium">
+                    <lightning-combobox
+                        name="suppressObject"
+                        label="Object"
+                        required
+                        value={suppressObjectType}
+                        placeholder="Select an Object"
+                        options={suppressObjectOptions}
+                        onchange={handleSuppressObjectChange}
+                        class="slds-m-bottom_small"></lightning-combobox>
+                    <lightning-textarea
+                        name="suppressFields"
+                        label="Field API Names (comma-delimited)"
+                        value={suppressFieldNames}
+                        placeholder="e.g. Phone, Fax, MailingStreet, Description"
+                        onchange={handleSuppressFieldNamesChange}></lightning-textarea>
+                    <p class="slds-text-body_small slds-text-color_weak slds-m-top_x-small">
+                        Each valid field is hidden from the merge preview for the selected object. Unknown
+                        field names are reported and nothing is deployed until they're corrected.
+                    </p>
+                </div>
+                <footer class="slds-modal__footer">
+                    <button class="slds-button slds-button_neutral" onclick={closeSuppressModal}>Cancel</button>
+                    <button class="slds-button slds-button_brand" onclick={handleSuppressSubmit} disabled={suppressDisabled}>Suppress Fields</button>
+                </footer>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/previewFields/previewFields.js
+++ b/force-app/main/default/lwc/previewFields/previewFields.js
@@ -3,6 +3,7 @@ import { subscribe, unsubscribe, onError, setDebugFlag, isEmpEnabled } from 'lig
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getFieldSettings from '@salesforce/apex/MRG_MergeSettings_CTRL.getAllPreviewFields';
 import savePreviewFields from '@salesforce/apex/MRG_MergeSettings_CTRL.savePreviewFieldsSettings';
+import suppressPreviewFields from '@salesforce/apex/MRG_MergeSettings_CTRL.suppressPreviewFields';
 
 export default class previewFields extends LightningElement {
     @track cols;
@@ -28,6 +29,14 @@ export default class previewFields extends LightningElement {
     notificationStyle;
     notificationTitle;
     modalLabel='Edit Preview Field';
+    // bulk "suppress a list of fields" modal
+    @track isSuppressModalOpen = false;
+    @track suppressObjectType = '';
+    @track suppressFieldNames = '';
+    suppressObjectOptions = [{label:'Account',value:'Account'},{label:'Contact',value:'Contact'}];
+    get suppressDisabled(){
+        return !this.suppressObjectType || !this.suppressFieldNames;
+    }
     // platform event
     channelName = '/event/MergeRecordSave__e';
     isSubscribeDisabled = false;
@@ -175,6 +184,35 @@ export default class previewFields extends LightningElement {
     }
     handleObjectFilterChange(event){
         this.objectType = event.detail.value;
+    }
+    openSuppressModal(){
+        this.suppressObjectType = '';
+        this.suppressFieldNames = '';
+        this.isSuppressModalOpen = true;
+    }
+    closeSuppressModal(){
+        this.isSuppressModalOpen = false;
+    }
+    handleSuppressObjectChange(event){
+        this.suppressObjectType = event.detail.value;
+    }
+    handleSuppressFieldNamesChange(event){
+        this.suppressFieldNames = event.target.value;
+    }
+    handleSuppressSubmit(){
+        suppressPreviewFields({objectType:this.suppressObjectType, fieldNames:this.suppressFieldNames})
+            .then(()=>{
+                this.isSuppressModalOpen = false;
+                this.suppressFieldNames = '';
+                this.notificationTitle = 'Suppressing Fields';
+                this.notificationStyle = 'success';
+                this.notificationBody = 'Deploying field suppression; the list refreshes when it completes.';
+                this.showNotification();
+            })
+            .catch((error)=>{
+                this.error = error;
+                this.handleError();
+            });
     }
     showNotification(){
         this.dispatchEvent(


### PR DESCRIPTION
## Summary
Picking preview-suppression fields one at a time is slow. Adds a **"Suppress a List of Fields"** button in **Field Settings → Merge Preview Field Settings**: pick an object (required), paste a comma-delimited list of field API names, and the system bulk-deploys the field-suppression metadata.

## How it works
- `MRG_MergeSettings_CTRL.suppressPreviewFields(objectType, fieldNames)` — parses + de-dupes the list, **validates each name against the object** (unknown names are reported and nothing deploys), normalizes to the field's true API casing, builds a hidden `PreviewFields` setting per field, and reuses the existing `MRG_Merge_SVC.savePreviewFields` bulk metadata-deploy path. New `previewField(objectName, fieldName, hidden)` constructor.
- `previewFields` LWC — the button + a modal (object combobox required, comma-delimited textarea; Submit disabled until both are set). The component's existing `MergeRecordSave__e` subscription refreshes the list when the async deploy finishes.

## Verification
Check-only deploy vs `gsgDEV`, full `MRG_*` suite: **0 component errors, 131/131 tests pass**, `MRG_MergeSettings_CTRL` 88.3%. New `MRG_SuppressPreviewFields_TEST` covers valid/unknown/empty cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)