### PR TITLE
fix: Auto-Merge Accounts Rules list not refreshing after save

### DIFF
--- a/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL.cls
+++ b/force-app/main/default/classes/MRG_AutoMergeAccounts_CTRL.cls
@@ -11,7 +11,9 @@ public with sharing class MRG_AutoMergeAccounts_CTRL {
 	* @param objectType the SObject api name
 	* @return List<MRG_AutoMergeAccountsRule>
 	*/
-	@auraEnabled(cacheable=true)
+	// not cacheable: rules are edited in this same UI and re-loaded right after a save, so a cached
+	// (pre-save) result would make the freshly saved rules appear to be missing
+	@auraEnabled
 	public static List<MRG_AutoMergeAccountsRule> getRules(String objectType) {
 		if(String.isBlank(objectType))
 			return new List<MRG_AutoMergeAccountsRule>();


### PR DESCRIPTION
`MRG_AutoMergeAccounts_CTRL.getRules` was `@AuraEnabled(cacheable=true)`. The rules are edited in the same UI and re-loaded immediately after an async metadata-deploy save, so the cached pre-save result could come back stale — making a freshly saved rule look like it didn't persist. Made `getRules` non-cacheable (it's called imperatively).

Verified the data layer is correct: saved rules persist with `Object__c`/`Object__r` populated. Rules are scoped to the merge-candidate object (e.g. Contact), so the list shows only rules for the object selected in the dropdown.

Deployed to gsgDEV for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)