### PR TITLE
feat: field autocomplete, Complex tie-break, multipicklist combine + merge-preview enhancements

### DIFF
--- a/force-app/main/default/classes/MRG_CombineMultiPicklist_TEST.cls
+++ b/force-app/main/default/classes/MRG_CombineMultiPicklist_TEST.cls
@@ -1,0 +1,31 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description unit tests for the multipicklist Combine preservation rule helpers
+*/
+@isTest
+private class MRG_CombineMultiPicklist_TEST {
+
+	static testMethod void testCombineUnionsAndDedupes() {
+		system.assertEquals('A;B;C', (String) MRG_Merge_SVC.combineMultiPicklist('A;B', 'B;C'),
+			'union de-duplicates shared values, preserving order');
+	}
+
+	static testMethod void testCombineTrimsAndDropsBlanks() {
+		system.assertEquals('A;B;C', (String) MRG_Merge_SVC.combineMultiPicklist(' A ; B ', 'B; C ;'),
+			'values are trimmed and empty segments dropped');
+	}
+
+	static testMethod void testCombineHandlesNulls() {
+		system.assertEquals('A;B', (String) MRG_Merge_SVC.combineMultiPicklist('A;B', null), 'null merge value -> keep value');
+		system.assertEquals('X', (String) MRG_Merge_SVC.combineMultiPicklist(null, 'X'), 'null keep value -> merge value');
+		system.assertEquals('', (String) MRG_Merge_SVC.combineMultiPicklist(null, null), 'both null -> empty');
+	}
+
+	static testMethod void testIsMultiPicklistFalseForOtherTypes() {
+		system.assertEquals(false, MRG_Merge_SVC.isMultiPicklist('Contact', 'Email'), 'Email is not a multipicklist');
+		system.assertEquals(false, MRG_Merge_SVC.isMultiPicklist('Contact', 'NoSuchField__x'), 'unknown field -> false');
+		system.assertEquals(false, MRG_Merge_SVC.isMultiPicklist('NoSuchObject__x', 'Email'), 'unknown object -> false');
+		system.assertEquals(false, MRG_Merge_SVC.isMultiPicklist('Contact', ''), 'blank field -> false');
+	}
+}

--- a/force-app/main/default/classes/MRG_CombineMultiPicklist_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_CombineMultiPicklist_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>38.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MRG_ComplexPreserveRule.cls
+++ b/force-app/main/default/classes/MRG_ComplexPreserveRule.cls
@@ -15,8 +15,9 @@ public with sharing class MRG_ComplexPreserveRule {
 	@auraEnabled public String fieldName;          // the field whose value is preserved
 	@auraEnabled public String filterLogic;        // report-style logic over the conditions
 	@auraEnabled public List<MRG_KeepRecordRule.condition> conditions;
-	@auraEnabled public String tieBreakField;      // field used to rank matching records
-	@auraEnabled public String tieBreakDirection;  // 'ASC' or 'DESC' (default DESC)
+	@auraEnabled public String tieBreakField;      // field used to rank matching records (secondary)
+	@auraEnabled public String tieBreakDirection;  // 'ASC' or 'DESC' (default DESC) for the field
+	@auraEnabled public String tieBreakRule;       // primary tie-break: a standard preservation rule
 
 	public MRG_ComplexPreserveRule() {
 		this.conditions = new List<MRG_KeepRecordRule.condition>();
@@ -78,15 +79,38 @@ public with sharing class MRG_ComplexPreserveRule {
 			return null;
 		if(matches.size() == 1)
 			return matches[0];
-		// rank the matches by the tie-break field; default to created order when none is set
+		// rank by the primary tie-break rule (when set), then by the secondary tie-break field+direction
+		Boolean hasPrimary = String.isNotBlank(tieBreakRule);
+		Boolean primaryDesc = primaryDescending();
+		Boolean primaryByLength = isLengthRule();
+		Boolean secondaryDesc = tieBreakDirection == null || tieBreakDirection.equalsIgnoreCase('DESC');
 		List<rankedRecord> ranked = new List<rankedRecord>();
-		Boolean descending = tieBreakDirection == null || tieBreakDirection.equalsIgnoreCase('DESC');
 		for(SObject record:matches) {
-			Object val = String.isNotBlank(tieBreakField) ? record.get(tieBreakField) : null;
-			ranked.add(new rankedRecord(record, val, descending));
+			Object primaryVal = hasPrimary ? primaryRankValue(record) : null;
+			Object secondaryVal = String.isNotBlank(tieBreakField) ? record.get(tieBreakField) : null;
+			ranked.add(new rankedRecord(record, hasPrimary, primaryVal, primaryDesc, primaryByLength, secondaryVal, secondaryDesc));
 		}
 		ranked.sort();
 		return ranked[0].record;
+	}
+
+	/*******************************************************************************************************
+	* @description the value the primary rule ranks on: CreatedDate for Oldest/Newest, otherwise the
+	* tie-break field value (Largest/Smallest compare value, Longest/Shortest compare text length)
+	*/
+	private Object primaryRankValue(SObject record) {
+		String rule = tieBreakRule == null ? '' : tieBreakRule.toLowerCase();
+		if(rule == 'newest' || rule == 'oldest')
+			return record.get('CreatedDate');
+		return String.isNotBlank(tieBreakField) ? record.get(tieBreakField) : null;
+	}
+	private Boolean primaryDescending() {
+		String rule = tieBreakRule == null ? '' : tieBreakRule.toLowerCase();
+		return rule == 'newest' || rule == 'largest' || rule == 'longest';
+	}
+	private Boolean isLengthRule() {
+		String rule = tieBreakRule == null ? '' : tieBreakRule.toLowerCase();
+		return rule == 'longest' || rule == 'shortest';
 	}
 
 	/*******************************************************************************************************
@@ -105,45 +129,68 @@ public with sharing class MRG_ComplexPreserveRule {
 	*/
 	private class rankedRecord implements Comparable {
 		public SObject record;
-		Object value;
-		Boolean descending;
+		Boolean hasPrimary;
+		Object primaryVal;
+		Boolean primaryDesc;
+		Boolean primaryByLength;
+		Object secondaryVal;
+		Boolean secondaryDesc;
 
-		public rankedRecord(SObject record, Object value, Boolean descending) {
+		public rankedRecord(SObject record, Boolean hasPrimary, Object primaryVal, Boolean primaryDesc, Boolean primaryByLength, Object secondaryVal, Boolean secondaryDesc) {
 			this.record = record;
-			this.value = value;
-			this.descending = descending;
+			this.hasPrimary = hasPrimary;
+			this.primaryVal = primaryVal;
+			this.primaryDesc = primaryDesc;
+			this.primaryByLength = primaryByLength;
+			this.secondaryVal = secondaryVal;
+			this.secondaryDesc = secondaryDesc;
 		}
 
 		public Integer compareTo(Object compareTo) {
 			rankedRecord other = (rankedRecord) compareTo;
-			Integer cmp = compareValues(this.value, other.value);
-			return descending ? -cmp : cmp;
+			if(hasPrimary) {
+				Integer p = directedCompare(this.primaryVal, other.primaryVal, this.primaryDesc, this.primaryByLength);
+				if(p != 0)
+					return p;
+			}
+			return directedCompare(this.secondaryVal, other.secondaryVal, this.secondaryDesc, false);
 		}
+	}
 
-		// nulls sort last (so a present value wins regardless of direction-flip); otherwise compare by
-		// the runtime type, falling back to string comparison
-		private Integer compareValues(Object a, Object b) {
-			if(a == null && b == null) return 0;
-			if(a == null) return descending ? -1 : 1;   // a (null) should rank after b
-			if(b == null) return descending ? 1 : -1;   // b (null) should rank after a
-			String type = MRG_Merge_SVC.getObjectType(a);
-			switch on type {
-				when 'Date' {
-					Date da = (Date) a, db = (Date) b;
-					return da == db ? 0 : (da > db ? 1 : -1);
-				}
-				when 'Datetime' {
-					Datetime da = (Datetime) a, db = (Datetime) b;
-					return da == db ? 0 : (da > db ? 1 : -1);
-				}
-				when 'Integer', 'Long', 'Decimal', 'Double' {
-					Decimal da = Decimal.valueOf(String.valueOf(a)), db = Decimal.valueOf(String.valueOf(b));
-					return da == db ? 0 : (da > db ? 1 : -1);
-				}
-				when else {
-					String sa = String.valueOf(a), sb = String.valueOf(b);
-					return sa == sb ? 0 : (sa > sb ? 1 : -1);
-				}
+	/*******************************************************************************************************
+	* @description directional compare with nulls always last; by text length when byLength, else by value
+	*/
+	private static Integer directedCompare(Object a, Object b, Boolean descending, Boolean byLength) {
+		if(a == null && b == null) return 0;
+		if(a == null) return 1;   // nulls rank last regardless of direction
+		if(b == null) return -1;
+		Integer raw = byLength ? compareLengths(a, b) : compareValues(a, b);
+		return descending ? -raw : raw;
+	}
+	private static Integer compareLengths(Object a, Object b) {
+		Integer la = String.valueOf(a).length();
+		Integer lb = String.valueOf(b).length();
+		return la == lb ? 0 : (la > lb ? 1 : -1);
+	}
+	// raw type-aware compare of two non-null values: +1 if a>b, -1 if a<b, 0 if equal
+	private static Integer compareValues(Object a, Object b) {
+		String type = MRG_Merge_SVC.getObjectType(a);
+		switch on type {
+			when 'Date' {
+				Date da = (Date) a, db = (Date) b;
+				return da == db ? 0 : (da > db ? 1 : -1);
+			}
+			when 'Datetime' {
+				Datetime da = (Datetime) a, db = (Datetime) b;
+				return da == db ? 0 : (da > db ? 1 : -1);
+			}
+			when 'Integer', 'Long', 'Decimal', 'Double' {
+				Decimal da = Decimal.valueOf(String.valueOf(a)), db = Decimal.valueOf(String.valueOf(b));
+				return da == db ? 0 : (da > db ? 1 : -1);
+			}
+			when else {
+				String sa = String.valueOf(a), sb = String.valueOf(b);
+				return sa == sb ? 0 : (sa > sb ? 1 : -1);
 			}
 		}
 	}

--- a/force-app/main/default/classes/MRG_ComplexPreserveRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_ComplexPreserveRule_TEST.cls
@@ -91,6 +91,63 @@ private class MRG_ComplexPreserveRule_TEST {
 		system.assertEquals('has-date', (String) rule.winningValue(recs), 'record with a tie-break value should win over a null');
 	}
 
+	// build a Contact with a read-only CreatedDate set (via JSON) for Oldest/Newest tie-break tests
+	private static Contact contactWithCreated(String last, Boolean optedOut, String street, Datetime created, Date bday) {
+		Map<String, Object> m = new Map<String, Object>{
+			'attributes' => new Map<String, Object>{ 'type' => 'Contact' },
+			'LastName' => last,
+			'HasOptedOutOfEmail' => optedOut,
+			'MailingStreet' => street,
+			'CreatedDate' => created,
+			'Birthdate' => bday
+		};
+		return (Contact) JSON.deserialize(JSON.serialize(m), Contact.class);
+	}
+
+	static testMethod void testTieBreakRuleLargest() {
+		List<Account> recs = new List<Account>{
+			new Account(Name='small', NumberOfEmployees=10),
+			new Account(Name='big', NumberOfEmployees=500)
+		};
+		MRG_ComplexPreserveRule rule = new MRG_ComplexPreserveRule();
+		rule.fieldName = 'Name';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('NumberOfEmployees','greaterThan','0') };
+		rule.tieBreakRule = 'Largest';
+		rule.tieBreakField = 'NumberOfEmployees';
+		system.assertEquals('big', (String) rule.winningValue(recs), 'Largest rule picks the larger NumberOfEmployees');
+	}
+
+	static testMethod void testTieBreakRuleLongest() {
+		List<Contact> recs = new List<Contact>{
+			new Contact(LastName='A', HasOptedOutOfEmail=true, MailingStreet='123 Main Street, Suite 400'),
+			new Contact(LastName='B', HasOptedOutOfEmail=true, MailingStreet='1 Elm')
+		};
+		MRG_ComplexPreserveRule rule = new MRG_ComplexPreserveRule();
+		rule.fieldName = 'LastName';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.tieBreakRule = 'Longest';
+		rule.tieBreakField = 'MailingStreet';
+		system.assertEquals('A', (String) rule.winningValue(recs), 'Longest rule picks the record with the longer MailingStreet');
+	}
+
+	static testMethod void testTieBreakRuleThenSecondaryField() {
+		Datetime same = Datetime.newInstance(2020, 1, 1, 0, 0, 0);
+		List<Contact> recs = new List<Contact>{
+			contactWithCreated('A', true, 'a', same, Date.newInstance(1980,1,1)),
+			contactWithCreated('B', true, 'b', same, Date.newInstance(2000,1,1))
+		};
+		MRG_ComplexPreserveRule rule = new MRG_ComplexPreserveRule();
+		rule.fieldName = 'MailingStreet';
+		rule.filterLogic = '1';
+		rule.conditions = new List<MRG_KeepRecordRule.condition>{ cond('HasOptedOutOfEmail','equals','true') };
+		rule.tieBreakRule = 'Newest';       // primary: CreatedDate (tied here)
+		rule.tieBreakField = 'Birthdate';   // secondary
+		rule.tieBreakDirection = 'DESC';
+		system.assertEquals('b', (String) rule.winningValue(recs), 'CreatedDate tie falls back to the secondary Birthdate DESC');
+	}
+
 	static testMethod void testEmptyConditionsNeverMatch() {
 		MRG_ComplexPreserveRule rule = new MRG_ComplexPreserveRule();
 		rule.fieldName = 'MailingStreet';

--- a/force-app/main/default/classes/MRG_Duplicate_SVC.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_SVC.cls
@@ -193,10 +193,11 @@ public with sharing class MRG_Duplicate_SVC {
                 if(String.isNotBlank(f)) fields.add(f.trim().toLowerCase());
             }
         }
-        // Id and CreatedDate are always present; remove to avoid duplicates then prepend
+        // Id, CreatedDate and LastModifiedDate are always present; remove to avoid duplicates then prepend
         fields.remove('id');
         fields.remove('createddate');
-        String soqlQuery = 'SELECT Id, CreatedDate';
+        fields.remove('lastmodifieddate');
+        String soqlQuery = 'SELECT Id, CreatedDate, LastModifiedDate';
         if(!fields.isEmpty())
             soqlQuery += ', ' + String.join(new List<String>(fields), ',');
         soqlQuery += ' FROM '+objectType;

--- a/force-app/main/default/classes/MRG_MergeCandidate.cls
+++ b/force-app/main/default/classes/MRG_MergeCandidate.cls
@@ -30,6 +30,11 @@ public with sharing class MRG_MergeCandidate {
     */
     @AuraEnabled public List<String> fields;
 
+    /***
+    * @description collection of fields whose values match across all records (hidden by default in the preview)
+    */
+    @AuraEnabled public List<String> matchingFields;
+
     @AuraEnabled public String status;
 
     @AuraEnabled public MergeCandidate__c mergeCandidate;

--- a/force-app/main/default/classes/MRG_MergeCandidate_SVC.cls
+++ b/force-app/main/default/classes/MRG_MergeCandidate_SVC.cls
@@ -39,6 +39,7 @@ public with sharing class MRG_MergeCandidate_SVC {
         MRG_Merge_SVC.mergeHistoryResult mergeResult = MRG_Merge_SVC.getMergeHistoryResult(new List<MergeCandidate__c>{candidate},objectType);
         Map<String, Schema.SObjectField> fieldmap = Schema.getGlobalDescribe().get(objectType).getDescribe().fields.getMap();
         Set<String> fieldDifferences = new Set<String>();
+        Set<String> matchingFields = new Set<String>();
         Set<String> writeableFields = MRG_Merge_SVC.getWriteableFields(objectType);
         Map<Id, SObject> objectMap = mergeResult.objectMap;
         SObject keepRecord;
@@ -67,6 +68,18 @@ public with sharing class MRG_MergeCandidate_SVC {
             }
         }
 
-        return new MRG_MergeCandidate(candidate,keepRecord,mergeRecords,mergeResult,fieldDifferences);
+        // fields that are the same across all records (and have a value to show) are hidden in the
+        // preview by default; surface them so the UI can reveal them on demand
+        if(keepRecord != null) {
+            for(String field:writeableFields){
+                String fieldApiName = fieldmap.containsKey(field) ? fieldmap.get(field).getDescribe().getName() : field;
+                if(!fieldDifferences.contains(fieldApiName) && keepRecord.get(field) != null)
+                    matchingFields.add(fieldApiName);
+            }
+        }
+
+        MRG_MergeCandidate result = new MRG_MergeCandidate(candidate,keepRecord,mergeRecords,mergeResult,fieldDifferences);
+        result.matchingFields = new List<String>(matchingFields);
+        return result;
     }
 }

--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -169,6 +169,7 @@ public with sharing class MRG_Merge_SVC {
 		@auraEnabled public List<MRG_KeepRecordRule.condition> conditions;
 		@auraEnabled public String tieBreakField;
 		@auraEnabled public String tieBreakDirection;
+		@auraEnabled public String tieBreakRule;
 		// optional fallback target: the losing value for this field is written here (if empty)
 		@auraEnabled public String fallbackField;
 		// for rule == 'Apex Defined': the MRG_FieldKeepRule implementation that decides this field
@@ -192,6 +193,7 @@ public with sharing class MRG_Merge_SVC {
 				: new List<MRG_KeepRecordRule.condition>();
 			this.tieBreakField = mergeField.TieBreakField__r != null ? mergeField.TieBreakField__r.QualifiedAPIName : null;
 			this.tieBreakDirection = mergeField.TieBreakDirection__c;
+			this.tieBreakRule = mergeField.TieBreakRule__c;
 			this.fallbackField = mergeField.FallbackField__r != null ? mergeField.FallbackField__r.QualifiedAPIName : null;
 			this.apexClass = mergeField.ApexClass__c;
 			this.containsValue = mergeField.ContainsValue__c;
@@ -251,6 +253,7 @@ public with sharing class MRG_Merge_SVC {
 			FilterLogic__c = mfw.filterLogic,
 			Conditions__c = mfw.conditions != null && !mfw.conditions.isEmpty() ? JSON.serialize(mfw.conditions) : null,
 			TieBreakDirection__c = mfw.tieBreakDirection,
+			TieBreakRule__c = mfw.tieBreakRule,
 			ApexClass__c = mfw.apexClass,
 			ContainsValue__c = mfw.containsValue
 		);
@@ -335,6 +338,7 @@ public with sharing class MRG_Merge_SVC {
 					TieBreakField__r.QualifiedAPIName,
 					FallbackField__r.QualifiedAPIName,
 					TieBreakDirection__c,
+					TieBreakRule__c,
 					FilterLogic__c,
 					Conditions__c,
 					Type__c,
@@ -623,6 +627,7 @@ public with sharing class MRG_Merge_SVC {
 				rule.conditions = mfw.conditions == null ? new List<MRG_KeepRecordRule.condition>() : mfw.conditions;
 				rule.tieBreakField = mfw.tieBreakField;
 				rule.tieBreakDirection = mfw.tieBreakDirection;
+				rule.tieBreakRule = mfw.tieBreakRule;
 				complexRules.add(rule);
 			}
 		}
@@ -879,12 +884,24 @@ public with sharing class MRG_Merge_SVC {
 					if(mergeRecordFieldValue!= null) {
 						// if we should preserve thie value then preserve it
 						if(preserveField != null) {
-							if(isChild && masterFieldIsKept){
+							if(preserveField.rule != null && preserveField.rule.equalsIgnoreCase('Combine')) {
+								// union the multi-select picklist values across the records (only for a multipicklist)
+								if(isMultiPicklist(objectType, fieldName)) {
+									Object combined = combineMultiPicklist(keptRecordfieldValue, mergeRecordFieldValue);
+									if(!valuesAreEqual(combined, keptRecordfieldValue)) {
+										keepValue = combined;
+										mergeValue = mergeRecordFieldValue;
+										keptRec.put(fieldName, keepValue);
+										hasChange = true;
+										mergedFieldIsKept = true;
+									}
+								}
+							} else if(isChild && masterFieldIsKept){
 								keepValue = mergeRecordFieldValue;
 								mergeValue = keptRecordfieldValue;
 								keptRec.put(fieldName,keepValue);
 								hasChange=true;
-								mergedFieldIsKept=true;								
+								mergedFieldIsKept=true;
 							} else if(testValue(mergeRecordFieldValue, keptRecordfieldValue, preserveField.rule, keptRecordIsOlder, preserveField.containsValue)) {
 								keepValue = mergeRecordFieldValue;
 								mergeValue = keptRecordfieldValue;
@@ -1066,6 +1083,41 @@ public with sharing class MRG_Merge_SVC {
 				writeableFields.add(fieldRef.getDescribe().getName().toLowerCase());
 		}
 		return writeableFields;
+	}
+	/*******************************************************************************************************
+	* @description whether a field on an object is a multi-select picklist
+	* @param objectType the SObject api name
+	* @param fieldName the field api name (case-insensitive)
+	* @return Boolean
+	*/
+	public static Boolean isMultiPicklist(String objectType, String fieldName) {
+		SObjectType objType = Schema.getGlobalDescribe().get(objectType);
+		if(objType == null || String.isBlank(fieldName))
+			return false;
+		Schema.SObjectField field = objType.getDescribe().fields.getMap().get(fieldName.toLowerCase());
+		return field != null && field.getDescribe().getType() == Schema.DisplayType.MULTIPICKLIST;
+	}
+	/*******************************************************************************************************
+	* @description unions two semicolon-delimited multipicklist values, de-duplicated, preserving order
+	* @param keepVal the surviving record's value
+	* @param mergeVal the merged record's value
+	* @return String the combined value
+	*/
+	public static Object combineMultiPicklist(Object keepVal, Object mergeVal) {
+		List<String> combined = new List<String>();
+		Set<String> seen = new Set<String>();
+		for(Object value:new List<Object>{ keepVal, mergeVal }) {
+			if(value == null)
+				continue;
+			for(String part:String.valueOf(value).split(';')) {
+				String trimmed = part.trim();
+				if(String.isNotBlank(trimmed) && !seen.contains(trimmed)) {
+					seen.add(trimmed);
+					combined.add(trimmed);
+				}
+			}
+		}
+		return String.join(combined, ';');
 	}
 	/*******************************************************************************************************
 	* @description gets writeable fields for a contact record

--- a/force-app/main/default/classes/MRG_Metadata_SVC.cls
+++ b/force-app/main/default/classes/MRG_Metadata_SVC.cls
@@ -223,6 +223,7 @@ public with sharing class MRG_Metadata_SVC {
 		fieldKeyValues.put('FilterLogic__c', mergeField.FilterLogic__c);
 		fieldKeyValues.put('Conditions__c', mergeField.Conditions__c);
 		fieldKeyValues.put('TieBreakDirection__c', mergeField.TieBreakDirection__c);
+		fieldKeyValues.put('TieBreakRule__c', mergeField.TieBreakRule__c);
 		fieldKeyValues.put('TieBreakField__c', mergeField.TieBreakField__r != null ? mergeField.TieBreakField__r.QualifiedAPIName : null);
 		// fallback field (re-homed #34)
 		fieldKeyValues.put('FallbackField__c', mergeField.FallbackField__r != null ? mergeField.FallbackField__r.QualifiedAPIName : null);

--- a/force-app/main/default/classes/MRG_Preview_TEST.cls
+++ b/force-app/main/default/classes/MRG_Preview_TEST.cls
@@ -19,23 +19,25 @@ private class MRG_Preview_TEST {
 			FirstName='Test',
 			LastName='Test',
 			Email='test@test.com',
+			Department='Sales',
 			MailingCity='Austin',
 			MailingState='TX',
 			MailingPostalCode='78751',
 			Birthdate=Date.Today().addDays(-1200)
 			)
-		);	
+		);
 		cons.add(new Contact(
 			FirstName='Test1',
 			LastName='Test1',
 			Email='tes1t@test.com',
+			Department='Sales',
 			MailingStreet='123 Main Street',
 			MailingState='CA',
 			MailingPostalCode='78754',
 			HasOptedOutOfEmail=true,
 			Birthdate=Date.Today().addDays(-500)
 			)
-		);	
+		);
 
 		insert cons;
         MergeCandidate__c mc = new MergeCandidate__c(
@@ -55,5 +57,12 @@ private class MRG_Preview_TEST {
     static testMethod void testCTRL() {
         MergeCandidate__c mc = [SELECT Id,KeepRecordId__c,MergeRecordId__c,Status__c FROM MergeCandidate__c LIMIT 1];
         MRG_MergeCandidate previewRecord = MRG_Preview_CTRL.getPreviewRecord(mc.Id);
+        system.assertNotEquals(null, previewRecord, 'a preview record is returned');
+        system.assertNotEquals(null, previewRecord.matchingFields, 'matching fields are populated');
+        // both contacts share Department='Sales' -> a matching field, not a difference
+        system.assert(previewRecord.matchingFields.contains('Department'),
+            'a field with the same value across records is reported as matching');
+        system.assert(!previewRecord.fields.contains('Department'),
+            'a matching field is not reported as a difference');
     }
 }

--- a/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.html
+++ b/force-app/main/default/lwc/autoMergeAccountsRules/autoMergeAccountsRules.html
@@ -38,10 +38,10 @@
                             <div key={condition.uiKey} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
                                 <div class="slds-col slds-size_1-of-12 slds-align-middle">{condition.conditionIndex}</div>
                                 <div class="slds-col slds-size_3-of-12">
-                                    <lightning-combobox label="Field" value={condition.fieldName} options={fieldOptions}
+                                    <c-field-selector label="Field" value={condition.fieldName} options={fieldOptions}
                                         data-rule={condition.ruleIndex} data-condition={condition.conditionIndex}
                                         onchange={handleConditionFieldChange}>
-                                    </lightning-combobox>
+                                    </c-field-selector>
                                 </div>
                                 <div class="slds-col slds-size_3-of-12">
                                     <lightning-combobox label="Aggregator" value={condition.aggregator} options={aggregatorOptions}

--- a/force-app/main/default/lwc/customDatatable/customDatatable.js
+++ b/force-app/main/default/lwc/customDatatable/customDatatable.js
@@ -9,7 +9,7 @@ export default class CustomDatatable extends LightningDatatable {
             template: pickliststatic,
             editTemplate: picklistColumn,
             standardCellLayout: true,
-            typeAttributes: ['label', 'placeholder', 'options', 'value', 'context', 'variant','name']
+            typeAttributes: ['label', 'placeholder', 'options', 'value', 'context', 'variant','name','cellStyle']
         }
     };
 }

--- a/force-app/main/default/lwc/customDatatable/pickliststatic.html
+++ b/force-app/main/default/lwc/customDatatable/pickliststatic.html
@@ -1,3 +1,3 @@
 <template>
-    <span class="slds-truncate" title={value}>{value}</span>
+    <span class="slds-truncate" style={typeAttributes.cellStyle} title={value}>{value}</span>
 </template>

--- a/force-app/main/default/lwc/fieldSelector/__tests__/fieldSelector.test.js
+++ b/force-app/main/default/lwc/fieldSelector/__tests__/fieldSelector.test.js
@@ -1,0 +1,76 @@
+import { createElement } from 'lwc';
+import FieldSelector from 'c/fieldSelector';
+
+const OPTIONS = [
+    { label: 'Email', value: 'Email' },
+    { label: 'Mailing Street', value: 'MailingStreet' },
+    { label: 'Phone', value: 'Phone' }
+];
+
+function flush() {
+    return Promise.resolve();
+}
+function input(el) {
+    return el.shadowRoot.querySelector('lightning-input');
+}
+function optionText(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('.field-option')).map(o => o.textContent.trim());
+}
+function optionEl(el, value) {
+    return Array.from(el.shadowRoot.querySelectorAll('.field-option')).find(o => o.dataset.value === value);
+}
+
+describe('c-field-selector', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    async function render() {
+        const el = createElement('c-field-selector', { is: FieldSelector });
+        el.options = OPTIONS;
+        document.body.appendChild(el);
+        await flush();
+        return el;
+    }
+
+    it('lists options as "label (api name)" when focused', async () => {
+        const el = await render();
+        input(el).dispatchEvent(new CustomEvent('focus'));
+        await flush();
+        expect(optionText(el)).toEqual(
+            expect.arrayContaining(['Email (Email)', 'Mailing Street (MailingStreet)', 'Phone (Phone)'])
+        );
+    });
+
+    it('filters by label', async () => {
+        const el = await render();
+        input(el).dispatchEvent(new CustomEvent('focus'));
+        const field = input(el);
+        field.value = 'mailing';
+        field.dispatchEvent(new CustomEvent('input'));
+        await flush();
+        expect(optionText(el)).toEqual(['Mailing Street (MailingStreet)']);
+    });
+
+    it('filters by API name', async () => {
+        const el = await render();
+        input(el).dispatchEvent(new CustomEvent('focus'));
+        const field = input(el);
+        field.value = 'MailingStreet';
+        field.dispatchEvent(new CustomEvent('input'));
+        await flush();
+        expect(optionText(el)).toEqual(['Mailing Street (MailingStreet)']);
+    });
+
+    it('selecting an option dispatches change with the API value', async () => {
+        const el = await render();
+        const handler = jest.fn();
+        el.addEventListener('change', handler);
+        input(el).dispatchEvent(new CustomEvent('focus'));
+        await flush();
+        optionEl(el, 'Phone').dispatchEvent(new CustomEvent('mousedown'));
+        expect(handler.mock.calls[0][0].detail.value).toBe('Phone');
+    });
+});

--- a/force-app/main/default/lwc/fieldSelector/fieldSelector.html
+++ b/force-app/main/default/lwc/fieldSelector/fieldSelector.html
@@ -1,0 +1,31 @@
+<template>
+    <div class="slds-form-element">
+        <template if:true={label}>
+            <label class="slds-form-element__label">{label}</label>
+        </template>
+        <div class="slds-form-element__control slds-combobox_container slds-is-relative">
+            <lightning-input
+                type="search"
+                variant="label-hidden"
+                value={query}
+                placeholder={placeholder}
+                disabled={disabled}
+                onfocus={handleFocus}
+                oninput={handleInput}
+                onblur={handleBlur}>
+            </lightning-input>
+            <template if:true={hasResults}>
+                <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-dropdown_length-7" role="listbox">
+                    <template for:each={filtered} for:item="opt">
+                        <li key={opt.value} role="presentation" class="slds-listbox__item">
+                            <div class="slds-listbox__option slds-listbox__option_plain field-option"
+                                role="option" data-value={opt.value} onmousedown={handleSelect}>
+                                {opt.display}
+                            </div>
+                        </li>
+                    </template>
+                </ul>
+            </template>
+        </div>
+    </div>
+</template>

--- a/force-app/main/default/lwc/fieldSelector/fieldSelector.js
+++ b/force-app/main/default/lwc/fieldSelector/fieldSelector.js
@@ -1,0 +1,82 @@
+import { LightningElement, api, track } from 'lwc';
+
+/**
+ * Autocomplete field picker. Filters as you type on EITHER the field label or the API name and
+ * shows each result as "label (api name)". Emits a `change` CustomEvent with { value } (the api
+ * name), so it is a drop-in replacement for a field lightning-combobox (parent handlers read
+ * event.detail.value and event.target.dataset.*).
+ */
+export default class FieldSelector extends LightningElement {
+    @api label;
+    @api placeholder = 'Search fields...';
+    @api disabled = false;
+
+    @track _options = [];
+    @api
+    get options() {
+        return this._options;
+    }
+    set options(value) {
+        this._options = (value || []).map(o => ({ label: o.label, value: o.value, display: o.label + ' (' + o.value + ')' }));
+        this.syncQuery();
+    }
+
+    @track _value;
+    @api
+    get value() {
+        return this._value;
+    }
+    set value(v) {
+        this._value = v;
+        this.syncQuery();
+    }
+
+    @track query = '';
+    @track open = false;
+
+    // show the current selection as "label (api)" in the input
+    syncQuery() {
+        if (this._value == null || this._value === '') {
+            this.query = '';
+            return;
+        }
+        const selected = this._options.find(o => o.value === this._value);
+        this.query = selected ? selected.display : this._value;
+    }
+
+    get filtered() {
+        const selected = this._options.find(o => o.value === this._value);
+        // when the box still shows the current selection, list everything (browsing, not filtering)
+        if (selected && this.query === selected.display) {
+            return this._options;
+        }
+        const q = (this.query || '').toLowerCase().trim();
+        if (!q) {
+            return this._options;
+        }
+        return this._options.filter(o => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q));
+    }
+
+    get hasResults() {
+        return this.open && this.filtered.length > 0;
+    }
+
+    handleFocus() {
+        this.open = true;
+    }
+    handleInput(event) {
+        this.query = event.target.value;
+        this.open = true;
+    }
+    handleBlur() {
+        this.open = false;
+    }
+    // mousedown fires before the input's blur, so the selection registers before the list closes
+    handleSelect(event) {
+        const value = event.currentTarget.dataset.value;
+        this._value = value;
+        this.syncQuery();
+        this.open = false;
+        this.dispatchEvent(new CustomEvent('change', { detail: { value } }));
+    }
+}

--- a/force-app/main/default/lwc/fieldSelector/fieldSelector.js-meta.xml
+++ b/force-app/main/default/lwc/fieldSelector/fieldSelector.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/keepRecordRules/keepRecordRules.html
+++ b/force-app/main/default/lwc/keepRecordRules/keepRecordRules.html
@@ -41,14 +41,14 @@
                                     {condition.conditionIndex}
                                 </div>
                                 <div class="slds-col slds-size_4-of-12">
-                                    <lightning-combobox
+                                    <c-field-selector
                                         label="Field"
                                         value={condition.fieldName}
                                         options={fieldOptions}
                                         data-rule={condition.ruleIndex}
                                         data-condition={condition.conditionIndex}
                                         onchange={handleFieldChange}>
-                                    </lightning-combobox>
+                                    </c-field-selector>
                                 </div>
                                 <div class="slds-col slds-size_3-of-12">
                                     <lightning-combobox

--- a/force-app/main/default/lwc/mergePreview/__tests__/mergePreview.test.js
+++ b/force-app/main/default/lwc/mergePreview/__tests__/mergePreview.test.js
@@ -29,16 +29,40 @@ jest.mock(
 
 const RECORD = {
     recordId: 'mc1',
-    keepRecord: { Id: '001A', Name: 'Acme', Phone: '111' },
-    mergeRecord1: { Id: '001B', Name: 'Acme 2', Phone: '222' },
-    mergeResultRecord: { Id: '001A', Name: 'Acme', Phone: '111' },
+    keepRecord: {
+        Id: '001A', Name: 'Acme', Phone: '111', Industry: 'Tech',
+        CreatedDate: '2020-01-01T00:00:00.000Z', LastModifiedDate: '2021-01-01T00:00:00.000Z'
+    },
+    mergeRecord1: {
+        Id: '001B', Name: 'Acme 2', Phone: '222', Industry: 'Tech',
+        CreatedDate: '2019-01-01T00:00:00.000Z', LastModifiedDate: '2020-06-01T00:00:00.000Z'
+    },
+    mergeResultRecord: {
+        Id: '001A', Name: 'Acme', Phone: '111', Industry: 'Tech', Website: 'acme.com',
+        CreatedDate: '2020-01-01T00:00:00.000Z', LastModifiedDate: '2021-01-01T00:00:00.000Z'
+    },
     fields: ['Phone', 'Name'],
+    matchingFields: ['Industry'],
+    // a fallback-routed value: the losing Description landed in the (otherwise empty) Website field
+    fieldHistory: [{ TargetField__c: 'Website', MergeValueType__c: 'Description' }],
     previewFields: [],
     mergeCandidate: { KeepName__c: 'Acme', MergeName__c: 'Acme 2', Status__c: 'New' }
 };
 
 function flush() {
     return Promise.resolve();
+}
+function fieldNames(table) {
+    return table.data.map(r => r.fieldname);
+}
+async function render() {
+    const el = createElement('c-merge-preview', { is: MergePreview });
+    el.recordId = 'mc1';
+    document.body.appendChild(el);
+    getPreviewRecord.emit(RECORD);
+    await flush();
+    await flush();
+    return el;
 }
 
 describe('c-merge-preview', () => {
@@ -49,18 +73,50 @@ describe('c-merge-preview', () => {
         jest.clearAllMocks();
     });
 
-    it('builds the comparison table (field + keep + merge + result columns, one row per field)', async () => {
-        const el = createElement('c-merge-preview', { is: MergePreview });
-        el.recordId = 'mc1';
-        document.body.appendChild(el);
-        getPreviewRecord.emit(RECORD);
-        await flush();
-        await flush();
-
+    it('builds the comparison table (field + keep + merge + result columns)', async () => {
+        const el = await render();
         const table = el.shadowRoot.querySelector('c-custom-datatable');
         expect(table).not.toBeNull();
         // fieldname + keepRecord + mergeRecord1 + mergeResultRecord (no merge2 for a pair)
         expect(table.columns.length).toBe(4);
-        expect(table.data.length).toBe(2); // one row per previewed field
+    });
+
+    it('shows Id as the first row and CreatedDate/LastModifiedDate as the last two rows', async () => {
+        const el = await render();
+        const names = fieldNames(el.shadowRoot.querySelector('c-custom-datatable'));
+        expect(names[0]).toBe('Id');
+        expect(names.slice(-2)).toEqual(['CreatedDate', 'LastModifiedDate']);
+    });
+
+    it('hides matching fields by default and reveals them when the checkbox is checked', async () => {
+        const el = await render();
+        const table = el.shadowRoot.querySelector('c-custom-datatable');
+        expect(fieldNames(table)).not.toContain('Industry');
+
+        const checkbox = el.shadowRoot.querySelector('lightning-input');
+        checkbox.checked = true;
+        checkbox.dispatchEvent(new CustomEvent('change'));
+        await flush();
+        expect(fieldNames(table)).toContain('Industry');
+    });
+
+    it('shows fallback-routed fields and highlights only the merge-result cell', async () => {
+        const el = await render();
+        const table = el.shadowRoot.querySelector('c-custom-datatable');
+        const fallbackRow = table.data.find(r => r.fieldname === 'Website');
+        expect(fallbackRow).toBeDefined();
+        expect(fallbackRow.mergeResultRecord).toBe('acme.com');
+        expect(fallbackRow.mergeResultStyle).toContain('background-color');
+
+        const phoneRow = table.data.find(r => r.fieldname === 'Phone');
+        expect(phoneRow.mergeResultStyle).toBe('');
+    });
+
+    it('never makes the system rows (Id/dates) editable', async () => {
+        const el = await render();
+        const table = el.shadowRoot.querySelector('c-custom-datatable');
+        ['Id', 'CreatedDate', 'LastModifiedDate'].forEach(name => {
+            expect(table.data.find(r => r.fieldname === name).editable).toBe(false);
+        });
     });
 });

--- a/force-app/main/default/lwc/mergePreview/mergePreview.html
+++ b/force-app/main/default/lwc/mergePreview/mergePreview.html
@@ -11,6 +11,14 @@
                 </div>
             </template>
             <template if:true={hasData}>
+                <div class="slds-m-bottom_small">
+                    <lightning-input
+                        type="checkbox"
+                        label="Show matching fields"
+                        checked={showMatching}
+                        onchange={handleShowMatchingChange}>
+                    </lightning-input>
+                </div>
                 <!--
                     <lightning-datatable
                             key-field="fieldname"

--- a/force-app/main/default/lwc/mergePreview/mergePreview.js
+++ b/force-app/main/default/lwc/mergePreview/mergePreview.js
@@ -36,6 +36,8 @@ export default class mergePreview extends LightningElement {
             })
             this.overrideMap = orMap;
         }
+        this._matchingFields = value.hasOwnProperty('matchingFields') && value.matchingFields != null ? value.matchingFields.slice().sort() : [];
+        this.fallbackFields = this.deriveFallbackFields(value.fieldHistory);
         if(fields.length > 0)
             fields.sort();
         this.rows = fields;
@@ -74,6 +76,48 @@ export default class mergePreview extends LightningElement {
     _rows;
     @track data;
     @track cols;
+    @track showMatching = false;
+    _matchingFields = [];
+    fallbackFields = [];
+
+    // system fields rendered as fixed rows (Id first; CreatedDate/LastModifiedDate last), never editable
+    systemFields = ['Id', 'CreatedDate', 'LastModifiedDate'];
+
+    deriveFallbackFields(history){
+        var targets = [];
+        if(Array.isArray(history)){
+            history.forEach(h=>{
+                if(h && h.TargetField__c && !targets.includes(h.TargetField__c))
+                    targets.push(h.TargetField__c);
+            });
+        }
+        return targets;
+    }
+
+    // ordered field list: Id first, then differing + fallback (+ matching when toggled on),
+    // then CreatedDate and LastModifiedDate last; suppressed and system fields excluded from the middle
+    get orderedFields(){
+        var ignore = Array.isArray(this.ignoreFields) ? this.ignoreFields : [];
+        var ordered = ['Id'];
+        var mid = [];
+        var add = (f)=>{
+            if(f && !mid.includes(f) && !this.systemFields.includes(f) && !ignore.includes(f))
+                mid.push(f);
+        };
+        (this.rows || []).forEach(add);
+        (this.fallbackFields || []).forEach(add);
+        if(this.showMatching)
+            (this._matchingFields || []).forEach(add);
+        mid.forEach(f=>ordered.push(f));
+        ordered.push('CreatedDate');
+        ordered.push('LastModifiedDate');
+        return ordered;
+    }
+
+    handleShowMatchingChange(event){
+        this.showMatching = event.target.checked;
+        this.createTableData();
+    }
 
     get processed(){
         return typeof this.mergeCandidate !== undefined && this.mergeCandidate != null && this.mergeCandidate.Status__c == 'Processed';
@@ -184,9 +228,10 @@ export default class mergePreview extends LightningElement {
                     type: 'picklistColumn', 
                     editable: {fieldName: 'editable'}, 
                     typeAttributes: {
-                        placeholder: 'Choose value to keep', 
-                        options: { fieldName: 'picklistOptions' }, 
-                        value: { fieldName: 'picklistValue' }
+                        placeholder: 'Choose value to keep',
+                        options: { fieldName: 'picklistOptions' },
+                        value: { fieldName: 'picklistValue' },
+                        cellStyle: { fieldName: 'mergeResultStyle' }
                     }
                 };
             } else {
@@ -215,66 +260,65 @@ export default class mergePreview extends LightningElement {
         var mergeResultRecord = this._record.hasOwnProperty('mergeResultRecord') ? this._record.mergeResultRecord : {};
         var orMap = typeof this.overrideMap === undefined || this.overrideMap == null ?  new Map() : this.overrideMap;
         
-        this.rows.forEach(field=>{
-            if(!this.ignoreFields.includes(field)){
-                var dataRow = {};
-                var picklistOptions = [];
-                var picklistValue;
+        this.orderedFields.forEach(field=>{
+            var isSystem = this.systemFields.includes(field);
+            var isFallback = (this.fallbackFields || []).includes(field);
+            var dataRow = {};
+            var picklistOptions = [];
 
-                columns.forEach(col=>{
-                    var fieldValue = null;
-                    var recordObj = {};
-                    switch(col) {
-                        case 'fieldname':
-                            fieldValue = field;
-                            break;
-                        case 'keepRecord':
-                            fieldValue = keepRecord.hasOwnProperty(field) ? keepRecord[field] : null;
-                            break;
-                        case 'mergeRecord1':
-                            fieldValue = mergeRecord1.hasOwnProperty(field) ? mergeRecord1[field] : null;
-                            break;
-                        case 'mergeRecord2':
-                            fieldValue = mergeRecord2.hasOwnProperty(field) ? mergeRecord2[field] : null;
-                            break;
-                        case 'mergeResultRecord':
-                            fieldValue = mergeResultRecord.hasOwnProperty(field) ? mergeResultRecord[field] : null;
-                            break;
+            columns.forEach(col=>{
+                var fieldValue = null;
+                switch(col) {
+                    case 'fieldname':
+                        fieldValue = field;
+                        break;
+                    case 'keepRecord':
+                        fieldValue = keepRecord.hasOwnProperty(field) ? keepRecord[field] : null;
+                        break;
+                    case 'mergeRecord1':
+                        fieldValue = mergeRecord1.hasOwnProperty(field) ? mergeRecord1[field] : null;
+                        break;
+                    case 'mergeRecord2':
+                        fieldValue = mergeRecord2.hasOwnProperty(field) ? mergeRecord2[field] : null;
+                        break;
+                    case 'mergeResultRecord':
+                        fieldValue = mergeResultRecord.hasOwnProperty(field) ? mergeResultRecord[field] : null;
+                        break;
+                }
+                if(col != 'mergeResultRecord'){
+                    // system rows (Id/CreatedDate/LastModifiedDate) are informational only -> not selectable
+                    if(!isSystem && fieldValue != null && !picklistOptions.includes(fieldValue) && col !='fieldname'){
+                        var opt = {};
+                        opt.label = fieldValue;
+                        opt.value = fieldValue;
+                        picklistOptions.push(opt);
                     }
-                    if(col != 'mergeResultRecord'){
-                        if(fieldValue != null && !picklistOptions.includes(fieldValue) && col !='fieldname'){
-                            var opt = {};
-                            opt.label = fieldValue;
-                            opt.value = fieldValue;
-                            picklistOptions.push(opt);
-                        }
-                    } else if(col == 'mergeResultRecord') {
-                        var editable = picklistOptions.length > 1;
-                        dataRow['editable'] = editable;
-                        if(picklistOptions.length > 1){
-                            var picklistFieldValue = {};
-                            picklistFieldValue.value = fieldValue;
-                            picklistFieldValue.options = picklistOptions;
-                            picklistFieldValue.placeholder = fieldValue;
-                            
-                            if(!orMap.has(field)){
-                                orMap.set(field,fieldValue);
-                            } else {
-                                var val = orMap.get(field);
-                                picklistFieldValue.value = val;
-                                fieldValue = val;
-                            }
+                } else if(col == 'mergeResultRecord') {
+                    var editable = !isSystem && picklistOptions.length > 1;
+                    dataRow['editable'] = editable;
+                    if(editable){
+                        var picklistFieldValue = {};
+                        picklistFieldValue.value = fieldValue;
+                        picklistFieldValue.options = picklistOptions;
+                        picklistFieldValue.placeholder = fieldValue;
 
-                            dataRow['picklistOptions'] = picklistFieldValue.options;
-                            dataRow['picklistValue'] = picklistFieldValue.value;
-                            
+                        if(!orMap.has(field)){
+                            orMap.set(field,fieldValue);
+                        } else {
+                            var val = orMap.get(field);
+                            picklistFieldValue.value = val;
+                            fieldValue = val;
                         }
-                        
-                    }            
-                    dataRow[col] = fieldValue;
-                });
-                dataRows.push(dataRow);
-            }
+
+                        dataRow['picklistOptions'] = picklistFieldValue.options;
+                        dataRow['picklistValue'] = picklistFieldValue.value;
+                    }
+                    // highlight fallback-routed values (they land in the merge result column)
+                    dataRow['mergeResultStyle'] = isFallback ? 'background-color:#fcf3cf;' : '';
+                }
+                dataRow[col] = fieldValue;
+            });
+            dataRows.push(dataRow);
         });
         this.data = dataRows;
         console.log('data');

--- a/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
@@ -1,8 +1,22 @@
 import { createElement } from 'lwc';
 import MergeSingleRecord from 'c/mergeSingleRecord';
+import getReadableObjectFields from '@salesforce/apex/MRG_MergeSettings_CTRL.getReadableObjectFields';
+
+jest.mock(
+    '@salesforce/apex/MRG_MergeSettings_CTRL.getReadableObjectFields',
+    () => {
+        const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+        return { default: createApexTestWireAdapter(jest.fn()) };
+    },
+    { virtual: true }
+);
 
 function flush() {
     return Promise.resolve();
+}
+function ruleCombobox(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('lightning-combobox'))
+        .find(c => Array.isArray(c.options) && c.options.some(o => o.value === 'Oldest'));
 }
 function hasButton(el, label) {
     return Array.from(el.shadowRoot.querySelectorAll('lightning-button')).some(b => b.label === label);
@@ -48,6 +62,34 @@ describe('c-merge-single-record', () => {
         expect(hasButton(el, 'Add Condition')).toBe(false);
         expect(hasInput(el, 'Contains Value')).toBe(false);
         expect(hasInput(el, 'Apex Class')).toBe(false);
+    });
+
+    it('offers Combine Values only when the selected field is a multipicklist', async () => {
+        const el = createElement('c-merge-single-record', { is: MergeSingleRecord });
+        el.usedFields = [];
+        el.record = { name: 'TEMPx', type: 'p', rule: 'Newest', objectName: 'Contact', fieldName: 'Tags', conditions: [] };
+        document.body.appendChild(el);
+        getReadableObjectFields.emit([{ label: 'Tags', name: 'Tags', type: 'MULTIPICKLIST' }]);
+        await flush();
+        await flush();
+        expect(ruleCombobox(el).options.some(o => o.value === 'Combine')).toBe(true);
+    });
+
+    it('hides Combine Values for a non-multipicklist field', async () => {
+        const el = createElement('c-merge-single-record', { is: MergeSingleRecord });
+        el.usedFields = [];
+        el.record = { name: 'TEMPx', type: 'p', rule: 'Newest', objectName: 'Contact', fieldName: 'Email', conditions: [] };
+        document.body.appendChild(el);
+        getReadableObjectFields.emit([{ label: 'Email', name: 'Email', type: 'EMAIL' }]);
+        await flush();
+        await flush();
+        expect(ruleCombobox(el).options.some(o => o.value === 'Combine')).toBe(false);
+    });
+
+    it('shows the Tie-Break Rule picker in the Complex section', async () => {
+        const el = await renderWithRule('Complex');
+        const labels = Array.from(el.shadowRoot.querySelectorAll('lightning-combobox')).map(c => c.label);
+        expect(labels).toContain('Tie-Break Rule (primary)');
     });
 
     it('dispatches a save notify when Save is clicked', async () => {

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
@@ -58,13 +58,13 @@
                             </template>
                             <template if:false={mergeRecord.fieldName}>
                                 <template if:true={fieldResults}>
-                                    <lightning-combobox
-                                        name="Field"
+                                    <c-field-selector
+                                        label="Field"
                                         value={mergeRecord.fieldName}
-                                        placeholder="Select Field"
+                                        placeholder="Search fields..."
                                         options={fieldResults}
                                         onchange={handleFieldSelect}
-                                    ></lightning-combobox>
+                                    ></c-field-selector>
                                 </template>
                             </template>
                         </template>
@@ -90,13 +90,13 @@
                             <template if:true={objectType}>
                                 <template if:true={fieldResults}>
                                     <template if:true={isRelatedField}>
-                                        <lightning-combobox
-                                            name="Field"
+                                        <c-field-selector
+                                            label="Related Field"
                                             value={mergeRecord.relatedField}
-                                            placeholder="Select Field"
+                                            placeholder="Search fields..."
                                             options={relatedFieldResults}
                                             onchange={handleRelatedFieldSelect}
-                                        ></lightning-combobox>
+                                        ></c-field-selector>
                                     </template>
                                 </template>
                             </template>
@@ -119,13 +119,13 @@
                                 this field instead (only if it is empty). The routed value is recorded in Merge
                                 Field History with the target field.
                             </p>
-                            <lightning-combobox
-                                name="Fallback Field"
+                            <c-field-selector
+                                label="Fallback Field"
                                 value={mergeRecord.fallbackField}
-                                placeholder="Select Fallback Field"
+                                placeholder="Search fields..."
                                 options={fieldResults}
                                 onchange={handleFallbackFieldSelect}
-                            ></lightning-combobox>
+                            ></c-field-selector>
                         </div>
                     </template>
                 </template>
@@ -142,13 +142,13 @@
                             <div key={condition.conditionIndex} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
                                 <div class="slds-col slds-size_1-of-12 slds-text-body_small slds-align-middle">{condition.conditionIndex}</div>
                                 <div class="slds-col slds-size_4-of-12">
-                                    <lightning-combobox
+                                    <c-field-selector
                                         label="Field"
                                         value={condition.fieldName}
                                         options={allFieldOptions}
                                         data-condition={condition.conditionIndex}
                                         onchange={handleConditionFieldSelect}>
-                                    </lightning-combobox>
+                                    </c-field-selector>
                                 </div>
                                 <div class="slds-col slds-size_3-of-12">
                                     <lightning-combobox
@@ -187,14 +187,18 @@
                             value={mergeRecord.filterLogic} onchange={handleFilterLogicChange}>
                         </lightning-input>
 
+                        <lightning-combobox label="Tie-Break Rule (primary)" value={mergeRecord.tieBreakRule}
+                            placeholder="Select Rule" options={tieBreakRuleOptions} onchange={handleTieBreakRuleSelect}
+                            class="slds-m-top_x-small">
+                        </lightning-combobox>
                         <div class="slds-grid slds-gutters slds-m-top_x-small">
                             <div class="slds-col slds-size_6-of-12">
-                                <lightning-combobox label="Tie-Break Field" value={mergeRecord.tieBreakField}
-                                    placeholder="Select Field" options={allFieldOptions} onchange={handleTieBreakFieldSelect}>
-                                </lightning-combobox>
+                                <c-field-selector label="Tie-Break Field (secondary)" value={mergeRecord.tieBreakField}
+                                    placeholder="Search fields..." options={allFieldOptions} onchange={handleTieBreakFieldSelect}>
+                                </c-field-selector>
                             </div>
                             <div class="slds-col slds-size_6-of-12">
-                                <lightning-combobox label="Tie-Break Direction" value={mergeRecord.tieBreakDirection}
+                                <lightning-combobox label="Secondary Direction" value={mergeRecord.tieBreakDirection}
                                     options={directionOptions} onchange={handleTieBreakDirectionSelect}>
                                 </lightning-combobox>
                             </div>

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
@@ -33,7 +33,30 @@ export default class mergeSingleRecord extends LightningElement {
         return type;
     }
     trackOptions = [{label:'Track Fields',value:'t'},{label:'Preserve Fields',value:'p'}];
-    ruleOptions = [{label:'Oldest Record',value:'Oldest'},{label:'Newest Record',value:'Newest'},{label:'Largest Field Value',value:'Largest'},{label:'Smallest Field Value',value:'Smallest'},{label:'Longest Text Value',value:'Longest'},{label:'Shortest Text Value',value:'Shortest'},{label:'Contains Text',value:'Contains'},{label:'Related Field Value',value:'Related Field'},{label:'Complex Rule',value:'Complex'},{label:'Apex Defined Rule',value:'Apex Defined'}];
+    // 'Combine Values' is appended only when the selected field is a multi-select picklist
+    get ruleOptions() {
+        const options = [
+            {label:'Oldest Record',value:'Oldest'},
+            {label:'Newest Record',value:'Newest'},
+            {label:'Largest Field Value',value:'Largest'},
+            {label:'Smallest Field Value',value:'Smallest'},
+            {label:'Longest Text Value',value:'Longest'},
+            {label:'Shortest Text Value',value:'Shortest'},
+            {label:'Contains Text',value:'Contains'},
+            {label:'Related Field Value',value:'Related Field'},
+            {label:'Complex Rule',value:'Complex'},
+            {label:'Apex Defined Rule',value:'Apex Defined'}
+        ];
+        if(this.isMultiPicklistField){
+            options.push({label:'Combine Values',value:'Combine'});
+        }
+        return options;
+    }
+    get isMultiPicklistField() {
+        return this.mergeRecord != null && this.mergeRecord.fieldName != null
+            && this.fieldTypeByName[this.mergeRecord.fieldName] === 'MULTIPICKLIST';
+    }
+    tieBreakRuleOptions = [{label:'(none)',value:''},{label:'Oldest',value:'Oldest'},{label:'Newest',value:'Newest'},{label:'Largest',value:'Largest'},{label:'Smallest',value:'Smallest'},{label:'Longest',value:'Longest'},{label:'Shortest',value:'Shortest'}];
     operatorOptions = [
         {label:'equals',value:'equals'},
         {label:'not equals',value:'notEquals'},
@@ -231,6 +254,10 @@ export default class mergeSingleRecord extends LightningElement {
 
     handleTieBreakFieldSelect(event){
         this.mergeRecord.tieBreakField = event.detail.value;
+    }
+
+    handleTieBreakRuleSelect(event){
+        this.mergeRecord.tieBreakRule = event.detail.value;
     }
 
     handleTieBreakDirectionSelect(event){

--- a/force-app/main/default/lwc/previewFieldSingleRecord/previewFieldSingleRecord.html
+++ b/force-app/main/default/lwc/previewFieldSingleRecord/previewFieldSingleRecord.html
@@ -45,13 +45,13 @@
                 <lightning-layout-item padding="around-small" size="2">
                     <template if:true={objectType}>
                         <template if:true={fieldResults}>
-                            <lightning-combobox
-                                name="Field"
+                            <c-field-selector
+                                label="Field"
                                 value={previewField.fieldName}
-                                placeholder="Select Field"
+                                placeholder="Search fields..."
                                 options={fieldResults}
                                 onchange={handleFieldSelect}
-                            ></lightning-combobox>
+                            ></c-field-selector>
                         </template>
                     </template>
                 </lightning-layout-item>

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/TieBreakRule__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/TieBreakRule__c.field-meta.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>PreservationRule__c</fullName>
+    <fullName>TieBreakRule__c</fullName>
+    <description>Complex rule primary tie-break: a standard preservation rule (Oldest/Newest/Largest/Smallest/Longest/Shortest) used to pick the winner among matching records. Tie-Break Field + Direction act as the secondary tie-break. Largest/Smallest/Longest/Shortest rank on the Tie-Break Field; Oldest/Newest use CreatedDate.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <label>Preservation Rule</label>
+    <label>Tie Break Rule</label>
     <required>false</required>
     <type>Picklist</type>
     <valueSet>
@@ -12,7 +13,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Oldest</fullName>
-                <default>true</default>
+                <default>false</default>
                 <label>Oldest</label>
             </value>
             <value>
@@ -33,37 +34,12 @@
             <value>
                 <fullName>Longest</fullName>
                 <default>false</default>
-                <label>Longest Text</label>
+                <label>Longest</label>
             </value>
             <value>
                 <fullName>Shortest</fullName>
                 <default>false</default>
-                <label>Shortest Text</label>
-            </value>
-            <value>
-                <fullName>Contains</fullName>
-                <default>false</default>
-                <label>Contains Text</label>
-            </value>
-            <value>
-                <fullName>Combine</fullName>
-                <default>false</default>
-                <label>Combine Values</label>
-            </value>
-            <value>
-                <fullName>Related Field</fullName>
-                <default>false</default>
-                <label>Related Field</label>
-            </value>
-            <value>
-                <fullName>Complex</fullName>
-                <default>false</default>
-                <label>Complex</label>
-            </value>
-            <value>
-                <fullName>Apex Defined</fullName>
-                <default>false</default>
-                <label>Apex Defined</label>
+                <label>Shortest</label>
             </value>
         </valueSetDefinition>
     </valueSet>


### PR DESCRIPTION
## Summary

Two related batches of merge-settings UX and engine enhancements, both targeting the next release (2.4.0).

### Field settings + preservation engine
- **Autocomplete field selector** — new reusable `c/fieldSelector` LWC. Type-ahead matches on the field **label OR API name**, and results render as `label (api name)`. Swapped the field pickers in `mergeSingleRecord`, `keepRecordRules`, `autoMergeAccountsRules`, and `previewFieldSingleRecord` over to it (small fixed lists like Object/Type/Operator stay plain comboboxes).
- **Complex rule tie-break** — new `MergeFieldSetting__mdt.TieBreakRule__c` (Oldest/Newest/Largest/Smallest/Longest/Shortest) is the **primary** tie-break; the existing Tie-Break Field + direction becomes the **secondary**. Blank rule = legacy field+direction behavior (backward compatible).
- **Combine multipicklist** — new `PreservationRule__c` value **"Combine Values"** unions semicolon-delimited values across merged records. Offered **only** for multipicklist fields (server-side `DisplayType.MULTIPICKLIST` guard).

### Merge preview
- **Show matching fields** — fields with equal values across records are now reported (`MRG_MergeCandidate.matchingFields`) and hidden behind a **"Show matching fields"** checkbox (default off).
- **Fallback highlight** — fallback-routed values (`MergeFieldHistory__c.TargetField__c`) are always shown, with their **merge-result cell highlighted pale yellow** (`#fcf3cf`).
- **System rows** — **Id** renders as the first row; **CreatedDate** and **LastModifiedDate** as the last two rows (added `LastModifiedDate` to the merge SOQL). These rows are informational only — never editable.

## Testing
- Jest: **39/39** pass (new `fieldSelector` suite + new `mergePreview` coverage for ordering, matching toggle, fallback highlight, non-editable system rows).
- gsgDEV check-only deploy (`RunSpecifiedTests` over the `MRG_*` suite): **141 Apex tests, 0 failures, 0 component errors.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
