### PR TITLE
fix: duplicate list too-many-rows + two-level pagination

### DIFF
--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -12,11 +12,12 @@ public with sharing class MRG_DuplicateMerge_CTRL {
 	*/
     @AuraEnabled(cacheable=TRUE)
     public static Integer getCount(String objectType, String ruleName){
-        // count distinct keeps: the pager pages over keep groups, not individual pairs
-        String soqlQuery= 'SELECT COUNT_DISTINCT(KeepRecordId__c) keeps FROM MergeCandidate__c ';
+        // count candidate pairs (the list pages over pairs, grouped for display). COUNT_DISTINCT and
+        // GROUP BY aggregate every matching row and throw an uncatchable "Too many query rows" once a
+        // candidate set exceeds 50k; a plain COUNT() is governor-safe (uses a single query row).
+        String soqlQuery= 'SELECT COUNT() FROM MergeCandidate__c ';
         soqlQuery+=MRG_Duplicate_SVC.getWhereClause(objectType, ruleName);
-        List<AggregateResult> results = Database.query(soqlQuery);
-        return results.isEmpty() ? 0 : (Integer) results[0].get('keeps');
+        return Database.countQuery(soqlQuery);
     }
 
 	/*******************************************************************************************************
@@ -27,37 +28,30 @@ public with sharing class MRG_DuplicateMerge_CTRL {
     @AuraEnabled(cacheable=TRUE)
     public static List<keepGroup> getKeepGroups(String objectType, String ruleName, Integer limitAmt, Integer offsetAmt){
         limitAmt = limitAmt == null ? 200 : limitAmt;
-        // page over distinct keeps, ordered by each keep's top confidence (nulls last)
-        String keepQuery = 'SELECT KeepRecordId__c keepId, MAX(ConfidenceScore__c) maxConf FROM MergeCandidate__c';
-        keepQuery += MRG_Duplicate_SVC.getWhereClause(objectType, ruleName);
-        keepQuery += ' GROUP BY KeepRecordId__c ORDER BY MAX(ConfidenceScore__c) DESC NULLS LAST';
-        keepQuery += ' LIMIT ' + limitAmt;
+        // page over the candidate pairs directly (highest confidence first) and group them by kept
+        // record for display. Avoids GROUP BY/COUNT_DISTINCT, which aggregate every matching row and
+        // throw an uncatchable "Too many query rows" once a candidate set exceeds 50k.
+        String pairQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL();
+        pairQuery += MRG_Duplicate_SVC.getWhereClause(objectType, ruleName);
+        pairQuery += ' ORDER BY ConfidenceScore__c DESC NULLS LAST, KeepRecordId__c, CreatedDate DESC, Id ASC';
+        pairQuery += ' LIMIT ' + limitAmt;
         if(offsetAmt != null
             && offsetAmt < 2000
             && offsetAmt > 0)
-            keepQuery += ' OFFSET :offsetAmt';
-        List<String> keepIds = new List<String>();
-        for(AggregateResult ar:(List<AggregateResult>) Database.query(keepQuery))
-            keepIds.add((String) ar.get('keepId'));
-        if(keepIds.isEmpty())
-            return new List<keepGroup>();
-        // fetch the pairs for those keeps, ordered by confidence desc within each keep
-        String pairQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL();
-        pairQuery += MRG_Duplicate_SVC.getWhereClause(objectType, ruleName);
-        pairQuery += ' AND KeepRecordId__c IN :keepIds';
-        pairQuery += ' ORDER BY ConfidenceScore__c DESC NULLS LAST, CreatedDate DESC, Id ASC';
+            pairQuery += ' OFFSET :offsetAmt';
+        // group the page's pairs by kept record, preserving first-seen (confidence) order
         Map<String, keepGroup> groupsByKeep = new Map<String, keepGroup>();
+        List<String> keepOrder = new List<String>();
         for(MergeCandidate__c c:(List<MergeCandidate__c>) Database.query(pairQuery)) {
-            if(!groupsByKeep.containsKey(c.KeepRecordId__c))
+            if(!groupsByKeep.containsKey(c.KeepRecordId__c)) {
                 groupsByKeep.put(c.KeepRecordId__c, new keepGroup(c));
+                keepOrder.add(c.KeepRecordId__c);
+            }
             groupsByKeep.get(c.KeepRecordId__c).pairs.add(new mergeGroup(c));
         }
-        // preserve the keep ordering from the paged aggregate query
         List<keepGroup> result = new List<keepGroup>();
-        for(String keepId:keepIds) {
-            if(groupsByKeep.containsKey(keepId))
-                result.add(groupsByKeep.get(keepId));
-        }
+        for(String keepId:keepOrder)
+            result.add(groupsByKeep.get(keepId));
         return result;
     }
 	/*******************************************************************************************************

--- a/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
+++ b/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
@@ -58,6 +58,29 @@ function mergeButton(el, recordId) {
     return Array.from(el.shadowRoot.querySelectorAll('lightning-button'))
         .find(b => b.label === 'Merge' && b.dataset.record === recordId);
 }
+function groupPager(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('c-pager')).find(p => !p.dataset.keep);
+}
+function pairPager(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('c-pager')).find(p => p.dataset.keep);
+}
+function makeGroups(n, pairsEach) {
+    return Array.from({ length: n }, (_, i) => ({
+        keepId: 'k' + i, keepName: 'Keep' + i, objectType: 'Account', keepLink: '/k' + i,
+        pairs: Array.from({ length: pairsEach }, (_, j) => ({
+            id: 'k' + i + 'p' + j, mergeId: 'm' + i + j, mergeName: 'M' + i + j, mergeLink: '/m' + i + j,
+            confidenceScore: 90 - j, autoMerge: false
+        }))
+    }));
+}
+async function renderGroups(groups) {
+    const el = createElement('c-dupe-list', { is: DupeList });
+    document.body.appendChild(el);
+    getKeepGroups.emit(groups);
+    await Promise.resolve();
+    await Promise.resolve();
+    return el;
+}
 
 describe('c-dupe-list', () => {
     afterEach(() => {
@@ -92,5 +115,26 @@ describe('c-dupe-list', () => {
 
         expect(mockMergeRecord).toHaveBeenCalledWith({ recordId: 'p1' });
         expect(previewButtons(el).length).toBe(1); // the other pair survives
+    });
+
+    it('pages through duplicate groups with the outer pager (10 per page)', async () => {
+        const el = await renderGroups(makeGroups(12, 1));
+        expect(groupPager(el)).toBeTruthy();
+        expect(previewButtons(el).length).toBe(10); // first page of groups
+
+        groupPager(el).dispatchEvent(new CustomEvent('page', { detail: 2, bubbles: true }));
+        await flush();
+        expect(previewButtons(el).length).toBe(2); // remaining 2 groups
+    });
+
+    it('pages through duplicates within a group with the inner pager (5 per page)', async () => {
+        const el = await renderGroups(makeGroups(1, 7));
+        expect(previewButtons(el).length).toBe(5); // first page of duplicates
+        const ip = pairPager(el);
+        expect(ip).toBeTruthy();
+
+        ip.dispatchEvent(new CustomEvent('page', { detail: 2, bubbles: true }));
+        await flush();
+        expect(previewButtons(el).length).toBe(2); // remaining 2 duplicates
     });
 });

--- a/force-app/main/default/lwc/dupeList/dupeList.html
+++ b/force-app/main/default/lwc/dupeList/dupeList.html
@@ -29,12 +29,17 @@
                 <lightning-spinner variant="brand" size="large" alternative-text="Processing..."></lightning-spinner>
             </div>
         </template>
+        <template if:true={cappedNotice}>
+            <div class="slds-m-horizontal_medium slds-m-bottom_small slds-text-color_weak slds-text-body_small">
+                {cappedNotice}
+            </div>
+        </template>
         <template if:true={hasGroups}>
-            <template if:true={hasPager}>
-                <c-pager total-pages={totalPages} current-page={currentPage} onpage={handlePager}></c-pager>
+            <template if:true={hasGroupPager}>
+                <c-pager total-pages={groupTotalPages} current-page={currentGroupPage} onpage={handleGroupPage}></c-pager>
             </template>
             <div class="slds-m-around_medium">
-                <template for:each={keepGroups} for:item="group">
+                <template for:each={pagedGroups} for:item="group">
                     <div key={group.keepId} class="slds-box slds-box_x-small slds-m-bottom_small">
                         <!-- keep header -->
                         <lightning-layout class="slds-text-title_caps slds-p-around_x-small slds-theme_shade">
@@ -57,7 +62,7 @@
                             <lightning-layout-item padding="around-small" size="6">Actions</lightning-layout-item>
                         </lightning-layout>
                         <!-- pair rows -->
-                        <template for:each={group.pairs} for:item="pair">
+                        <template for:each={group.visiblePairs} for:item="pair">
                             <lightning-layout key={pair.id} class="slds-border_top">
                                 <lightning-layout-item padding="around-small" size="3">
                                     <lightning-formatted-url value={pair.mergeLink} label={pair.mergeName} target="_blank"></lightning-formatted-url>
@@ -75,6 +80,12 @@
                                     <lightning-button variant="neutral" label="Merge Accounts" onclick={handleMergeAccounts} class="slds-m-right_x-small" data-record={pair.id}></lightning-button>
                                 </lightning-layout-item>
                             </lightning-layout>
+                        </template>
+                        <!-- inner pager: duplicates within this group -->
+                        <template if:true={group.showPairPager}>
+                            <div class="slds-border_top slds-p-top_x-small">
+                                <c-pager total-pages={group.pairTotalPages} current-page={group.pairPage} onpage={handlePairPage} data-keep={group.keepId}></c-pager>
+                            </div>
                         </template>
                     </div>
                 </template>

--- a/force-app/main/default/lwc/dupeList/dupeList.js
+++ b/force-app/main/default/lwc/dupeList/dupeList.js
@@ -1,4 +1,4 @@
-import { LightningElement, api, track, wire } from 'lwc';
+import { LightningElement, track, wire } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getKeepGroups from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getKeepGroups';
 import getDuplicateRules from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getRules';
@@ -7,35 +7,63 @@ import doMergeRecord from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecord'
 import doRemoveRecord from '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecord';
 import doMergeAccounts from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccounts';
 
+// the highest-confidence duplicates are fetched in one governor-safe query (no GROUP BY /
+// COUNT_DISTINCT, which throw past 50k candidates), then paged client-side: an outer pager over
+// duplicate groups and an inner pager over the duplicates within each group.
+const CAP = 2000;
+const GROUPS_PER_PAGE = 10;
+const PAIRS_PER_PAGE = 5;
+
 export default class DupeList extends LightningElement {
     @track objectType;
-    @track keepGroups;
     @track rule;
     @track error;
-    @track limitAmt = 100;
-    @track offsetAmt;
-    @track totalRows;
-    @track totalPages;
-    @track currentPage;
+    @track allGroups = [];
+    @track currentGroupPage = 1;
+    @track totalDuplicates;
     @track selectedRecordId;
     @track navItems = [];
     @track isModalOpen = false;
     @track showSpinner = false;
+    @track ruleOptions;
 
-    get hasPager(){
-        return this.totalPages != null && this.totalPages !== undefined;
-    }
-    get hasGroups(){
-        return this.keepGroups != null && this.keepGroups.length > 0;
+    objectOptions = [{label:'Account',value:'Account'},{label:'Contact', value:'Contact'}];
+    notificationBody;
+    notificationStyle;
+    notificationTitle;
+
+    connectedCallback(){
+        if(this.objectType == null || this.objectType === undefined){
+            this.objectType = 'Contact';
+            this.fetchRules();
+        }
     }
 
-    set countValue(value){
-        this.totalRows = value != null ? Number(value) : null;
-        this.totalPages = this.totalRows !== undefined && this.totalRows != null && this.totalRows > this.limitAmt ? Number(Math.ceil(this.totalRows / this.limitAmt)) : 1;
-        this.currentPage = this.currentPage === undefined || this.currentPage == null ? 1 : this.currentPage;
-    }
-    get countValue(){
-        return this.totalRows;
+    @wire(getKeepGroups, {objectType:'$objectType', ruleName:'$rule', limitAmt: CAP, offsetAmt: 0})
+        getRowData({error, data}) {
+            if(data){
+                this.allGroups = this.decorate(data);
+                this.currentGroupPage = 1;
+                this.showSpinner = false;
+                this.fetchCount();
+            } else if(error){
+                this.showSpinner = false;
+                this.allGroups = [];
+                this.error = error;
+                this.handleError();
+            }
+        }
+
+    decorate(data){
+        return JSON.parse(JSON.stringify(data)).map(group=>{
+            group.pairs = (group.pairs || []).map(pair=>{
+                pair.confidenceDisplay = (pair.confidenceScore != null && pair.confidenceScore !== undefined) ? pair.confidenceScore : '—';
+                return pair;
+            });
+            group.pairCount = group.pairs.length;
+            group.pairPage = 1;
+            return group;
+        });
     }
 
     set rules(value) {
@@ -52,51 +80,45 @@ export default class DupeList extends LightningElement {
     get rules(){
         return this.ruleOptions;
     }
-    @track ruleOptions;
 
-    objectOptions = [{label:'Account',value:'Account'},{label:'Contact', value:'Contact'}];
-    notificationBody;
-    notificationStyle;
-    notificationTitle;
-
-    connectedCallback(){
-        var objectisNull = this.objectType == null || this.objectType === undefined;
-        this.limitAmt = this.limitAmt == null || this.limitAmt === undefined ? 100 : Number(this.limitAmt);
-        this.offsetAmt = this.offsetAmt == null || this.offsetAmt === undefined ? 0 : this.offsetAmt;
-        this.objectType = objectisNull ? 'Contact' : this.objectType;
-        if(objectisNull){
-            this.fetchRules();
-        }
+    get hasGroups(){
+        return this.allGroups != null && this.allGroups.length > 0;
     }
-
-    @wire(getKeepGroups, {objectType:'$objectType',ruleName:'$rule',limitAmt:'$limitAmt',offsetAmt:'$offsetAmt'})
-        getRowData({error, data}) {
-            if(data){
-                this.keepGroups = this.decorate(data);
-                this.showSpinner = false;
-                this.fetchCount();
-            } else if(error){
-                this.showSpinner = false;
-                this.keepGroups = undefined;
-                this.error = error;
-                this.handleError();
-            }
-        }
-
-    decorate(data){
-        return JSON.parse(JSON.stringify(data)).map(group=>{
-            group.pairs = (group.pairs || []).map(pair=>{
-                pair.confidenceDisplay = (pair.confidenceScore != null && pair.confidenceScore !== undefined) ? pair.confidenceScore : '—';
-                return pair;
-            });
-            group.pairCount = group.pairs.length;
-            return group;
+    get groupTotalPages(){
+        return Math.max(1, Math.ceil(this.allGroups.length / GROUPS_PER_PAGE));
+    }
+    get hasGroupPager(){
+        return this.allGroups.length > GROUPS_PER_PAGE;
+    }
+    // the groups on the current outer page, each sliced to its current inner (duplicates) page
+    get pagedGroups(){
+        const start = (this.currentGroupPage - 1) * GROUPS_PER_PAGE;
+        return this.allGroups.slice(start, start + GROUPS_PER_PAGE).map(g=>{
+            const pairPage = g.pairPage || 1;
+            return {
+                keepId: g.keepId,
+                keepName: g.keepName,
+                keepLink: g.keepLink,
+                objectType: g.objectType,
+                pairCount: g.pairCount,
+                pairPage: pairPage,
+                pairTotalPages: Math.max(1, Math.ceil(g.pairs.length / PAIRS_PER_PAGE)),
+                showPairPager: g.pairs.length > PAIRS_PER_PAGE,
+                visiblePairs: g.pairs.slice((pairPage - 1) * PAIRS_PER_PAGE, pairPage * PAIRS_PER_PAGE)
+            };
         });
+    }
+    // when more duplicates exist than the fetched cap, tell the user this is the top slice
+    get cappedNotice(){
+        return (this.totalDuplicates != null && this.totalDuplicates > CAP)
+            ? 'Showing the ' + CAP + ' highest-confidence duplicates of ' + this.totalDuplicates +
+              ' total. Work the top matches, then refresh for the next set.'
+            : null;
     }
 
     fetchCount(){
         getCount({objectType:this.objectType,ruleName:this.rule})
-            .then(result=>{ this.countValue = result; })
+            .then(result=>{ this.totalDuplicates = result != null ? Number(result) : null; })
             .catch(error=>{ this.error=error; this.handleError(); });
     }
     fetchRules(){
@@ -107,28 +129,30 @@ export default class DupeList extends LightningElement {
 
     handleRuleFilterChange(event){
         this.rule = event.detail.value;
-        this.totalRows = null;
-        this.currentPage = null;
+        this.currentGroupPage = 1;
     }
     handleObjectFilterChange(event){
         if(this.objectType != event.detail.value){
-            this.totalRows = null;
-            this.currentPage = null;
+            this.currentGroupPage = 1;
             this.objectType = event.detail.value;
             this.fetchRules();
             this.rule = null;
         }
     }
-    handlePager(event){
-        this.currentPage = Number(event.detail);
-        this.offsetAmt = Number((this.currentPage - 1) * Number(this.limitAmt));
+    handleGroupPage(event){
+        this.currentGroupPage = Number(event.detail);
+    }
+    handlePairPage(event){
+        const keepId = event.currentTarget.dataset.keep;
+        const page = Number(event.detail);
+        this.allGroups = this.allGroups.map(g=> g.keepId == keepId ? Object.assign({}, g, { pairPage: page }) : g);
     }
 
     // ---- preview modal + in-group navigation ----
     handlePreview(event){
         var pairId = event.currentTarget.dataset.record;
         var keepId = event.currentTarget.dataset.keep;
-        var group = (this.keepGroups || []).find(g=>g.keepId == keepId);
+        var group = (this.allGroups || []).find(g=>g.keepId == keepId);
         this.navItems = group ? group.pairs.map(pair=>this.toNavItem(pair, pairId)) : [];
         this.selectedRecordId = pairId;
         this.isModalOpen = true;
@@ -220,15 +244,22 @@ export default class DupeList extends LightningElement {
     removeSelectedPair(){
         var id = this.selectedRecordId;
         var groups = [];
-        (this.keepGroups || []).forEach(group=>{
+        (this.allGroups || []).forEach(group=>{
             var pairs = (group.pairs || []).filter(pair=>pair.id != id);
             if(pairs.length > 0){
                 group.pairs = pairs;
                 group.pairCount = pairs.length;
+                var maxPage = Math.max(1, Math.ceil(pairs.length / PAIRS_PER_PAGE));
+                if((group.pairPage || 1) > maxPage){
+                    group.pairPage = maxPage;
+                }
                 groups.push(group);
             }
         });
-        this.keepGroups = groups;
+        this.allGroups = groups;
+        if(this.currentGroupPage > this.groupTotalPages){
+            this.currentGroupPage = this.groupTotalPages;
+        }
         this.selectedRecordId = null;
     }
 


### PR DESCRIPTION
## Duplicate list crashed at 50k+ candidates

With >50,000 active candidates the duplicate list threw an **uncatchable** `System.LimitException: Too many query rows: 50001`. Cause: `getCount` used `COUNT_DISTINCT` and `getKeepGroups` used `GROUP BY` — both aggregate **every** matching row toward the 50k query-row limit; the `LIMIT` only caps returned groups, not rows scanned. (Confirmed in lcvFULL: 53,494 active candidates.)

## Fix
- **getCount**: `COUNT_DISTINCT` → `Database.countQuery` (plain `COUNT()`, governor-safe — 1 query row).
- **getKeepGroups**: drop the `GROUP BY` keep-aggregate; fetch the top-N candidate pairs by confidence in one bounded query and group them by kept record.
- **dupeList (two-level pagination)**: fetch the highest-confidence **cap (2000)** once, then page **client-side** — an outer pager over duplicate **groups** (10/page) and an inner pager over **duplicates within each group** (5/page). A notice shows "top 2000 of N" when capped.

Per the chosen approach: numbered pages, confidence-first, capped.

## Verification
- Anonymous Apex in lcvFULL: `COUNT()` and the paged pair query are governor-safe at 53,494 (1 and 101 query rows).
- Controller test suite on gsgDEV: **10/10 pass** (grouping + confidence-order preserved).
- Jest: **48 total**, incl. new outer- and inner-pager tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)