### PR TITLE
test: broaden LWC Jest coverage (rule editors, pager, preview, suppress)

### DIFF
--- a/force-app/main/default/lwc/autoMergeAccountsRules/__tests__/autoMergeAccountsRules.test.js
+++ b/force-app/main/default/lwc/autoMergeAccountsRules/__tests__/autoMergeAccountsRules.test.js
@@ -1,0 +1,89 @@
+import { createElement } from 'lwc';
+import AutoMergeAccountsRules from 'c/autoMergeAccountsRules';
+
+jest.mock(
+    'lightning/empApi',
+    () => ({ subscribe: jest.fn(() => Promise.resolve({})), onError: jest.fn() }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getObjectFields',
+    () => ({ default: jest.fn(() => Promise.resolve([{ label: 'Email', name: 'Email', type: 'STRING' }])) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getRules',
+    () => ({
+        default: jest.fn(() => Promise.resolve([
+            { id: 'a1', label: 'AMA1', objectName: 'Contact', autoMerge: true, filterLogic: '1', conditions: [{ fieldName: 'Email', operator: 'equals', value: 'x', aggregator: 'all' }] }
+        ]))
+    }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getOperators',
+    () => {
+        const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+        return { default: createApexTestWireAdapter(jest.fn()) };
+    },
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.getAggregators',
+    () => {
+        const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+        return { default: createApexTestWireAdapter(jest.fn()) };
+    },
+    { virtual: true }
+);
+const mockSave = jest.fn(() => Promise.resolve());
+jest.mock(
+    '@salesforce/apex/MRG_AutoMergeAccounts_CTRL.saveRules',
+    () => ({ default: (...args) => mockSave(...args) }),
+    { virtual: true }
+);
+
+function flush() {
+    return Promise.resolve();
+}
+function byLabel(el, tag, label) {
+    return Array.from(el.shadowRoot.querySelectorAll(tag)).find(e => e.label === label);
+}
+
+describe('c-auto-merge-accounts-rules', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    async function renderForContact() {
+        const el = createElement('c-auto-merge-accounts-rules', { is: AutoMergeAccountsRules });
+        document.body.appendChild(el);
+        byLabel(el, 'lightning-combobox', 'Object').dispatchEvent(new CustomEvent('change', { detail: { value: 'Contact' } }));
+        await flush();
+        await flush();
+        await flush();
+        return el;
+    }
+
+    it('strips UI-only keys (incl. condition aggregator/input metadata) on save', async () => {
+        const el = await renderForContact();
+        byLabel(el, 'lightning-button', 'Save').dispatchEvent(new CustomEvent('click'));
+        await flush();
+
+        expect(mockSave).toHaveBeenCalled();
+        const payload = JSON.parse(mockSave.mock.calls[0][0].jsonData);
+        expect(payload).toHaveLength(1);
+        expect(Object.keys(payload[0]).sort()).toEqual(['autoMerge', 'conditions', 'filterLogic', 'id', 'label', 'objectName']);
+        expect(Object.keys(payload[0].conditions[0]).sort()).toEqual(['aggregator', 'fieldName', 'operator', 'value']);
+    });
+
+    it('adds a rule for the selected object', async () => {
+        const el = await renderForContact();
+        byLabel(el, 'lightning-button', 'Add Rule').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(Array.from(el.shadowRoot.querySelectorAll('lightning-input')).some(i => i.label === 'Rule Label')).toBe(true);
+    });
+});

--- a/force-app/main/default/lwc/keepRecordRules/__tests__/keepRecordRules.test.js
+++ b/force-app/main/default/lwc/keepRecordRules/__tests__/keepRecordRules.test.js
@@ -1,0 +1,81 @@
+import { createElement } from 'lwc';
+import KeepRecordRules from 'c/keepRecordRules';
+
+jest.mock(
+    'lightning/empApi',
+    () => ({ subscribe: jest.fn(() => Promise.resolve({})), onError: jest.fn() }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_KeepRecordRules_CTRL.getObjectFields',
+    () => ({ default: jest.fn(() => Promise.resolve([{ label: 'Email', name: 'Email', type: 'STRING' }])) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_KeepRecordRules_CTRL.getKeepRecordRules',
+    () => ({
+        default: jest.fn(() => Promise.resolve([
+            { id: 'r1', label: 'Keep1', objectName: 'Account', order: 1, filterLogic: '1', conditions: [{ fieldName: 'Email', operator: 'equals', value: 'x' }] }
+        ]))
+    }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_KeepRecordRules_CTRL.getOperators',
+    () => {
+        const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+        return { default: createApexTestWireAdapter(jest.fn()) };
+    },
+    { virtual: true }
+);
+const mockSave = jest.fn(() => Promise.resolve());
+jest.mock(
+    '@salesforce/apex/MRG_KeepRecordRules_CTRL.saveKeepRecordRules',
+    () => ({ default: (...args) => mockSave(...args) }),
+    { virtual: true }
+);
+
+function flush() {
+    return Promise.resolve();
+}
+function byLabel(el, tag, label) {
+    return Array.from(el.shadowRoot.querySelectorAll(tag)).find(e => e.label === label);
+}
+
+describe('c-keep-record-rules', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    async function renderForAccount() {
+        const el = createElement('c-keep-record-rules', { is: KeepRecordRules });
+        document.body.appendChild(el);
+        byLabel(el, 'lightning-combobox', 'Object').dispatchEvent(new CustomEvent('change', { detail: { value: 'Account' } }));
+        await flush();
+        await flush();
+        await flush();
+        return el;
+    }
+
+    it('strips UI-only keys from the payload sent to Apex on save', async () => {
+        const el = await renderForAccount();
+        byLabel(el, 'lightning-button', 'Save').dispatchEvent(new CustomEvent('click'));
+        await flush();
+
+        expect(mockSave).toHaveBeenCalled();
+        const payload = JSON.parse(mockSave.mock.calls[0][0].jsonData);
+        expect(payload).toHaveLength(1);
+        expect(Object.keys(payload[0]).sort()).toEqual(['conditions', 'filterLogic', 'id', 'label', 'objectName', 'order']);
+        expect(Object.keys(payload[0].conditions[0]).sort()).toEqual(['fieldName', 'operator', 'value']);
+    });
+
+    it('adds a rule for the selected object', async () => {
+        const el = await renderForAccount();
+        byLabel(el, 'lightning-button', 'Add Rule').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(Array.from(el.shadowRoot.querySelectorAll('lightning-input')).some(i => i.label === 'Rule Label')).toBe(true);
+    });
+});

--- a/force-app/main/default/lwc/mergePreview/__tests__/mergePreview.test.js
+++ b/force-app/main/default/lwc/mergePreview/__tests__/mergePreview.test.js
@@ -1,0 +1,66 @@
+import { createElement } from 'lwc';
+import MergePreview from 'c/mergePreview';
+import getPreviewRecord from '@salesforce/apex/MRG_Preview_CTRL.getPreviewRecord';
+
+jest.mock(
+    'lightning/empApi',
+    () => ({
+        subscribe: jest.fn(() => Promise.resolve({})),
+        unsubscribe: jest.fn(() => Promise.resolve({})),
+        onError: jest.fn(),
+        setDebugFlag: jest.fn(),
+        isEmpEnabled: jest.fn(() => Promise.resolve(true))
+    }),
+    { virtual: true }
+);
+jest.mock(
+    'lightning/uiRecordApi',
+    () => ({ updateRecord: jest.fn(() => Promise.resolve()) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_Preview_CTRL.getPreviewRecord',
+    () => {
+        const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+        return { default: createApexTestWireAdapter(jest.fn()) };
+    },
+    { virtual: true }
+);
+
+const RECORD = {
+    recordId: 'mc1',
+    keepRecord: { Id: '001A', Name: 'Acme', Phone: '111' },
+    mergeRecord1: { Id: '001B', Name: 'Acme 2', Phone: '222' },
+    mergeResultRecord: { Id: '001A', Name: 'Acme', Phone: '111' },
+    fields: ['Phone', 'Name'],
+    previewFields: [],
+    mergeCandidate: { KeepName__c: 'Acme', MergeName__c: 'Acme 2', Status__c: 'New' }
+};
+
+function flush() {
+    return Promise.resolve();
+}
+
+describe('c-merge-preview', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('builds the comparison table (field + keep + merge + result columns, one row per field)', async () => {
+        const el = createElement('c-merge-preview', { is: MergePreview });
+        el.recordId = 'mc1';
+        document.body.appendChild(el);
+        getPreviewRecord.emit(RECORD);
+        await flush();
+        await flush();
+
+        const table = el.shadowRoot.querySelector('c-custom-datatable');
+        expect(table).not.toBeNull();
+        // fieldname + keepRecord + mergeRecord1 + mergeResultRecord (no merge2 for a pair)
+        expect(table.columns.length).toBe(4);
+        expect(table.data.length).toBe(2); // one row per previewed field
+    });
+});

--- a/force-app/main/default/lwc/mergeRecordList/__tests__/mergeRecordList.test.js
+++ b/force-app/main/default/lwc/mergeRecordList/__tests__/mergeRecordList.test.js
@@ -1,0 +1,87 @@
+import { createElement } from 'lwc';
+import MergeRecordList from 'c/mergeRecordList';
+import getFieldSettings from '@salesforce/apex/MRG_MergeSettings_CTRL.getAllMergeFields';
+
+jest.mock(
+    'lightning/empApi',
+    () => ({
+        subscribe: jest.fn(() => Promise.resolve({})),
+        unsubscribe: jest.fn(() => Promise.resolve({})),
+        onError: jest.fn(),
+        setDebugFlag: jest.fn(),
+        isEmpEnabled: jest.fn(() => Promise.resolve(true))
+    }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_MergeSettings_CTRL.getAllMergeFields',
+    () => {
+        const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+        return { default: createApexTestWireAdapter(jest.fn()) };
+    },
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_MergeSettings_CTRL.saveMergeFields',
+    () => ({ default: jest.fn(() => Promise.resolve()) }),
+    { virtual: true }
+);
+
+const ROWS = [
+    { id: '1', name: 'EmailContact', label: 'Email', objectName: 'Contact', fieldName: 'Email', type: 'p', rule: 'Newest', relatedField: null, disable: false, conditions: [] },
+    { id: '2', name: 'PhoneContact', label: 'Phone', objectName: 'Contact', fieldName: 'Phone', type: 't', rule: null, relatedField: null, disable: false, conditions: [] }
+];
+
+function flush() {
+    return Promise.resolve();
+}
+function rowEls(el) {
+    return el.shadowRoot.querySelectorAll('c-merge-single-record');
+}
+function addButton(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('lightning-button')).find(b => b.label === 'Add New Merge Field');
+}
+
+describe('c-merge-record-list', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    async function render() {
+        const el = createElement('c-merge-record-list', { is: MergeRecordList });
+        document.body.appendChild(el);
+        getFieldSettings.emit(ROWS);
+        await flush();
+        await flush();
+        return el;
+    }
+
+    it('renders one row per merge field setting', async () => {
+        const el = await render();
+        expect(rowEls(el).length).toBe(2);
+    });
+
+    it('cancelling an added field removes the empty placeholder row', async () => {
+        const el = await render();
+        addButton(el).dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(rowEls(el).length).toBe(3);
+
+        rowEls(el)[2].dispatchEvent(new CustomEvent('notify', { detail: { actionType: 'cancel' } }));
+        await flush();
+
+        expect(rowEls(el).length).toBe(2); // regression: placeholder used to linger
+    });
+
+    it('adding twice does not stack two placeholder rows', async () => {
+        const el = await render();
+        addButton(el).dispatchEvent(new CustomEvent('click'));
+        await flush();
+        addButton(el).dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(rowEls(el).length).toBe(3);
+    });
+});

--- a/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
@@ -1,0 +1,62 @@
+import { createElement } from 'lwc';
+import MergeSingleRecord from 'c/mergeSingleRecord';
+
+function flush() {
+    return Promise.resolve();
+}
+function hasButton(el, label) {
+    return Array.from(el.shadowRoot.querySelectorAll('lightning-button')).some(b => b.label === label);
+}
+function hasInput(el, label) {
+    return Array.from(el.shadowRoot.querySelectorAll('lightning-input')).some(i => i.label === label);
+}
+
+async function renderWithRule(rule) {
+    const el = createElement('c-merge-single-record', { is: MergeSingleRecord });
+    el.usedFields = [];
+    // name includes TEMP -> edit mode; type 'p' -> preserve, so the rule config sections can show
+    el.record = { name: 'TEMPx', type: 'p', rule, objectName: 'Contact', fieldName: 'Email', conditions: [], filterLogic: '', tieBreakDirection: 'DESC' };
+    document.body.appendChild(el);
+    await flush();
+    return el;
+}
+
+describe('c-merge-single-record', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    it('reveals the Complex condition builder when the rule is Complex', async () => {
+        const el = await renderWithRule('Complex');
+        expect(hasButton(el, 'Add Condition')).toBe(true);
+    });
+
+    it('reveals the substring input when the rule is Contains', async () => {
+        const el = await renderWithRule('Contains');
+        expect(hasInput(el, 'Contains Value')).toBe(true);
+    });
+
+    it('reveals the Apex Class input when the rule is Apex Defined', async () => {
+        const el = await renderWithRule('Apex Defined');
+        expect(hasInput(el, 'Apex Class')).toBe(true);
+    });
+
+    it('shows no rule config for a simple rule', async () => {
+        const el = await renderWithRule('Newest');
+        expect(hasButton(el, 'Add Condition')).toBe(false);
+        expect(hasInput(el, 'Contains Value')).toBe(false);
+        expect(hasInput(el, 'Apex Class')).toBe(false);
+    });
+
+    it('dispatches a save notify when Save is clicked', async () => {
+        const el = await renderWithRule('Newest');
+        const handler = jest.fn();
+        el.addEventListener('notify', handler);
+        Array.from(el.shadowRoot.querySelectorAll('lightning-button')).find(b => b.label === 'Save').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(handler).toHaveBeenCalled();
+        expect(handler.mock.calls[0][0].detail.actionType).toBe('save');
+    });
+});

--- a/force-app/main/default/lwc/pager/__tests__/pager.test.js
+++ b/force-app/main/default/lwc/pager/__tests__/pager.test.js
@@ -1,0 +1,55 @@
+import { createElement } from 'lwc';
+import Pager from 'c/pager';
+
+function flush() {
+    return Promise.resolve();
+}
+function pageButtons(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('button.page-index'));
+}
+
+describe('c-pager', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    async function render(totalPages, currentPage) {
+        const el = createElement('c-pager', { is: Pager });
+        el.totalPages = totalPages;
+        el.currentPage = currentPage;
+        document.body.appendChild(el);
+        await flush();
+        return el;
+    }
+
+    it('hides the pager when there is a single page', async () => {
+        const el = await render(1, 1);
+        expect(pageButtons(el).length).toBe(0);
+    });
+
+    it('renders a button per page and disables the current page', async () => {
+        const el = await render(3, 1);
+        const pages = pageButtons(el);
+        expect(pages.length).toBe(3);
+        expect(pages.find(b => Number(b.value) === 1).disabled).toBe(true);
+    });
+
+    it('fires a page event with the selected page number', async () => {
+        const el = await render(3, 1);
+        const handler = jest.fn();
+        el.addEventListener('page', handler);
+        pageButtons(el).find(b => Number(b.value) === 2).dispatchEvent(new CustomEvent('click'));
+        expect(handler.mock.calls[0][0].detail).toBe(2);
+    });
+
+    it('Next advances to the following page', async () => {
+        const el = await render(3, 1);
+        const handler = jest.fn();
+        el.addEventListener('page', handler);
+        // only Next renders on the first page
+        el.shadowRoot.querySelector('lightning-button-icon').dispatchEvent(new CustomEvent('click'));
+        expect(handler.mock.calls[0][0].detail).toBe(2);
+    });
+});

--- a/force-app/main/default/lwc/previewFields/__tests__/previewFields.test.js
+++ b/force-app/main/default/lwc/previewFields/__tests__/previewFields.test.js
@@ -29,6 +29,12 @@ jest.mock(
     () => ({ default: jest.fn(() => Promise.resolve()) }),
     { virtual: true }
 );
+const mockSuppress = jest.fn(() => Promise.resolve('job-id'));
+jest.mock(
+    '@salesforce/apex/MRG_MergeSettings_CTRL.suppressPreviewFields',
+    () => ({ default: (...args) => mockSuppress(...args) }),
+    { virtual: true }
+);
 
 const ROWS = [
     { id: 'a', label: 'Phone', name: 'PhoneContact', objectName: 'Contact', fieldName: 'Phone', hidden: true },
@@ -88,5 +94,46 @@ describe('c-preview-fields', () => {
         addButton(el).dispatchEvent(new CustomEvent('click'));
         await flush();
         expect(rowEls(el).length).toBe(3); // a single placeholder, not two
+    });
+
+    // ---- bulk "suppress a list of fields" modal ----
+    const opener = el => Array.from(el.shadowRoot.querySelectorAll('lightning-button')).find(b => b.label === 'Suppress a List of Fields');
+    // base-component attributes aren't reflected to the DOM in the stubs, so select by label/type
+    const combobox = el => Array.from(el.shadowRoot.querySelectorAll('lightning-combobox')).find(c => c.label === 'Object');
+    const textarea = el => el.shadowRoot.querySelector('lightning-textarea');
+    const submit = el => Array.from(el.shadowRoot.querySelectorAll('button')).find(b => b.textContent.trim() === 'Suppress Fields');
+
+    it('requires an object and field list before the suppress submit is enabled', async () => {
+        const el = await render();
+        opener(el).dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(combobox(el)).not.toBeNull(); // modal open
+        expect(submit(el).disabled).toBe(true); // nothing entered
+
+        combobox(el).dispatchEvent(new CustomEvent('change', { detail: { value: 'Account' } }));
+        await flush();
+        expect(submit(el).disabled).toBe(true); // object only, still no fields
+
+        const ta = textarea(el);
+        ta.value = 'Phone, Fax';
+        ta.dispatchEvent(new CustomEvent('change'));
+        await flush();
+        expect(submit(el).disabled).toBe(false); // both set
+    });
+
+    it('submits the comma-delimited list to suppressPreviewFields', async () => {
+        const el = await render();
+        opener(el).dispatchEvent(new CustomEvent('click'));
+        await flush();
+        combobox(el).dispatchEvent(new CustomEvent('change', { detail: { value: 'Account' } }));
+        const ta = textarea(el);
+        ta.value = 'Phone, Fax';
+        ta.dispatchEvent(new CustomEvent('change'));
+        await flush();
+
+        submit(el).dispatchEvent(new CustomEvent('click'));
+        await flush();
+
+        expect(mockSuppress).toHaveBeenCalledWith({ objectType: 'Account', fieldNames: 'Phone, Fax' });
     });
 });


### PR DESCRIPTION
Broadens the LWC Jest suite across the components that had no coverage. **28 tests / 10 suites, all green** (`npm run test:unit`).

**List editors (cancel/empty-row regression trio):**
- `mergeRecordList`, `previewFields`, `dupeRuleList` — render-per-row, cancel removes the placeholder, double-add doesn't stack.

**Rule editors:**
- `mergeSingleRecord` — reveals the correct config per rule (Complex / Contains / Apex Defined), none for simple rules; Save fires `notify`.
- `keepRecordRules` + `autoMergeAccountsRules` — `handleSave` strips UI-only keys so the Apex payload is clean (asserts rule + condition shapes).

**Other:**
- `previewFields` suppress modal (#66) — object+fields required before submit; submits the comma list to `suppressPreviewFields`.
- `dupeList` — keep-group renders a row per pair; merging removes only that pair.
- `pager` — page buttons, current-page disabled, page/Next events.
- `mergePreview` — builds the field comparison table from the preview record.
- `customDatatable` — real mount assertion (replaced the stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)