### PR TITLE
chore: grant mergeControlAdmin access to rule-UI + Apex field-keep classes (consolidates #59, #64)

### DIFF
--- a/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
@@ -96,6 +96,30 @@
         <apexClass>MRG_TriggerHandler_TEST</apexClass>
         <enabled>true</enabled>
     </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_ApexFieldKeepRule_TEST</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_AutoMergeAccounts_CTRL</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_FieldKeepContext</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_FieldKeepRule</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_KeepRecordRules_CTRL</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>MRG_SampleFieldKeepRule</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
     <customMetadataTypeAccesses>
         <enabled>true</enabled>
         <name>DuplicateRuleSettings__mdt</name>


### PR DESCRIPTION
Consolidates the two pending permission-set PRs into one to avoid the duplicate-`classAccesses` merge conflict.

Adds `mergeControlAdmin` class access for:
- **Rule-UI controllers** (was #59): `MRG_AutoMergeAccounts_CTRL`, `MRG_KeepRecordRules_CTRL` — so a user with only this permission set can use the Keep Record Rules (#32) and Auto-Merge Accounts Rules (#35) admin screens.
- **Apex field-keep classes** (was #64): `MRG_FieldKeepRule`, `MRG_FieldKeepContext`, `MRG_SampleFieldKeepRule`, `MRG_ApexFieldKeepRule_TEST`.

Replaces #59 and #64 (both closed).

Verified: full `force-app` check-only deploy vs `gsgDEV` — Succeeded, 0 component errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)