### PR TITLE
fix: field selector type-ahead (build 2.4.4-1)

### DIFF
--- a/force-app/main/default/lwc/mergeFieldSelector/__tests__/mergeFieldSelector.test.js
+++ b/force-app/main/default/lwc/mergeFieldSelector/__tests__/mergeFieldSelector.test.js
@@ -11,7 +11,7 @@ function flush() {
     return Promise.resolve();
 }
 function input(el) {
-    return el.shadowRoot.querySelector('lightning-input');
+    return el.shadowRoot.querySelector('input');
 }
 function optionText(el) {
     return Array.from(el.shadowRoot.querySelectorAll('.field-option')).map(o => o.textContent.trim());
@@ -35,32 +35,35 @@ describe('c-merge-field-selector', () => {
         return el;
     }
 
-    it('lists options as "label (api name)" when focused', async () => {
-        const el = await render();
-        input(el).dispatchEvent(new CustomEvent('focus'));
-        await flush();
-        expect(optionText(el)).toEqual(
-            expect.arrayContaining(['Email (Email)', 'Mailing Street (MailingStreet)', 'Phone (Phone)'])
-        );
-    });
-
-    it('filters by label', async () => {
-        const el = await render();
-        input(el).dispatchEvent(new CustomEvent('focus'));
+    async function type(el, text) {
         const field = input(el);
-        field.value = 'mailing';
+        field.value = text;
         field.dispatchEvent(new CustomEvent('input'));
         await flush();
+    }
+
+    it('shows no results until at least 3 characters are typed', async () => {
+        const el = await render();
+        input(el).dispatchEvent(new CustomEvent('focus'));
+        await flush();
+        expect(optionText(el)).toEqual([]); // focus alone shows nothing
+
+        await type(el, 'ph');
+        expect(optionText(el)).toEqual([]); // 2 chars -> still nothing
+
+        await type(el, 'pho');
+        expect(optionText(el)).toEqual(['Phone (Phone)']); // 3 chars -> results
+    });
+
+    it('filters by label (contains)', async () => {
+        const el = await render();
+        await type(el, 'street');
         expect(optionText(el)).toEqual(['Mailing Street (MailingStreet)']);
     });
 
-    it('filters by API name', async () => {
+    it('filters by API name (contains)', async () => {
         const el = await render();
-        input(el).dispatchEvent(new CustomEvent('focus'));
-        const field = input(el);
-        field.value = 'MailingStreet';
-        field.dispatchEvent(new CustomEvent('input'));
-        await flush();
+        await type(el, 'mailingstreet');
         expect(optionText(el)).toEqual(['Mailing Street (MailingStreet)']);
     });
 
@@ -68,8 +71,7 @@ describe('c-merge-field-selector', () => {
         const el = await render();
         const handler = jest.fn();
         el.addEventListener('change', handler);
-        input(el).dispatchEvent(new CustomEvent('focus'));
-        await flush();
+        await type(el, 'pho');
         optionEl(el, 'Phone').dispatchEvent(new CustomEvent('mousedown'));
         expect(handler.mock.calls[0][0].detail.value).toBe('Phone');
     });

--- a/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.css
+++ b/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.css
@@ -1,0 +1,10 @@
+/* anchor the results dropdown directly below the input instead of overlapping it */
+.field-selector-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    width: 100%;
+    margin-top: 2px;
+    z-index: 9001;
+}

--- a/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.html
+++ b/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.html
@@ -4,18 +4,18 @@
             <label class="slds-form-element__label">{label}</label>
         </template>
         <div class="slds-form-element__control slds-combobox_container slds-is-relative">
-            <lightning-input
-                type="search"
-                variant="label-hidden"
-                value={query}
+            <input
+                type="text"
+                class="slds-input"
                 placeholder={placeholder}
                 disabled={disabled}
+                autocomplete="off"
+                role="combobox"
                 onfocus={handleFocus}
                 oninput={handleInput}
-                onblur={handleBlur}>
-            </lightning-input>
+                onblur={handleBlur} />
             <template if:true={hasResults}>
-                <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-dropdown_length-7" role="listbox">
+                <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-dropdown_length-7 field-selector-dropdown" role="listbox">
                     <template for:each={filtered} for:item="opt">
                         <li key={opt.value} role="presentation" class="slds-listbox__item">
                             <div class="slds-listbox__option slds-listbox__option_plain field-option"

--- a/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.js
+++ b/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.js
@@ -1,58 +1,86 @@
-import { LightningElement, api, track } from 'lwc';
+import { LightningElement, api } from 'lwc';
 
 /**
- * Autocomplete field picker. Filters as you type on EITHER the field label or the API name and
- * shows each result as "label (api name)". Emits a `change` CustomEvent with { value } (the api
- * name), so it is a drop-in replacement for a field lightning-combobox (parent handlers read
- * event.detail.value and event.target.dataset.*).
+ * Autocomplete field picker. Once the user types at least MIN_CHARS characters, it shows the
+ * fields whose label OR API name contains the typed text, each as "label (api name)". Emits a
+ * `change` CustomEvent with { value } (the api name), so it is a drop-in replacement for a field
+ * lightning-combobox (parent handlers read event.detail.value and event.target.dataset.*).
  */
+const MIN_CHARS = 3;
+
 export default class MergeFieldSelector extends LightningElement {
     @api label;
     @api placeholder = 'Search fields...';
     @api disabled = false;
 
-    @track _options = [];
+    _options = [];
     @api
     get options() {
         return this._options;
     }
     set options(value) {
         this._options = (value || []).map(o => ({ label: o.label, value: o.value, display: o.label + ' (' + o.value + ')' }));
-        this.syncQuery();
+        this.syncDisplay();
     }
 
-    @track _value;
+    _value;
     @api
     get value() {
         return this._value;
     }
     set value(v) {
         this._value = v;
-        this.syncQuery();
+        this.syncDisplay();
     }
 
-    @track query = '';
-    @track open = false;
+    // active search text — drives the result list only. The input itself is UNCONTROLLED (no
+    // value binding) so re-renders never reset it mid-typing.
+    query = '';
+    open = false;
+    _pendingDisplaySync = false;
 
-    // show the current selection as "label (api)" in the input
-    syncQuery() {
+    // text shown for the current selection ("label (api name)")
+    get displayValue() {
         if (this._value == null || this._value === '') {
-            this.query = '';
-            return;
+            return '';
         }
         const selected = this._options.find(o => o.value === this._value);
-        this.query = selected ? selected.display : this._value;
+        return selected ? selected.display : this._value;
+    }
+
+    // push the selection text into the uncontrolled input imperatively (the only writes to it)
+    syncDisplay() {
+        const input = this.template.querySelector('input');
+        if (!input) {
+            this._pendingDisplaySync = true; // input not rendered yet; apply after render
+            return;
+        }
+        // never overwrite what the user is actively typing (e.g. a parent re-render landing mid-type)
+        if (this.template.activeElement === input) {
+            return;
+        }
+        input.value = this.displayValue;
+    }
+
+    renderedCallback() {
+        if (this._pendingDisplaySync) {
+            this._pendingDisplaySync = false;
+            this.syncDisplay();
+        }
+    }
+
+    // when the box is just showing the current selection that is not a search
+    get searchTerm() {
+        if (this.query === this.displayValue) {
+            return '';
+        }
+        return (this.query || '').trim();
     }
 
     get filtered() {
-        const selected = this._options.find(o => o.value === this._value);
-        // when the box still shows the current selection, list everything (browsing, not filtering)
-        if (selected && this.query === selected.display) {
-            return this._options;
-        }
-        const q = (this.query || '').toLowerCase().trim();
-        if (!q) {
-            return this._options;
+        const q = this.searchTerm.toLowerCase();
+        if (q.length < MIN_CHARS) {
+            return [];
         }
         return this._options.filter(o => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q));
     }
@@ -75,7 +103,11 @@ export default class MergeFieldSelector extends LightningElement {
     handleSelect(event) {
         const value = event.currentTarget.dataset.value;
         this._value = value;
-        this.syncQuery();
+        this.query = this.displayValue;
+        const input = this.template.querySelector('input');
+        if (input) {
+            input.value = this.displayValue;
+        }
         this.open = false;
         this.dispatchEvent(new CustomEvent('change', { detail: { value } }));
     }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -21,6 +21,7 @@
     "merge@2.4.0-1": "04tKb000000Egz2IAC",
     "merge@2.4.1-1": "04tKb000000Egz7IAC",
     "merge@2.4.2-1": "04tKb000000EgzCIAS",
-    "merge@2.4.3-1": "04tKb000000EgzHIAS"
+    "merge@2.4.3-1": "04tKb000000EgzHIAS",
+    "merge@2.4.4-1": "04tKb000000EgzMIAS"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.4.3",
-      "versionNumber": "2.4.3.NEXT"
+      "versionName": "ver 2.4.4",
+      "versionNumber": "2.4.4.NEXT"
     }
   ],
   "namespace": "",


### PR DESCRIPTION
## Field selector type-ahead fixes (build 2.4.4-1)

Fixes found during dev testing of the `mergeFieldSelector` autocomplete:

- **Input locked after one character** — the controlled `lightning-input` reset its value on every re-render. Switched to a **native uncontrolled `<input>`**; its value is written only imperatively (on selection / external value sync), and that sync is **focus-guarded** so it never overwrites text while you're typing.
- **Dropdown never appeared** — the `slds-dropdown-trigger` wrapper made SLDS hide the results list unless the trigger had `slds-is-open`. Removed the wrapper; the list renders in a relative container positioned below the input via component CSS.
- **≥3 characters** before results show; filter matches **label OR API name contains** the typed text.
- Removed redundant `@track` decorators (fields are reactive by default).

### Packaging
- Bumped to **ver 2.4.4**; built beta **2.4.4-1** (`04tKb000000EgzMIAS`).
- **Not promoted** — to be installed/tested first, then promoted separately.

### Verification
- Jest: 39/39 pass.
- Verified typing + dropdown behavior in gsgDEV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
