### PR TITLE
fix: keep field-selector dropdown open when using its scrollbar (2.4.5)

### DIFF
--- a/force-app/main/default/lwc/mergeFieldSelector/__tests__/mergeFieldSelector.test.js
+++ b/force-app/main/default/lwc/mergeFieldSelector/__tests__/mergeFieldSelector.test.js
@@ -75,4 +75,21 @@ describe('c-merge-field-selector', () => {
         optionEl(el, 'Phone').dispatchEvent(new CustomEvent('mousedown'));
         expect(handler.mock.calls[0][0].detail.value).toBe('Phone');
     });
+
+    it('stays open when interacting inside (e.g. the scrollbar) and closes on an outside click', async () => {
+        const el = await render();
+        await type(el, 'pho');
+        expect(optionText(el)).toEqual(['Phone (Phone)']);
+
+        // a mousedown inside the component (root handler sets the flag) must NOT close it
+        el.shadowRoot.querySelector('.slds-form-element').dispatchEvent(new CustomEvent('mousedown'));
+        document.dispatchEvent(new CustomEvent('mousedown'));
+        await flush();
+        expect(optionText(el)).toEqual(['Phone (Phone)']);
+
+        // a document mousedown with no preceding inside-mousedown closes it
+        document.dispatchEvent(new CustomEvent('mousedown'));
+        await flush();
+        expect(optionText(el)).toEqual([]);
+    });
 });

--- a/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.html
+++ b/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.html
@@ -1,5 +1,5 @@
 <template>
-    <div class="slds-form-element">
+    <div class="slds-form-element" onmousedown={handleRootMouseDown}>
         <template if:true={label}>
             <label class="slds-form-element__label">{label}</label>
         </template>
@@ -12,8 +12,7 @@
                 autocomplete="off"
                 role="combobox"
                 onfocus={handleFocus}
-                oninput={handleInput}
-                onblur={handleBlur} />
+                oninput={handleInput} />
             <template if:true={hasResults}>
                 <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-dropdown_length-7 field-selector-dropdown" role="listbox">
                     <template for:each={filtered} for:item="opt">

--- a/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.js
+++ b/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.js
@@ -38,6 +38,28 @@ export default class MergeFieldSelector extends LightningElement {
     query = '';
     open = false;
     _pendingDisplaySync = false;
+    _mouseInside = false;
+
+    connectedCallback() {
+        // close the list on an outside click (not on blur — blur fires when the user grabs the
+        // dropdown's scrollbar, which would wrongly close it)
+        this._onDocumentMouseDown = () => {
+            if (!this._mouseInside) {
+                this.open = false;
+            }
+            this._mouseInside = false;
+        };
+        document.addEventListener('mousedown', this._onDocumentMouseDown);
+    }
+
+    disconnectedCallback() {
+        document.removeEventListener('mousedown', this._onDocumentMouseDown);
+    }
+
+    // a mousedown anywhere within this component (input, list or its scrollbar) is "inside"
+    handleRootMouseDown() {
+        this._mouseInside = true;
+    }
 
     // text shown for the current selection ("label (api name)")
     get displayValue() {
@@ -96,10 +118,6 @@ export default class MergeFieldSelector extends LightningElement {
         this.query = event.target.value;
         this.open = true;
     }
-    handleBlur() {
-        this.open = false;
-    }
-    // mousedown fires before the input's blur, so the selection registers before the list closes
     handleSelect(event) {
         const value = event.currentTarget.dataset.value;
         this._value = value;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.4.4",
-      "versionNumber": "2.4.4.NEXT"
+      "versionName": "ver 2.4.5",
+      "versionNumber": "2.4.5.NEXT"
     }
   ],
   "namespace": "",


### PR DESCRIPTION
## Scrollbar dismisses results — fixed

Clicking the dropdown's scrollbar blurred the input, and the blur handler closed the list, so the results vanished mid-scroll.

**Fix:** replaced blur-to-close with **close-on-outside-mousedown**. A document `mousedown` listener closes the list unless the mousedown originated inside the component (tracked via a root `onmousedown` flag). Scrollbar and option interaction no longer dismiss the results; clicking outside still closes it. No `preventDefault`, so native scrollbar dragging is untouched.

### Packaging
- Bumped to **ver 2.4.5**; beta build to follow.

### Verification
- Jest: **40/40** (added an outside-click regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)