### PR TITLE
chore: release 2.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The Merge Control app provides SF Administrators with the following tools relate
 
 ## Installation
 
-Current release: **2.4.4** (unlocked package, `04tKb000000EgzMIAS`)
+Current release: **2.4.5** (unlocked package, `04tKb000000EgzRIAS`)
 
 Install via URL:
-- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgzMIAS
-- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgzMIAS
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgzRIAS
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000EgzRIAS
 
 Or with the Salesforce CLI:
 
 ```
-sf package install --package 04tKb000000EgzMIAS --target-org <org-alias> --wait 10
+sf package install --package 04tKb000000EgzRIAS --target-org <org-alias> --wait 10
 ```
 
 After installing, assign the **Merge Control Administrator** permission set to administrators.

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -22,6 +22,7 @@
     "merge@2.4.1-1": "04tKb000000Egz7IAC",
     "merge@2.4.2-1": "04tKb000000EgzCIAS",
     "merge@2.4.3-1": "04tKb000000EgzHIAS",
-    "merge@2.4.4-1": "04tKb000000EgzMIAS"
+    "merge@2.4.4-1": "04tKb000000EgzMIAS",
+    "merge@2.4.5-1": "04tKb000000EgzRIAS"
   }
 }


### PR DESCRIPTION
Promotes unlocked package version **2.4.5-1** (`04tKb000000EgzRIAS`), records the version alias, and updates the README install URL/CLI.

2.4.5 fixes the field-selector dropdown closing when you grab its scrollbar (blur-close replaced with close-on-outside-mousedown).

Verified: installed into lcvFULL (SUCCESS) and tested before promoting; Jest 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)