### PR TITLE
feat: collapsible tabbed Advanced section for field preservation (2.4.6)

### DIFF
--- a/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.css
+++ b/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.css
@@ -1,10 +1,17 @@
-/* anchor the results dropdown directly below the input instead of overlapping it */
+/* anchor the results dropdown directly below the input instead of overlapping it.
+   .slds-dropdown defaults to center alignment (left:50% + translateX(-50%)); neutralize that
+   so the list lines up under the input rather than shifting off to the left. */
 .field-selector-dropdown {
     position: absolute;
     top: 100%;
+    bottom: auto;
     left: 0;
-    right: 0;
+    right: auto;
     width: 100%;
+    min-width: 100%;
+    max-width: 100%;
     margin-top: 2px;
+    transform: none;
+    float: none;
     z-index: 9001;
 }

--- a/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.html
+++ b/force-app/main/default/lwc/mergeFieldSelector/mergeFieldSelector.html
@@ -14,7 +14,7 @@
                 onfocus={handleFocus}
                 oninput={handleInput} />
             <template if:true={hasResults}>
-                <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-dropdown_length-7 field-selector-dropdown" role="listbox">
+                <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_left slds-dropdown_fluid slds-dropdown_length-7 field-selector-dropdown" role="listbox">
                     <template for:each={filtered} for:item="opt">
                         <li key={opt.value} role="presentation" class="slds-listbox__item">
                             <div class="slds-listbox__option slds-listbox__option_plain field-option"

--- a/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
@@ -24,6 +24,15 @@ function hasButton(el, label) {
 function hasInput(el, label) {
     return Array.from(el.shadowRoot.querySelectorAll('lightning-input')).some(i => i.label === label);
 }
+function hasInputContaining(el, text) {
+    return Array.from(el.shadowRoot.querySelectorAll('lightning-input')).some(i => (i.label || '').includes(text));
+}
+function tabLabels(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('.slds-tabs_default__link')).map(a => a.textContent.trim());
+}
+function advancedToggle(el) {
+    return el.shadowRoot.querySelector('.advanced-toggle');
+}
 
 async function renderWithRule(rule) {
     const el = createElement('c-merge-single-record', { is: MergeSingleRecord });
@@ -90,6 +99,44 @@ describe('c-merge-single-record', () => {
         const el = await renderWithRule('Complex');
         const labels = Array.from(el.shadowRoot.querySelectorAll('lightning-combobox')).map(c => c.label);
         expect(labels).toContain('Tie-Break Rule (primary)');
+    });
+
+    it('auto-opens Advanced with Rule Definition, Tie-Break and Fallback tabs for Complex', async () => {
+        const el = await renderWithRule('Complex');
+        expect(tabLabels(el)).toEqual(['Rule Definition', 'Tie-Break', 'Fallback Field']);
+    });
+
+    it('shows Related Field + Fallback tabs for the Related Field rule', async () => {
+        const el = await renderWithRule('Related Field');
+        expect(tabLabels(el)).toEqual(['Related Field', 'Fallback Field']);
+    });
+
+    it('shows Contains Value + Fallback tabs for the Contains rule', async () => {
+        const el = await renderWithRule('Contains');
+        expect(tabLabels(el)).toEqual(['Contains Value', 'Fallback Field']);
+    });
+
+    it('keeps Advanced collapsed for a simple rule and shows only Fallback when expanded', async () => {
+        const el = await renderWithRule('Newest');
+        expect(tabLabels(el)).toEqual([]); // collapsed -> tabs not rendered
+        advancedToggle(el).dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(tabLabels(el)).toEqual(['Fallback Field']);
+    });
+
+    it('keeps Filter Logic collapsed by default (Complex with no filter logic)', async () => {
+        const el = await renderWithRule('Complex');
+        expect(hasButton(el, 'Add Condition')).toBe(true);
+        expect(hasInputContaining(el, 'Filter Logic')).toBe(false);
+    });
+
+    it('expands Filter Logic when it already has a value', async () => {
+        const el = createElement('c-merge-single-record', { is: MergeSingleRecord });
+        el.usedFields = [];
+        el.record = { name: 'TEMPx', type: 'p', rule: 'Complex', objectName: 'Contact', fieldName: 'Email', conditions: [], filterLogic: '1 AND 2', tieBreakDirection: 'DESC' };
+        document.body.appendChild(el);
+        await flush();
+        expect(hasInputContaining(el, 'Filter Logic')).toBe(true);
     });
 
     it('dispatches a save notify when Save is clicked', async () => {

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.css
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.css
@@ -1,0 +1,13 @@
+/* Advanced section: visually set apart from the main field row so it is clear you are in the
+   expanded configuration view */
+.advanced-card {
+    border-left: 4px solid #1b96ff;
+    background-color: #f3f9ff;
+    border-radius: 0.25rem;
+}
+
+.advanced-toggle {
+    display: inline-flex;
+    align-items: center;
+    font-weight: 700;
+}

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
@@ -87,19 +87,6 @@
                                 options={ruleOptions}
                                 onchange={handleRuleSelect}
                             ></lightning-combobox>
-                            <template if:true={objectType}>
-                                <template if:true={fieldResults}>
-                                    <template if:true={isRelatedField}>
-                                        <c-merge-field-selector
-                                            label="Related Field"
-                                            value={mergeRecord.relatedField}
-                                            placeholder="Search fields..."
-                                            options={relatedFieldResults}
-                                            onchange={handleRelatedFieldSelect}
-                                        ></c-merge-field-selector>
-                                    </template>
-                                </template>
-                            </template>
                         </template>
                     </lightning-layout-item>
                     <lightning-layout-item padding="around-small" size="2">
@@ -110,126 +97,160 @@
                     </lightning-layout-item>
                 </lightning-layout>
 
-                <template if:true={objectType}>
-                    <template if:true={fieldResults}>
-                        <div class="slds-box slds-m-horizontal_small slds-m-bottom_small">
-                            <p class="slds-text-title_caps slds-m-bottom_x-small">Fallback Field (optional)</p>
-                            <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
-                                When this field's value is lost on the kept record, write the losing value into
-                                this field instead (only if it is empty). The routed value is recorded in Merge
-                                Field History with the target field.
-                            </p>
-                            <c-merge-field-selector
-                                label="Fallback Field"
-                                value={mergeRecord.fallbackField}
-                                placeholder="Search fields..."
-                                options={fieldResults}
-                                onchange={handleFallbackFieldSelect}
-                            ></c-merge-field-selector>
-                        </div>
-                    </template>
-                </template>
+                <template if:true={showAdvanced}>
+                    <div class="advanced-card slds-box slds-m-horizontal_small slds-m-bottom_medium">
+                        <button class="slds-button advanced-toggle" onclick={toggleAdvanced} aria-expanded={advancedOpen}>
+                            <lightning-icon icon-name={advancedChevron} size="x-small" class="slds-m-right_x-small"></lightning-icon>
+                            <span class="slds-text-title_caps">Advanced</span>
+                        </button>
 
-                <template if:true={isComplex}>
-                    <div class="slds-box slds-m-horizontal_small slds-m-bottom_medium">
-                        <p class="slds-text-title_caps slds-m-bottom_x-small">Complex Rule</p>
-                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
-                            Preserve this field's value from the record that matches the conditions below.
-                            When more than one record matches, the tie-break field decides which wins.
-                        </p>
+                        <template if:true={advancedOpen}>
+                            <div class="slds-tabs_default slds-m-top_small">
+                                <ul class="slds-tabs_default__nav" role="tablist">
+                                    <template for:each={tabs} for:item="tab">
+                                        <li key={tab.key} class={tab.liClass} role="presentation">
+                                            <a class="slds-tabs_default__link" role="tab" tabindex="0"
+                                                data-tab={tab.key} onclick={selectTab}>{tab.label}</a>
+                                        </li>
+                                    </template>
+                                </ul>
 
-                        <template for:each={mergeRecord.conditions} for:item="condition">
-                            <div key={condition.conditionIndex} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
-                                <div class="slds-col slds-size_1-of-12 slds-text-body_small slds-align-middle">{condition.conditionIndex}</div>
-                                <div class="slds-col slds-size_4-of-12">
-                                    <c-merge-field-selector
-                                        label="Field"
-                                        value={condition.fieldName}
-                                        options={allFieldOptions}
-                                        data-condition={condition.conditionIndex}
-                                        onchange={handleConditionFieldSelect}>
+                                <template if:true={isRelatedField}>
+                                    <div class={panelClass.related} role="tabpanel">
+                                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
+                                            Choose the field that the value of this current field should be preserved with.
+                                        </p>
+                                        <c-merge-field-selector label="Related Field" value={mergeRecord.relatedField}
+                                            placeholder="Search fields..." options={relatedFieldResults}
+                                            onchange={handleRelatedFieldSelect}>
+                                        </c-merge-field-selector>
+                                    </div>
+                                </template>
+
+                                <template if:true={isContains}>
+                                    <div class={panelClass.contains} role="tabpanel">
+                                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
+                                            Keep this field's value from whichever record's value contains the substring
+                                            below (case-sensitive).
+                                        </p>
+                                        <lightning-input label="Contains Value" value={mergeRecord.containsValue}
+                                            onchange={handleContainsValueChange}>
+                                        </lightning-input>
+                                    </div>
+                                </template>
+
+                                <template if:true={isComplex}>
+                                    <div class={panelClass.ruleDef} role="tabpanel">
+                                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
+                                            Preserve this field's value from the record that matches the conditions below.
+                                        </p>
+
+                                        <template for:each={mergeRecord.conditions} for:item="condition">
+                                            <div key={condition.conditionIndex} class="slds-grid slds-gutters slds-grid_vertical-align-end slds-m-bottom_x-small">
+                                                <div class="slds-col slds-size_1-of-12 slds-text-body_small slds-align-middle">{condition.conditionIndex}</div>
+                                                <div class="slds-col slds-size_4-of-12">
+                                                    <c-merge-field-selector
+                                                        label="Field"
+                                                        value={condition.fieldName}
+                                                        options={allFieldOptions}
+                                                        data-condition={condition.conditionIndex}
+                                                        onchange={handleConditionFieldSelect}>
+                                                    </c-merge-field-selector>
+                                                </div>
+                                                <div class="slds-col slds-size_3-of-12">
+                                                    <lightning-combobox
+                                                        label="Operator"
+                                                        value={condition.operator}
+                                                        options={operatorOptions}
+                                                        data-condition={condition.conditionIndex}
+                                                        onchange={handleConditionOperatorSelect}>
+                                                    </lightning-combobox>
+                                                </div>
+                                                <div class="slds-col slds-size_3-of-12">
+                                                    <template if:true={condition.isCheckbox}>
+                                                        <lightning-input type="checkbox" label="Value" checked={condition.checked}
+                                                            data-condition={condition.conditionIndex} onchange={handleConditionValueChange}>
+                                                        </lightning-input>
+                                                    </template>
+                                                    <template if:false={condition.isCheckbox}>
+                                                        <lightning-input type={condition.inputType} label="Value" value={condition.value}
+                                                            data-condition={condition.conditionIndex} onchange={handleConditionValueChange}>
+                                                        </lightning-input>
+                                                    </template>
+                                                </div>
+                                                <div class="slds-col slds-size_1-of-12">
+                                                    <lightning-button-icon icon-name="utility:close" alternative-text="Remove condition"
+                                                        title="Remove condition" data-condition={condition.conditionIndex} onclick={removeCondition}>
+                                                    </lightning-button-icon>
+                                                </div>
+                                            </div>
+                                        </template>
+
+                                        <lightning-button label="Add Condition" icon-name="utility:add" variant="base"
+                                            class="slds-m-bottom_x-small" onclick={addCondition}>
+                                        </lightning-button>
+
+                                        <div class="slds-m-top_x-small">
+                                            <button class="slds-button" onclick={toggleFilterLogic} aria-expanded={filterLogicOpen}>
+                                                <lightning-icon icon-name={filterLogicChevron} size="xx-small" class="slds-m-right_xx-small"></lightning-icon>
+                                                Filter Logic
+                                            </button>
+                                            <template if:true={filterLogicOpen}>
+                                                <lightning-input label="Filter Logic (e.g. (1 AND 2) OR 3 — leave blank to AND all conditions)"
+                                                    value={mergeRecord.filterLogic} onchange={handleFilterLogicChange}>
+                                                </lightning-input>
+                                            </template>
+                                        </div>
+                                    </div>
+
+                                    <div class={panelClass.tieBreak} role="tabpanel">
+                                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
+                                            When more than one record matches, the tie-break field decides which wins.
+                                        </p>
+                                        <lightning-combobox label="Tie-Break Rule (primary)" value={mergeRecord.tieBreakRule}
+                                            placeholder="Select Rule" options={tieBreakRuleOptions} onchange={handleTieBreakRuleSelect}>
+                                        </lightning-combobox>
+                                        <div class="slds-grid slds-gutters slds-m-top_x-small">
+                                            <div class="slds-col slds-size_6-of-12">
+                                                <c-merge-field-selector label="Tie-Break Field (secondary)" value={mergeRecord.tieBreakField}
+                                                    placeholder="Search fields..." options={allFieldOptions} onchange={handleTieBreakFieldSelect}>
+                                                </c-merge-field-selector>
+                                            </div>
+                                            <div class="slds-col slds-size_6-of-12">
+                                                <lightning-combobox label="Secondary Direction" value={mergeRecord.tieBreakDirection}
+                                                    options={directionOptions} onchange={handleTieBreakDirectionSelect}>
+                                                </lightning-combobox>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                <template if:true={isApex}>
+                                    <div class={panelClass.apex} role="tabpanel">
+                                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
+                                            This field's kept value is decided by a custom Apex class implementing
+                                            MRG_FieldKeepRule, run after the built-in rules. Enter the class name
+                                            (e.g. MRG_SampleFieldKeepRule).
+                                        </p>
+                                        <lightning-input label="Apex Class" value={mergeRecord.apexClass}
+                                            onchange={handleApexClassChange}>
+                                        </lightning-input>
+                                    </div>
+                                </template>
+
+                                <div class={panelClass.fallback} role="tabpanel">
+                                    <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
+                                        When this field's value is lost on the kept record, write the losing value into
+                                        this field instead (only if it is empty). The routed value is recorded in Merge
+                                        Field History with the target field.
+                                    </p>
+                                    <c-merge-field-selector label="Fallback Field" value={mergeRecord.fallbackField}
+                                        placeholder="Search fields..." options={fieldResults}
+                                        onchange={handleFallbackFieldSelect}>
                                     </c-merge-field-selector>
-                                </div>
-                                <div class="slds-col slds-size_3-of-12">
-                                    <lightning-combobox
-                                        label="Operator"
-                                        value={condition.operator}
-                                        options={operatorOptions}
-                                        data-condition={condition.conditionIndex}
-                                        onchange={handleConditionOperatorSelect}>
-                                    </lightning-combobox>
-                                </div>
-                                <div class="slds-col slds-size_3-of-12">
-                                    <template if:true={condition.isCheckbox}>
-                                        <lightning-input type="checkbox" label="Value" checked={condition.checked}
-                                            data-condition={condition.conditionIndex} onchange={handleConditionValueChange}>
-                                        </lightning-input>
-                                    </template>
-                                    <template if:false={condition.isCheckbox}>
-                                        <lightning-input type={condition.inputType} label="Value" value={condition.value}
-                                            data-condition={condition.conditionIndex} onchange={handleConditionValueChange}>
-                                        </lightning-input>
-                                    </template>
-                                </div>
-                                <div class="slds-col slds-size_1-of-12">
-                                    <lightning-button-icon icon-name="utility:close" alternative-text="Remove condition"
-                                        title="Remove condition" data-condition={condition.conditionIndex} onclick={removeCondition}>
-                                    </lightning-button-icon>
                                 </div>
                             </div>
                         </template>
-
-                        <lightning-button label="Add Condition" icon-name="utility:add" variant="base"
-                            class="slds-m-bottom_x-small" onclick={addCondition}>
-                        </lightning-button>
-
-                        <lightning-input label="Filter Logic (e.g. (1 AND 2) OR 3 — leave blank to AND all conditions)"
-                            value={mergeRecord.filterLogic} onchange={handleFilterLogicChange}>
-                        </lightning-input>
-
-                        <lightning-combobox label="Tie-Break Rule (primary)" value={mergeRecord.tieBreakRule}
-                            placeholder="Select Rule" options={tieBreakRuleOptions} onchange={handleTieBreakRuleSelect}
-                            class="slds-m-top_x-small">
-                        </lightning-combobox>
-                        <div class="slds-grid slds-gutters slds-m-top_x-small">
-                            <div class="slds-col slds-size_6-of-12">
-                                <c-merge-field-selector label="Tie-Break Field (secondary)" value={mergeRecord.tieBreakField}
-                                    placeholder="Search fields..." options={allFieldOptions} onchange={handleTieBreakFieldSelect}>
-                                </c-merge-field-selector>
-                            </div>
-                            <div class="slds-col slds-size_6-of-12">
-                                <lightning-combobox label="Secondary Direction" value={mergeRecord.tieBreakDirection}
-                                    options={directionOptions} onchange={handleTieBreakDirectionSelect}>
-                                </lightning-combobox>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-
-                <template if:true={isApex}>
-                    <div class="slds-box slds-m-horizontal_small slds-m-bottom_medium">
-                        <p class="slds-text-title_caps slds-m-bottom_x-small">Apex Defined Rule</p>
-                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
-                            This field's kept value is decided by a custom Apex class implementing
-                            MRG_FieldKeepRule, run after the built-in rules. Enter the class name
-                            (e.g. MRG_SampleFieldKeepRule).
-                        </p>
-                        <lightning-input label="Apex Class" value={mergeRecord.apexClass}
-                            onchange={handleApexClassChange}>
-                        </lightning-input>
-                    </div>
-                </template>
-
-                <template if:true={isContains}>
-                    <div class="slds-box slds-m-horizontal_small slds-m-bottom_medium">
-                        <p class="slds-text-title_caps slds-m-bottom_x-small">Contains Text</p>
-                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
-                            Keep this field's value from whichever record's value contains the substring
-                            below (case-sensitive).
-                        </p>
-                        <lightning-input label="Contains Value" value={mergeRecord.containsValue}
-                            onchange={handleContainsValueChange}>
-                        </lightning-input>
                     </div>
                 </template>
             </template>

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
@@ -10,7 +10,11 @@ export default class mergeSingleRecord extends LightningElement {
         this.mergeRecord = JSON.parse(JSON.stringify(value));
         this.objectType = this.mergeRecord.objectName;
         this.isEdit = this.mergeRecord !== undefined && this.mergeRecord != null && this.mergeRecord.name.includes('TEMP');
-    }   
+        // Advanced opens automatically for an advanced rule; Filter Logic expands if it has a value
+        this.advancedOpen = this.isAdvancedRule;
+        this.activeTab = this.firstTabKey;
+        this.filterLogicOpen = !!(this.mergeRecord && this.mergeRecord.filterLogic);
+    }
     get record(){
         return this.mergeRecord;
     }
@@ -21,6 +25,9 @@ export default class mergeSingleRecord extends LightningElement {
     @track error;
     @track isEdit = false;
     @track action;
+    advancedOpen = false;
+    filterLogicOpen = false;
+    activeTab = 'fallback';
     get isActive() {
         return this.record != null && !this.record.disable;
     }
@@ -120,6 +127,64 @@ export default class mergeSingleRecord extends LightningElement {
         return this.mergeRecord !== undefined && this.mergeRecord != null && this.preserve && this.mergeRecord.rule == 'Contains';
     }
 
+    // rules that need configuration beyond the simple ones -> auto-open the Advanced section
+    get isAdvancedRule(){
+        return this.isRelatedField || this.isContains || this.isComplex || this.isApex;
+    }
+    // Advanced (incl. the always-present Fallback tab) is available once an object is chosen
+    get showAdvanced(){
+        return this.objectType != null && this.objectType !== '';
+    }
+    get advancedChevron(){
+        return this.advancedOpen ? 'utility:chevrondown' : 'utility:chevronright';
+    }
+    get filterLogicChevron(){
+        return this.filterLogicOpen ? 'utility:chevrondown' : 'utility:chevronright';
+    }
+    // the first (default-active) tab for the current rule
+    get firstTabKey(){
+        if(this.isRelatedField) return 'related';
+        if(this.isContains) return 'contains';
+        if(this.isComplex) return 'ruleDef';
+        if(this.isApex) return 'apex';
+        return 'fallback';
+    }
+    // nav tabs: the rule-specific tab(s) first, Fallback Field always last
+    get tabs(){
+        const t = [];
+        if(this.isRelatedField) t.push({key:'related', label:'Related Field'});
+        else if(this.isContains) t.push({key:'contains', label:'Contains Value'});
+        else if(this.isComplex){ t.push({key:'ruleDef', label:'Rule Definition'}); t.push({key:'tieBreak', label:'Tie-Break'}); }
+        else if(this.isApex) t.push({key:'apex', label:'Apex Class'});
+        t.push({key:'fallback', label:'Fallback Field'});
+        return t.map(tab=>({
+            key: tab.key,
+            label: tab.label,
+            liClass: 'slds-tabs_default__item' + (tab.key === this.activeTab ? ' slds-is-active' : '')
+        }));
+    }
+    // per-panel visibility classes (all panels for the rule render; only the active one is shown)
+    get panelClass(){
+        const cls = key => 'slds-tabs_default__content slds-p-around_small ' + (this.activeTab === key ? 'slds-show' : 'slds-hide');
+        return {
+            related: cls('related'),
+            contains: cls('contains'),
+            ruleDef: cls('ruleDef'),
+            tieBreak: cls('tieBreak'),
+            apex: cls('apex'),
+            fallback: cls('fallback')
+        };
+    }
+    toggleAdvanced(){
+        this.advancedOpen = !this.advancedOpen;
+    }
+    toggleFilterLogic(){
+        this.filterLogicOpen = !this.filterLogicOpen;
+    }
+    selectTab(event){
+        this.activeTab = event.currentTarget.dataset.tab;
+    }
+
     // re-derive each condition's value input type from its selected field, and add row indices
     refreshConditionInputTypes(){
         if(this.mergeRecord && Array.isArray(this.mergeRecord.conditions)){
@@ -217,7 +282,13 @@ export default class mergeSingleRecord extends LightningElement {
             this.mergeRecord.filterLogic = this.mergeRecord.filterLogic || '';
             this.mergeRecord.tieBreakDirection = this.mergeRecord.tieBreakDirection || 'DESC';
             this.refreshConditionInputTypes();
+            this.filterLogicOpen = !!this.mergeRecord.filterLogic;
         }
+        // choosing an advanced rule opens the Advanced section; move to that rule's first tab
+        if(this.isAdvancedRule){
+            this.advancedOpen = true;
+        }
+        this.activeTab = this.firstTabKey;
     }
 
     addCondition(){

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.4.5",
-      "versionNumber": "2.4.5.NEXT"
+      "versionName": "ver 2.4.6",
+      "versionNumber": "2.4.6.NEXT"
     }
   ],
   "namespace": "",


### PR DESCRIPTION
## Advanced field-preservation UI

Reworks the `mergeSingleRecord` edit experience. Per-rule configuration and the Fallback field now live in a single, visually distinct **Advanced** card (blue accent) instead of separate boxes.

- **Collapsed by default; auto-opens** when you choose Contains, Complex Rule, Related Field Value, or Apex Defined Rule.
- **Tabbed**, with **Fallback Field always the last tab**:
  - Related Field Value → `Related Field`, `Fallback Field`
  - Contains Text → `Contains Value`, `Fallback Field`
  - Apex Defined → `Apex Class`, `Fallback Field`
  - Complex → `Rule Definition`, `Tie-Break`, `Fallback Field`
  - simple / Track → `Fallback Field` only
- **Complex › Rule Definition**: conditions + Add Condition + a **collapsible Filter Logic** (auto-expanded when it already has a value). **Tie-Break** tab holds the primary rule + secondary field/direction.
- Moved the Related Field picker out of the main row into its tab.
- **mergeFieldSelector dropdown**: left-aligned (neutralized SLDS center transform + `slds-dropdown_left`) so lookups render directly below the input in narrow tab columns.

### Packaging
- Bumped to **ver 2.4.6**; beta build + lcvFULL install to follow.

### Verification
- Jest **46/46** (added 6 tests: tab sets per rule, auto-open, collapse, Filter Logic expand).
- Reviewed in gsgDEV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)