### PR TITLE
chore: release 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The Merge Control app provides SF Administrators with the following tools relate
 
 ## Installation
 
-Current release: **2.2.0** (unlocked package, `04tKb000000EgynIAC`)
+Current release: **2.3.0** (unlocked package, `04tKb000000EgysIAC`)
 
 Install via URL:
-- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgynIAC
-- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgynIAC
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgysIAC
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgysIAC
 
 Or with the Salesforce CLI:
 
 ```
-sf package install --package 04tKb000000EgynIAC --target-org <org-alias> --wait 10
+sf package install --package 04tKb000000EgysIAC --target-org <org-alias> --wait 10
 ```
 
 After installing, assign the **Merge Control Administrator** permission set to administrators.

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.2",
-      "versionNumber": "2.2.0.NEXT"
+      "versionName": "ver 2.3",
+      "versionNumber": "2.3.0.NEXT"
     }
   ],
   "namespace": "",
@@ -16,6 +16,7 @@
     "merge@2.0.0-1": "04tKb000000EgyJIAS",
     "merge@2.0.0-2": "04tKb000000EgyOIAS",
     "merge@2.1.0-1": "04tKb000000EgydIAC",
-    "merge@2.2.0-1": "04tKb000000EgynIAC"
+    "merge@2.2.0-1": "04tKb000000EgynIAC",
+    "merge@2.3.0-1": "04tKb000000EgysIAC"
   }
 }


### PR DESCRIPTION
Release **2.3.0** (unlocked, promoted): `04tKb000000EgysIAC`.

Bumps `versionNumber` to `2.3.0.NEXT`, records alias `merge@2.3.0-1`, updates README.

**Verification:** real deploy to `gsgDEV` (158 components, 0 errors); full MRG Apex suite **140/140 pass, 92% org coverage, 0 classes <75%**; LWC Jest **28/28**. Package version built with code coverage (91%) and promoted.

**Since 2.2.0:** Apex Defined field-keep rule (#63); Longest/Shortest/Contains preservation rules + cancel/empty-row fix (#65); bulk-suppress preview fields (#66); permission-set class access (#67); LWC Jest suite (#68, #69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)