### PR TITLE
fix: keep fieldSelector exposed; release 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The Merge Control app provides SF Administrators with the following tools relate
 
 ## Installation
 
-Current release: **2.4.0** (unlocked package, `04tKb000000Egz2IAC`)
+Current release: **2.4.1** (unlocked package, `04tKb000000Egz7IAC`)
 
 Install via URL:
-- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Egz2IAC
-- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Egz2IAC
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Egz7IAC
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Egz7IAC
 
 Or with the Salesforce CLI:
 
 ```
-sf package install --package 04tKb000000Egz2IAC --target-org <org-alias> --wait 10
+sf package install --package 04tKb000000Egz7IAC --target-org <org-alias> --wait 10
 ```
 
 After installing, assign the **Merge Control Administrator** permission set to administrators.

--- a/force-app/main/default/lwc/fieldSelector/fieldSelector.js-meta.xml
+++ b/force-app/main/default/lwc/fieldSelector/fieldSelector.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>49.0</apiVersion>
-    <isExposed>false</isExposed>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.4",
-      "versionNumber": "2.4.0.NEXT"
+      "versionName": "ver 2.4.1",
+      "versionNumber": "2.4.1.NEXT"
     }
   ],
   "namespace": "",
@@ -18,6 +18,7 @@
     "merge@2.1.0-1": "04tKb000000EgydIAC",
     "merge@2.2.0-1": "04tKb000000EgynIAC",
     "merge@2.3.0-1": "04tKb000000EgysIAC",
-    "merge@2.4.0-1": "04tKb000000Egz2IAC"
+    "merge@2.4.0-1": "04tKb000000Egz2IAC",
+    "merge@2.4.1-1": "04tKb000000Egz7IAC"
   }
 }


### PR DESCRIPTION
## Release 2.4.1 — keep `fieldSelector` exposed

`fieldSelector` is the autocomplete field-selector LWC introduced in 2.4.0. It is **actively used** by four parents (`mergeSingleRecord`, `keepRecordRules`, `autoMergeAccountsRules`, `previewFieldSingleRecord`), so it is **not deprecated**.

An unlocked package cannot lower `isExposed` once a prior version exposed the component, so this flips it back to `true`.

### Changes
- `fieldSelector.js-meta.xml`: `isExposed` `false` → `true`
- Bump to **ver 2.4.1** and promote unlocked package version **2.4.1-1** (`04tKb000000Egz7IAC`)
- README install URL → 2.4.1

### Verification
- Jest: 39/39 pass (component code unchanged).
- Package version created with `--code-coverage` and promoted successfully (the `false`→`true` exposure change was accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
