### PR TITLE
fix: restore legacy fieldSelector public properties; release 2.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The Merge Control app provides SF Administrators with the following tools relate
 
 ## Installation
 
-Current release: **2.4.1** (unlocked package, `04tKb000000Egz7IAC`)
+Current release: **2.4.2** (unlocked package, `04tKb000000EgzCIAS`)
 
 Install via URL:
-- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Egz7IAC
-- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Egz7IAC
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgzCIAS
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgzCIAS
 
 Or with the Salesforce CLI:
 
 ```
-sf package install --package 04tKb000000Egz7IAC --target-org <org-alias> --wait 10
+sf package install --package 04tKb000000EgzCIAS --target-org <org-alias> --wait 10
 ```
 
 After installing, assign the **Merge Control Administrator** permission set to administrators.

--- a/force-app/main/default/lwc/fieldSelector/fieldSelector.js
+++ b/force-app/main/default/lwc/fieldSelector/fieldSelector.js
@@ -11,6 +11,13 @@ export default class FieldSelector extends LightningElement {
     @api placeholder = 'Search fields...';
     @api disabled = false;
 
+    // Retained for unlocked-package API compatibility with the prior fieldSelector component:
+    // public @api properties can't be removed once a published version exposed them. The
+    // autocomplete does not use these.
+    @api fieldSelectorLabel;
+    @api fieldSelectorStyle;
+    @api objectType;
+
     @track _options = [];
     @api
     get options() {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.4.1",
-      "versionNumber": "2.4.1.NEXT"
+      "versionName": "ver 2.4.2",
+      "versionNumber": "2.4.2.NEXT"
     }
   ],
   "namespace": "",
@@ -19,6 +19,7 @@
     "merge@2.2.0-1": "04tKb000000EgynIAC",
     "merge@2.3.0-1": "04tKb000000EgysIAC",
     "merge@2.4.0-1": "04tKb000000Egz2IAC",
-    "merge@2.4.1-1": "04tKb000000Egz7IAC"
+    "merge@2.4.1-1": "04tKb000000Egz7IAC",
+    "merge@2.4.2-1": "04tKb000000EgzCIAS"
   }
 }


### PR DESCRIPTION
## Release 2.4.2 — restore legacy `fieldSelector` public properties

A previously published version of the `merge` package exposed a `fieldSelector` component with the public properties **`fieldSelectorLabel`**, **`fieldSelectorStyle`**, and **`objectType`** (these predate this git repo, so they weren't visible in history). The 2.4.0 autocomplete reused the `fieldSelector` name with a different `@api` surface, and an unlocked package **cannot remove public `@api` properties** once a published version exposed them — so deploying/upgrade-installing failed.

### Fix
- `fieldSelector.js`: re-declare `fieldSelectorLabel`, `fieldSelectorStyle`, `objectType` as `@api` properties for package API compatibility (unused by the autocomplete; comment explains why). The component is now a superset of the legacy API, so it deploys into orgs with the legacy component and upgrade-installs cleanly.
- Bump to **ver 2.4.2** and promote unlocked package version **2.4.2-1** (`04tKb000000EgzCIAS`).
- README install URL → 2.4.2.

### Verification
- Jest: 39/39 pass (autocomplete behavior unchanged).
- Package version created with `--code-coverage` and promoted successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
