### PR TITLE
feat: candidate filtering (#83) + grid display (#84)

### DIFF
--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -11,13 +11,189 @@ public with sharing class MRG_DuplicateMerge_CTRL {
 	* @return  List<mergeGroup> 
 	*/
     @AuraEnabled(cacheable=TRUE)
-    public static Integer getCount(String objectType, String ruleName){
+    public static Integer getCount(MRG_Duplicate_SVC.candidateFilter filter){
         // count candidate pairs (the list pages over pairs, grouped for display). COUNT_DISTINCT and
         // GROUP BY aggregate every matching row and throw an uncatchable "Too many query rows" once a
         // candidate set exceeds 50k; a plain COUNT() is governor-safe (uses a single query row).
+        // locals below are the bind targets referenced by getWhereClause(filter)
+        MRG_Duplicate_SVC.candidateFilter f = filter == null ? new MRG_Duplicate_SVC.candidateFilter() : filter;
+        String objectType = f.objectType;
+        String ruleName = f.ruleName;
+        Decimal confidenceMin = f.confidenceMin;
+        Decimal confidenceMax = f.confidenceMax;
+        Boolean autoMerge = f.autoMerge;
+        List<String> statuses = f.safeStatuses();
         String soqlQuery= 'SELECT COUNT() FROM MergeCandidate__c ';
-        soqlQuery+=MRG_Duplicate_SVC.getWhereClause(objectType, ruleName);
+        soqlQuery+=MRG_Duplicate_SVC.getWhereClause(f);
         return Database.countQuery(soqlQuery);
+    }
+	/*******************************************************************************************************
+	* @description the selectable Status__c filter values (Status__c is Text, not a picklist; deriving
+	* values via GROUP BY would re-trip the 50k row limit, so the supported set is enumerated here)
+	* @return List<Map<String,String>> label/value option list
+	*/
+    @AuraEnabled(cacheable=TRUE)
+    public static List<Map<String,String>> getStatusOptions(){
+        return new List<Map<String,String>>{
+            new Map<String,String>{'label'=>'New','value'=>'New'},
+            new Map<String,String>{'label'=>'Processed','value'=>'Processed'},
+            new Map<String,String>{'label'=>'Accounts Merged','value'=>MRG_AccountMerge_SVC.STATUS_ACCOUNTS_MERGED}
+        };
+    }
+	/*******************************************************************************************************
+	* @description the field set selectable for the grid display (#84): Id is always first, CreatedDate +
+	* LastModifiedDate always last, the first 10 object fields lead by default, and any field hidden via
+	* the preview field settings is excluded entirely.
+	* @param objectType the SObject type
+	* @return gridFieldOptions lead/optional/trail field buckets
+	*/
+    @AuraEnabled(cacheable=TRUE)
+    public static gridFieldOptions getGridFieldOptions(String objectType){
+        gridFieldOptions result = new gridFieldOptions();
+        result.leadFields = new List<gridFieldOption>();
+        result.optionalFields = new List<gridFieldOption>();
+        result.trailFields = new List<gridFieldOption>();
+        if(String.isBlank(objectType) || Schema.getGlobalDescribe().get(objectType) == null)
+            return result;
+        Map<String, Schema.SObjectField> fmap = Schema.getGlobalDescribe().get(objectType).getDescribe().fields.getMap();
+        Set<String> hidden = hiddenPreviewFields(objectType);
+        Set<String> system3 = new Set<String>{'id','createddate','lastmodifieddate'};
+        List<gridFieldOption> selectable = new List<gridFieldOption>();
+        for(MRG_Merge_SVC.objectField fld:MRG_MergeSettings_CTRL.getObjectFields(objectType, true)){
+            String lname = fld.name.toLowerCase();
+            if(hidden.contains(lname) || system3.contains(lname))
+                continue;
+            gridFieldOption o = new gridFieldOption();
+            o.name = fld.name; o.label = fld.label; o.type = fld.type;
+            selectable.add(o);
+        }
+        selectable.sort();
+        result.leadFields.add(fieldOption(fmap,'Id'));
+        Integer firstCount = Math.min(10, selectable.size());
+        for(Integer i=0;i<selectable.size();i++){
+            if(i < firstCount)
+                result.leadFields.add(selectable[i]);
+            else
+                result.optionalFields.add(selectable[i]);
+        }
+        result.trailFields.add(fieldOption(fmap,'CreatedDate'));
+        result.trailFields.add(fieldOption(fmap,'LastModifiedDate'));
+        return result;
+    }
+	/*******************************************************************************************************
+	* @description grid data (#84): a page of candidates grouped by kept record, each group showing the
+	* kept record, its duplicate(s) and the simulated merge result, for the requested display fields.
+	* The simulated result reuses the bulk preview engine (MRG_Merge_SVC.getMergeHistoryResult) so up to
+	* a page of candidates is computed in a single call.
+	* @param filter the candidate filter
+	* @param fields the ordered display field API names (Id/CreatedDate/LastModifiedDate handled as well)
+	* @param pageSize candidates per page (clamped 10..200, default 50)
+	* @param pageNumber 1-based page number (bounded to the top 2000 confidence-ranked candidates)
+	* @return gridResponse columns + grouped rows
+	*/
+    @AuraEnabled
+    public static gridResponse getGridData(MRG_Duplicate_SVC.candidateFilter filter, List<String> fields, Integer pageSize, Integer pageNumber){
+        MRG_Duplicate_SVC.candidateFilter f = filter == null ? new MRG_Duplicate_SVC.candidateFilter() : filter;
+        // locals below are the bind targets referenced by getWhereClause(filter)
+        String objectType = f.objectType;
+        String ruleName = f.ruleName;
+        Decimal confidenceMin = f.confidenceMin;
+        Decimal confidenceMax = f.confidenceMax;
+        Boolean autoMerge = f.autoMerge;
+        List<String> statuses = f.safeStatuses();
+        // clamp page size + offset (OFFSET maxes at 2000, matching the list's top-2000 window)
+        pageSize = pageSize == null ? 50 : pageSize;
+        if(pageSize < 10) pageSize = 10;
+        if(pageSize > 200) pageSize = 200;
+        if(pageNumber == null || pageNumber < 1) pageNumber = 1;
+        Integer offsetAmt = (pageNumber - 1) * pageSize;
+        if(offsetAmt < 0) offsetAmt = 0;
+        if(offsetAmt > 2000) offsetAmt = 2000;
+
+        gridResponse resp = new gridResponse();
+        resp.columns = new List<gridFieldOption>();
+        resp.groups = new List<gridGroup>();
+        if(String.isBlank(objectType) || Schema.getGlobalDescribe().get(objectType) == null)
+            return resp;
+        Map<String, Schema.SObjectField> fmap = Schema.getGlobalDescribe().get(objectType).getDescribe().fields.getMap();
+
+        // resolve display fields (defensive: always Id; drop hidden + unknown fields)
+        Set<String> hidden = hiddenPreviewFields(objectType);
+        List<String> displayFields = new List<String>{'Id'};
+        Set<String> displaySet = new Set<String>{'id'};
+        if(fields != null){
+            for(String fld:fields){
+                if(String.isBlank(fld))
+                    continue;
+                String l = fld.toLowerCase();
+                if(displaySet.contains(l) || hidden.contains(l) || !fmap.containsKey(l))
+                    continue;
+                displayFields.add(fmap.get(l).getDescribe().getName());
+                displaySet.add(l);
+            }
+        }
+        for(String fld:displayFields)
+            resp.columns.add(fieldOption(fmap, fld));
+
+        // page of candidates (highest confidence first)
+        String pairQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL();
+        pairQuery += MRG_Duplicate_SVC.getWhereClause(f);
+        pairQuery += ' ORDER BY ConfidenceScore__c DESC NULLS LAST, KeepRecordId__c, CreatedDate DESC, Id ASC';
+        pairQuery += ' LIMIT ' + pageSize;
+        if(offsetAmt > 0)
+            pairQuery += ' OFFSET :offsetAmt';
+        List<MergeCandidate__c> pageCandidates = (List<MergeCandidate__c>) Database.query(pairQuery);
+        if(pageCandidates.isEmpty())
+            return resp;
+
+        // bulk fetch the display values for the kept + duplicate records
+        Set<Id> recordIds = new Set<Id>();
+        for(MergeCandidate__c c:pageCandidates){
+            if(String.isNotBlank(c.KeepRecordId__c)) recordIds.add(c.KeepRecordId__c);
+            if(String.isNotBlank(c.MergeRecordId__c)) recordIds.add(c.MergeRecordId__c);
+            if(String.isNotBlank(c.Merge2RecordId__c)) recordIds.add(c.Merge2RecordId__c);
+        }
+        Map<Id, SObject> displayMap = new Map<Id, SObject>(
+            Database.query('SELECT ' + String.join(displayFields, ',') + ' FROM ' + objectType + ' WHERE Id IN :recordIds'));
+
+        // simulate the merges once for the whole page; map the result records by kept id
+        MRG_Merge_SVC.mergeHistoryResult mr = MRG_Merge_SVC.getMergeHistoryResult(pageCandidates, objectType);
+        Map<Id, Map<String,Object>> resultByKeepId = new Map<Id, Map<String,Object>>();
+        if(mr != null && mr.updateRecords != null){
+            for(SObject u:mr.updateRecords){
+                if(u.get('Id') != null)
+                    resultByKeepId.put((Id) u.get('Id'), lowerKeyed(u));
+            }
+        }
+
+        // group by kept record, preserving the confidence order
+        Map<String, gridGroup> byKeep = new Map<String, gridGroup>();
+        List<String> keepOrder = new List<String>();
+        for(MergeCandidate__c c:pageCandidates){
+            String keepId = c.KeepRecordId__c;
+            if(!byKeep.containsKey(keepId)){
+                gridGroup g = new gridGroup();
+                g.keepId = keepId;
+                g.keepName = c.KeepName__c;
+                g.objectType = objectType;
+                g.rows = new List<gridRow>();
+                if(displayMap.containsKey(keepId))
+                    g.rows.add(buildRow('keep', keepId, null, false, displayFields, displayMap.get(keepId)));
+                byKeep.put(keepId, g);
+                keepOrder.add(keepId);
+            }
+            gridGroup g = byKeep.get(keepId);
+            if(String.isNotBlank(c.MergeRecordId__c) && displayMap.containsKey(c.MergeRecordId__c))
+                g.rows.add(buildRow('duplicate', c.MergeRecordId__c, c.Id, true, displayFields, displayMap.get(c.MergeRecordId__c)));
+            if(String.isNotBlank(c.Merge2RecordId__c) && displayMap.containsKey(c.Merge2RecordId__c))
+                g.rows.add(buildRow('duplicate', c.Merge2RecordId__c, c.Id, true, displayFields, displayMap.get(c.Merge2RecordId__c)));
+        }
+        for(String keepId:keepOrder){
+            gridGroup g = byKeep.get(keepId);
+            g.rows.add(buildResultRow(displayFields, displayMap.get(keepId), resultByKeepId.get(Id.valueOf(keepId))));
+            resp.groups.add(g);
+        }
+        return resp;
     }
 
 	/*******************************************************************************************************
@@ -26,13 +202,21 @@ public with sharing class MRG_DuplicateMerge_CTRL {
 	* @return  List<mergeGroup> 
 	*/
     @AuraEnabled(cacheable=TRUE)
-    public static List<keepGroup> getKeepGroups(String objectType, String ruleName, Integer limitAmt, Integer offsetAmt){
+    public static List<keepGroup> getKeepGroups(MRG_Duplicate_SVC.candidateFilter filter, Integer limitAmt, Integer offsetAmt){
         limitAmt = limitAmt == null ? 200 : limitAmt;
         // page over the candidate pairs directly (highest confidence first) and group them by kept
         // record for display. Avoids GROUP BY/COUNT_DISTINCT, which aggregate every matching row and
         // throw an uncatchable "Too many query rows" once a candidate set exceeds 50k.
+        // locals below are the bind targets referenced by getWhereClause(filter)
+        MRG_Duplicate_SVC.candidateFilter f = filter == null ? new MRG_Duplicate_SVC.candidateFilter() : filter;
+        String objectType = f.objectType;
+        String ruleName = f.ruleName;
+        Decimal confidenceMin = f.confidenceMin;
+        Decimal confidenceMax = f.confidenceMax;
+        Boolean autoMerge = f.autoMerge;
+        List<String> statuses = f.safeStatuses();
         String pairQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL();
-        pairQuery += MRG_Duplicate_SVC.getWhereClause(objectType, ruleName);
+        pairQuery += MRG_Duplicate_SVC.getWhereClause(f);
         pairQuery += ' ORDER BY ConfidenceScore__c DESC NULLS LAST, KeepRecordId__c, CreatedDate DESC, Id ASC';
         pairQuery += ' LIMIT ' + limitAmt;
         if(offsetAmt != null
@@ -131,6 +315,64 @@ public with sharing class MRG_DuplicateMerge_CTRL {
             response = e.getMessage();
         }
         return response;
+    }
+	/*******************************************************************************************************
+	* @description merges several candidates at once (grid multi-select, #84)
+	* @param recordIds the merge candidate recordIds
+	* @return String response
+	*/
+    @AuraEnabled
+    public static String mergeRecords(List<Id> recordIds){
+        if(recordIds == null || recordIds.isEmpty())
+            return 'No records selected';
+        String soqlQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL() + ' WHERE Id IN :recordIds';
+        List<MergeCandidate__c> candidates = (List<MergeCandidate__c>) Database.query(soqlQuery);
+        Map<String, List<MergeCandidate__c>> byObject = new Map<String, List<MergeCandidate__c>>();
+        for(MergeCandidate__c c:candidates){
+            if(!byObject.containsKey(c.Object__c))
+                byObject.put(c.Object__c, new List<MergeCandidate__c>());
+            byObject.get(c.Object__c).add(c);
+        }
+        for(String objType:byObject.keySet())
+            MRG_Merge_SVC.processMergesFromBatch(byObject.get(objType), objType, false);
+        return candidates.size() + ' record(s) merged';
+    }
+	/*******************************************************************************************************
+	* @description marks several candidates as not-a-duplicate at once (grid multi-select, #84)
+	* @param recordIds the merge candidate recordIds
+	* @return String response
+	*/
+    @AuraEnabled
+    public static String removeRecords(List<Id> recordIds){
+        if(recordIds == null || recordIds.isEmpty())
+            return 'No records selected';
+        List<MergeCandidate__c> updates = new List<MergeCandidate__c>();
+        for(Id rid:recordIds)
+            updates.add(new MergeCandidate__c(Id=rid, NotADuplicate__c=true));
+        try {
+            update updates;
+            return updates.size() + ' record(s) set to not a duplicate';
+        } catch(Exception e){
+            return e.getMessage();
+        }
+    }
+	/*******************************************************************************************************
+	* @description merges the Accounts for several contact candidates at once (grid multi-select, #84)
+	* @param recordIds the merge candidate recordIds
+	* @return String response
+	*/
+    @AuraEnabled
+    public static String mergeAccountsBulk(List<Id> recordIds){
+        if(recordIds == null || recordIds.isEmpty())
+            return 'No records selected';
+        String soqlQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL() + ' WHERE Id IN :recordIds';
+        List<MergeCandidate__c> candidates = (List<MergeCandidate__c>) Database.query(soqlQuery);
+        Integer merged = 0;
+        for(MergeCandidate__c c:candidates){
+            if(MRG_AccountMerge_SVC.mergeAccounts(c) != null)
+                merged++;
+        }
+        return merged + ' account merge(s) completed';
     }
 	/*******************************************************************************************************
 	* @description Returns the merge fields
@@ -291,6 +533,128 @@ public with sharing class MRG_DuplicateMerge_CTRL {
                 this.recordIds.add(this.mergeId);
             if(String.isNotBlank(this.merge2Id))
                 this.recordIds.add(this.merge2Id);
-        }      
+        }
+    }
+
+    // ---- grid helpers (#84) ----
+	/*******************************************************************************************************
+	* @description the set of field API names (lower-cased) hidden from the preview for an object
+	*/
+    private static Set<String> hiddenPreviewFields(String objectType){
+        Set<String> hidden = new Set<String>();
+        for(MRG_MergeSettings_CTRL.previewField pf:MRG_MergeSettings_CTRL.getAllPreviewFields(objectType)){
+            if(pf.hidden && String.isNotBlank(pf.fieldName))
+                hidden.add(pf.fieldName.toLowerCase());
+        }
+        return hidden;
+    }
+	/*******************************************************************************************************
+	* @description resolves a field's label/type from the object's describe map (falls back to the name)
+	*/
+    private static gridFieldOption fieldOption(Map<String, Schema.SObjectField> fmap, String name){
+        gridFieldOption o = new gridFieldOption();
+        o.name = name;
+        if(fmap.containsKey(name.toLowerCase())){
+            Schema.DescribeFieldResult dfr = fmap.get(name.toLowerCase()).getDescribe();
+            o.name = dfr.getName();
+            o.label = dfr.getLabel();
+            o.type = String.valueOf(dfr.getType());
+        } else {
+            o.label = name;
+            o.type = 'STRING';
+        }
+        return o;
+    }
+	/*******************************************************************************************************
+	* @description a row of display-field cells for a queried record (fields were queried, so get() is safe)
+	*/
+    private static gridRow buildRow(String rowType, String recordId, String candidateId, Boolean selectable, List<String> fields, SObject rec){
+        gridRow row = new gridRow();
+        row.rowType = rowType;
+        row.recordId = recordId;
+        row.candidateId = candidateId;
+        row.selectable = selectable;
+        row.cells = new List<gridCell>();
+        for(String fld:fields){
+            gridCell cell = new gridCell();
+            cell.name = fld;
+            cell.value = rec != null ? toStr(rec.get(fld)) : '';
+            row.cells.add(cell);
+        }
+        return row;
+    }
+	/*******************************************************************************************************
+	* @description the simulated result row: the kept record's value overlaid with any field the merge
+	* engine changed (read from the serialized result map so unqueried fields don't throw)
+	*/
+    private static gridRow buildResultRow(List<String> fields, SObject keepRec, Map<String,Object> resultMap){
+        gridRow row = new gridRow();
+        row.rowType = 'result';
+        row.recordId = keepRec != null ? (String) keepRec.get('Id') : null;
+        row.candidateId = null;
+        row.selectable = false;
+        row.cells = new List<gridCell>();
+        for(String fld:fields){
+            gridCell cell = new gridCell();
+            cell.name = fld;
+            String lf = fld.toLowerCase();
+            Object val = (resultMap != null && resultMap.containsKey(lf)) ? resultMap.get(lf)
+                : (keepRec != null ? keepRec.get(fld) : null);
+            cell.value = toStr(val);
+            row.cells.add(cell);
+        }
+        return row;
+    }
+	/*******************************************************************************************************
+	* @description an SObject as a lower-cased-key value map (only populated/queried fields are present)
+	*/
+    private static Map<String,Object> lowerKeyed(SObject rec){
+        Map<String,Object> out = new Map<String,Object>();
+        Map<String,Object> m = (Map<String,Object>) JSON.deserializeUntyped(JSON.serialize(rec));
+        for(String k:m.keySet())
+            out.put(k.toLowerCase(), m.get(k));
+        return out;
+    }
+    private static String toStr(Object val){
+        return val == null ? '' : String.valueOf(val);
+    }
+
+    // ---- grid wrappers (#84) ----
+    public class gridFieldOptions {
+        @AuraEnabled public List<gridFieldOption> leadFields;
+        @AuraEnabled public List<gridFieldOption> optionalFields;
+        @AuraEnabled public List<gridFieldOption> trailFields;
+    }
+    public class gridFieldOption implements Comparable {
+        @AuraEnabled public String name;
+        @AuraEnabled public String label;
+        @AuraEnabled public String type;
+        public Integer compareTo(Object o){
+            gridFieldOption other = (gridFieldOption) o;
+            String a = this.label == null ? '' : this.label.toLowerCase();
+            String b = other.label == null ? '' : other.label.toLowerCase();
+            return a.compareTo(b);
+        }
+    }
+    public class gridResponse {
+        @AuraEnabled public List<gridFieldOption> columns;
+        @AuraEnabled public List<gridGroup> groups;
+    }
+    public class gridGroup {
+        @AuraEnabled public String keepId;
+        @AuraEnabled public String keepName;
+        @AuraEnabled public String objectType;
+        @AuraEnabled public List<gridRow> rows;
+    }
+    public class gridRow {
+        @AuraEnabled public String rowType;
+        @AuraEnabled public String recordId;
+        @AuraEnabled public String candidateId;
+        @AuraEnabled public Boolean selectable;
+        @AuraEnabled public List<gridCell> cells;
+    }
+    public class gridCell {
+        @AuraEnabled public String name;
+        @AuraEnabled public String value;
     }
 }

--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -71,20 +71,39 @@ public with sharing class MRG_DuplicateMerge_CTRL {
             selectable.add(o);
         }
         selectable.sort();
-        // selected set: saved config (if any), else the first 10 by label (excludes hidden by construction)
-        List<String> saved = getSavedFields(objectType);
-        Set<String> selectedSet = new Set<String>();
-        if(saved != null){
-            for(String s:saved)
-                selectedSet.add(s.toLowerCase());
-        } else {
-            for(Integer i=0;i<Math.min(10, selectable.size());i++)
-                selectedSet.add(selectable[i].name.toLowerCase());
-        }
         for(gridFieldOption o:selectable)
-            o.selected = selectedSet.contains(o.name.toLowerCase());
+            o.selected = false;
+        Map<String, gridFieldOption> byName = new Map<String, gridFieldOption>();
+        for(gridFieldOption o:selectable)
+            byName.put(o.name.toLowerCase(), o);
+        // selected fields first, in their saved order (preserves the user's column ordering); when no
+        // config is saved, default to the first 10 by label. Unselected fields follow, ordered by label.
+        List<String> saved = getSavedFields(objectType);
+        List<gridFieldOption> ordered = new List<gridFieldOption>();
+        Set<String> used = new Set<String>();
+        if(saved != null){
+            for(String s:saved){
+                String sl = s.toLowerCase();
+                if(byName.containsKey(sl) && !used.contains(sl)){
+                    gridFieldOption o = byName.get(sl);
+                    o.selected = true;
+                    ordered.add(o);
+                    used.add(sl);
+                }
+            }
+        } else {
+            for(Integer i=0;i<Math.min(10, selectable.size());i++){
+                selectable[i].selected = true;
+                ordered.add(selectable[i]);
+                used.add(selectable[i].name.toLowerCase());
+            }
+        }
+        for(gridFieldOption o:selectable){
+            if(!used.contains(o.name.toLowerCase()))
+                ordered.add(o);
+        }
         result.leadFields.add(fieldOption(fmap,'Id'));
-        result.fields = selectable;
+        result.fields = ordered;
         result.trailFields.add(fieldOption(fmap,'CreatedDate'));
         result.trailFields.add(fieldOption(fmap,'LastModifiedDate'));
         return result;

--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -41,18 +41,20 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         };
     }
 	/*******************************************************************************************************
-	* @description the field set selectable for the grid display (#84): Id is always first, CreatedDate +
-	* LastModifiedDate always last, the first 10 object fields lead by default, and any field hidden via
-	* the preview field settings is excluded entirely.
+	* @description the field set selectable for the grid display (#84). Id is always first and
+	* CreatedDate + LastModifiedDate always last (system columns); every other accessible field is
+	* selectable (any field hidden via the preview settings is excluded entirely). Each selectable field
+	* carries its current selected state: the saved per-object configuration if one exists, otherwise the
+	* first 10 fields by label. Selection is shared across users via MergeGridConfig__c.
 	* @param objectType the SObject type
-	* @return gridFieldOptions lead/optional/trail field buckets
+	* @return gridFieldOptions system lead/trail columns + the selectable field list
 	*/
     @AuraEnabled(cacheable=TRUE)
     public static gridFieldOptions getGridFieldOptions(String objectType){
         gridFieldOptions result = new gridFieldOptions();
         result.leadFields = new List<gridFieldOption>();
-        result.optionalFields = new List<gridFieldOption>();
         result.trailFields = new List<gridFieldOption>();
+        result.fields = new List<gridFieldOption>();
         if(String.isBlank(objectType) || Schema.getGlobalDescribe().get(objectType) == null)
             return result;
         Map<String, Schema.SObjectField> fmap = Schema.getGlobalDescribe().get(objectType).getDescribe().fields.getMap();
@@ -65,20 +67,53 @@ public with sharing class MRG_DuplicateMerge_CTRL {
                 continue;
             gridFieldOption o = new gridFieldOption();
             o.name = fld.name; o.label = fld.label; o.type = fld.type;
+            o.displayLabel = fld.label + ' (' + fld.name + ')';
             selectable.add(o);
         }
         selectable.sort();
-        result.leadFields.add(fieldOption(fmap,'Id'));
-        Integer firstCount = Math.min(10, selectable.size());
-        for(Integer i=0;i<selectable.size();i++){
-            if(i < firstCount)
-                result.leadFields.add(selectable[i]);
-            else
-                result.optionalFields.add(selectable[i]);
+        // selected set: saved config (if any), else the first 10 by label (excludes hidden by construction)
+        List<String> saved = getSavedFields(objectType);
+        Set<String> selectedSet = new Set<String>();
+        if(saved != null){
+            for(String s:saved)
+                selectedSet.add(s.toLowerCase());
+        } else {
+            for(Integer i=0;i<Math.min(10, selectable.size());i++)
+                selectedSet.add(selectable[i].name.toLowerCase());
         }
+        for(gridFieldOption o:selectable)
+            o.selected = selectedSet.contains(o.name.toLowerCase());
+        result.leadFields.add(fieldOption(fmap,'Id'));
+        result.fields = selectable;
         result.trailFields.add(fieldOption(fmap,'CreatedDate'));
         result.trailFields.add(fieldOption(fmap,'LastModifiedDate'));
         return result;
+    }
+	/*******************************************************************************************************
+	* @description saves the grid field selection for an object type, shared across all users (#84)
+	* @param objectType the SObject type
+	* @param fields the selected field API names
+	*/
+    @AuraEnabled
+    public static void saveGridFieldConfig(String objectType, List<String> fields){
+        if(String.isBlank(objectType))
+            return;
+        MergeGridConfig__c cfg = new MergeGridConfig__c(
+            ObjectType__c = objectType,
+            Fields__c = JSON.serialize(fields == null ? new List<String>() : fields)
+        );
+        upsert cfg ObjectType__c;
+    }
+	/*******************************************************************************************************
+	* @description the saved grid field selection for an object type, or null if none saved
+	*/
+    private static List<String> getSavedFields(String objectType){
+        List<MergeGridConfig__c> cfgs = [
+            SELECT Fields__c FROM MergeGridConfig__c WHERE ObjectType__c =:objectType LIMIT 1
+        ];
+        if(cfgs.isEmpty() || String.isBlank(cfgs[0].Fields__c))
+            return null;
+        return (List<String>) JSON.deserialize(cfgs[0].Fields__c, List<String>.class);
     }
 	/*******************************************************************************************************
 	* @description grid data (#84): a page of candidates grouped by kept record, each group showing the
@@ -622,13 +657,15 @@ public with sharing class MRG_DuplicateMerge_CTRL {
     // ---- grid wrappers (#84) ----
     public class gridFieldOptions {
         @AuraEnabled public List<gridFieldOption> leadFields;
-        @AuraEnabled public List<gridFieldOption> optionalFields;
+        @AuraEnabled public List<gridFieldOption> fields;
         @AuraEnabled public List<gridFieldOption> trailFields;
     }
     public class gridFieldOption implements Comparable {
         @AuraEnabled public String name;
         @AuraEnabled public String label;
         @AuraEnabled public String type;
+        @AuraEnabled public String displayLabel;
+        @AuraEnabled public Boolean selected;
         public Integer compareTo(Object o){
             gridFieldOption other = (gridFieldOption) o;
             String a = this.label == null ? '' : this.label.toLowerCase();

--- a/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
@@ -201,6 +201,29 @@ private class MRG_DuplicateMerge_TEST {
 			trailNames.add(o.name);
 		system.assert(trailNames.contains('CreatedDate'), 'CreatedDate should be a trailing field');
 		system.assert(trailNames.contains('LastModifiedDate'), 'LastModifiedDate should be a trailing field');
+		system.assert(!opts.fields.isEmpty(), 'selectable fields should be returned');
+		Integer defaultSelected = 0;
+		for(MRG_DuplicateMerge_CTRL.gridFieldOption o:opts.fields)
+			if(o.selected == true) defaultSelected++;
+		system.assert(defaultSelected > 0, 'with no saved config the first fields should be selected by default');
+	}
+
+	static testMethod void testGridFieldConfigSaveLoad(){
+		MRG_DuplicateMerge_CTRL.saveGridFieldConfig('Contact', new List<String>{'Email'});
+		MRG_DuplicateMerge_CTRL.gridFieldOptions opts = MRG_DuplicateMerge_CTRL.getGridFieldOptions('Contact');
+		Integer selectedCount = 0;
+		Boolean emailSelected = false;
+		for(MRG_DuplicateMerge_CTRL.gridFieldOption o:opts.fields){
+			if(o.selected == true){
+				selectedCount++;
+				if(o.name == 'Email') emailSelected = true;
+			}
+		}
+		system.assertEquals(1, selectedCount, 'only the saved field should be selected');
+		system.assert(emailSelected, 'the saved Email field should be selected');
+		// upsert by external id: saving again updates the same record rather than erroring
+		MRG_DuplicateMerge_CTRL.saveGridFieldConfig('Contact', new List<String>{'Email','Phone'});
+		system.assertEquals(1, [SELECT COUNT() FROM MergeGridConfig__c WHERE ObjectType__c='Contact'], 'one config record per object type');
 	}
 
 	static testMethod void testGridData(){

--- a/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
@@ -62,8 +62,8 @@ private class MRG_DuplicateMerge_TEST {
 		update mc;
 	}
     static testMethod void testCTLR() {
-        Integer count = MRG_DuplicateMerge_CTRL.getCount('Contact','test');
-        List<MRG_DuplicateMerge_CTRL.keepGroup> groups = MRG_DuplicateMerge_CTRL.getKeepGroups('Contact','test',100,0);
+        Integer count = MRG_DuplicateMerge_CTRL.getCount(new MRG_Duplicate_SVC.candidateFilter('Contact','test'));
+        List<MRG_DuplicateMerge_CTRL.keepGroup> groups = MRG_DuplicateMerge_CTRL.getKeepGroups(new MRG_Duplicate_SVC.candidateFilter('Contact','test'),100,0);
         system.assert(!groups.isEmpty(), 'a keep group should be returned');
         List<MRG_DuplicateMerge_CTRL.mergeGroup> pairs = groups[0].pairs;
         String mergeGroupJSON = JSON.serialize(pairs[0]);
@@ -92,7 +92,7 @@ private class MRG_DuplicateMerge_TEST {
         mc.ConfidenceScore__c = 95.50;
         mc.Source__c = 'External';
         update mc;
-        List<MRG_DuplicateMerge_CTRL.keepGroup> groups = MRG_DuplicateMerge_CTRL.getKeepGroups('Contact','test',100,0);
+        List<MRG_DuplicateMerge_CTRL.keepGroup> groups = MRG_DuplicateMerge_CTRL.getKeepGroups(new MRG_Duplicate_SVC.candidateFilter('Contact','test'),100,0);
         system.assertEquals(1, groups.size(), 'one keep group should be returned');
         system.assertEquals(1, groups[0].pairs.size(), 'the keep group should have one pair');
         system.assertEquals(95.50, groups[0].pairs[0].confidenceScore, 'confidence score should flow through to the pair wrapper');
@@ -108,7 +108,7 @@ private class MRG_DuplicateMerge_TEST {
         pairs[1].ConfidenceScore__c = 90.00;
         update pairs;
         MRG_DuplicateMerge_CTRL.keepGroup grp;
-        for(MRG_DuplicateMerge_CTRL.keepGroup g:MRG_DuplicateMerge_CTRL.getKeepGroups('Contact','test',100,0)){
+        for(MRG_DuplicateMerge_CTRL.keepGroup g:MRG_DuplicateMerge_CTRL.getKeepGroups(new MRG_Duplicate_SVC.candidateFilter('Contact','test'),100,0)){
             if(g.keepId == String.valueOf(keepId))
                 grp = g;
         }
@@ -186,5 +186,91 @@ private class MRG_DuplicateMerge_TEST {
 		MRG_MergeCandidate mergeCandidate = MRG_MergeCandidate_SVC.getMergeCandidate(can.Id);
 		test.stopTest();
 
+	}
+
+	static testMethod void testStatusOptions(){
+		List<Map<String,String>> opts = MRG_DuplicateMerge_CTRL.getStatusOptions();
+		system.assertEquals(3, opts.size(), 'three status options should be offered');
+	}
+
+	static testMethod void testGridFieldOptions(){
+		MRG_DuplicateMerge_CTRL.gridFieldOptions opts = MRG_DuplicateMerge_CTRL.getGridFieldOptions('Contact');
+		system.assertEquals('Id', opts.leadFields[0].name, 'Id should be the first lead field');
+		Set<String> trailNames = new Set<String>();
+		for(MRG_DuplicateMerge_CTRL.gridFieldOption o:opts.trailFields)
+			trailNames.add(o.name);
+		system.assert(trailNames.contains('CreatedDate'), 'CreatedDate should be a trailing field');
+		system.assert(trailNames.contains('LastModifiedDate'), 'LastModifiedDate should be a trailing field');
+	}
+
+	static testMethod void testGridData(){
+		MRG_Merge_TEST.createMergeFields();
+		MRG_Duplicate_SVC.candidateFilter f = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		test.startTest();
+		MRG_DuplicateMerge_CTRL.gridResponse resp = MRG_DuplicateMerge_CTRL.getGridData(
+			f, new List<String>{'Email','CreatedDate','LastModifiedDate'}, 50, 1);
+		test.stopTest();
+		system.assert(!resp.columns.isEmpty(), 'columns should be returned');
+		system.assertEquals('Id', resp.columns[0].name, 'Id should be the first column');
+		system.assert(!resp.groups.isEmpty(), 'at least one keep group should be returned');
+		Set<String> rowTypes = new Set<String>();
+		for(MRG_DuplicateMerge_CTRL.gridRow r:resp.groups[0].rows)
+			rowTypes.add(r.rowType);
+		system.assert(rowTypes.contains('keep'), 'a keep row should be present');
+		system.assert(rowTypes.contains('duplicate'), 'a duplicate row should be present');
+		system.assert(rowTypes.contains('result'), 'a simulated result row should be present');
+	}
+
+	static testMethod void testGridDataPageSizeClamped(){
+		MRG_Duplicate_SVC.candidateFilter f = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		// below-min and above-max page sizes must not throw and still return the page
+		MRG_DuplicateMerge_CTRL.gridResponse small = MRG_DuplicateMerge_CTRL.getGridData(f, new List<String>{'Email'}, 1, 1);
+		MRG_DuplicateMerge_CTRL.gridResponse big = MRG_DuplicateMerge_CTRL.getGridData(f, new List<String>{'Email'}, 9999, 1);
+		system.assert(!small.groups.isEmpty(), 'a below-min page size should clamp to 10 and still return data');
+		system.assert(!big.groups.isEmpty(), 'an above-max page size should clamp to 200 and still return data');
+	}
+
+	static testMethod void testCountFilters(){
+		MergeCandidate__c mc = [SELECT Id FROM MergeCandidate__c LIMIT 1];
+		mc.ConfidenceScore__c = 50;
+		update mc;
+
+		MRG_Duplicate_SVC.candidateFilter high = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		high.confidenceMin = 90;
+		system.assertEquals(0, MRG_DuplicateMerge_CTRL.getCount(high), 'a min confidence above the candidate score should exclude it');
+
+		MRG_Duplicate_SVC.candidateFilter low = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		low.confidenceMin = 10;
+		system.assert(MRG_DuplicateMerge_CTRL.getCount(low) >= 1, 'a min confidence below the score should include it');
+
+		MRG_Duplicate_SVC.candidateFilter notAuto = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		notAuto.autoMerge = false;
+		system.assertEquals(0, MRG_DuplicateMerge_CTRL.getCount(notAuto), 'the auto-merge candidate should be excluded when filtering autoMerge=false');
+
+		MRG_Duplicate_SVC.candidateFilter processed = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		processed.statuses = new List<String>{'Processed'};
+		system.assertEquals(0, MRG_DuplicateMerge_CTRL.getCount(processed), 'a New candidate should be excluded when filtering status=Processed');
+	}
+
+	static testMethod void testBulkRemove(){
+		Id mcId = [SELECT Id FROM MergeCandidate__c LIMIT 1].Id;
+		test.startTest();
+		String removeResp = MRG_DuplicateMerge_CTRL.removeRecords(new List<Id>{mcId});
+		test.stopTest();
+		system.assert(removeResp.contains('1'), 'one record should be removed');
+		MergeCandidate__c rec = [SELECT NotADuplicate__c FROM MergeCandidate__c WHERE Id=:mcId];
+		system.assertEquals(true, rec.NotADuplicate__c, 'the candidate should be marked not a duplicate');
+		// empty selections are guarded
+		system.assertEquals('No records selected', MRG_DuplicateMerge_CTRL.mergeRecords(new List<Id>()), 'empty merge selection should be guarded');
+		system.assertEquals('No records selected', MRG_DuplicateMerge_CTRL.mergeAccountsBulk(new List<Id>()), 'empty account-merge selection should be guarded');
+	}
+
+	static testMethod void testBulkMerge(){
+		MRG_Merge_TEST.createMergeFields();
+		Id mcId = [SELECT Id FROM MergeCandidate__c LIMIT 1].Id;
+		test.startTest();
+		String resp = MRG_DuplicateMerge_CTRL.mergeRecords(new List<Id>{mcId});
+		test.stopTest();
+		system.assert(resp.contains('merged'), 'the bulk merge should report a merge');
 	}
 }

--- a/force-app/main/default/classes/MRG_Duplicate_SVC.cls
+++ b/force-app/main/default/classes/MRG_Duplicate_SVC.cls
@@ -41,16 +41,65 @@ public with sharing class MRG_Duplicate_SVC {
     public static String getWhereClause(String objectType, String ruleName, Boolean showIgnored){
 
         String whereClause = getWhereClause();
-        
+
         if(String.isNotBlank(objectType))
             whereClause+=' AND Object__c=:objectType';
-        
+
         if(String.isNotBlank(ruleName))
             whereClause+=' AND Rule__c=:ruleName';
-        
+
         whereClause += showIgnored ? '' : ' AND NotADuplicate__c=false';
-        
+
         return whereClause;
+    }
+	/*******************************************************************************************************
+	* @description builds a WHERE clause from a candidateFilter. The bind tokens it emits
+	* (statuses, objectType, ruleName, confidenceMin, confidenceMax, autoMerge) must exist as local
+	* variables at the point Database.query/countQuery is called (see MRG_DuplicateMerge_CTRL).
+	* @param f the candidate filter
+	* @return String where clause for merge candidate
+	********************************************************************************************************/
+    public static String getWhereClause(candidateFilter f){
+        List<String> clauses = new List<String>();
+        clauses.add('Status__c IN :statuses');
+        if(String.isNotBlank(f.objectType))
+            clauses.add('Object__c = :objectType');
+        if(String.isNotBlank(f.ruleName))
+            clauses.add('Rule__c = :ruleName');
+        if(f.confidenceMin != null)
+            clauses.add('ConfidenceScore__c >= :confidenceMin');
+        if(f.confidenceMax != null)
+            clauses.add('ConfidenceScore__c <= :confidenceMax');
+        if(f.autoMerge != null)
+            clauses.add('AutoMerge__c = :autoMerge');
+        if(f.showIgnored != true)
+            clauses.add('NotADuplicate__c = false');
+        return ' WHERE ' + String.join(clauses, ' AND ');
+    }
+	/*******************************************************************************************************
+	* @description filter for the merge candidate list / grid. Passed from the LWC as a typed object;
+	* statuses defaults to {'New'} (use safeStatuses() to guard against a null/empty list from the client).
+	********************************************************************************************************/
+    public class candidateFilter {
+        @AuraEnabled public String objectType {get;set;}
+        @AuraEnabled public String ruleName {get;set;}
+        @AuraEnabled public Decimal confidenceMin {get;set;}
+        @AuraEnabled public Decimal confidenceMax {get;set;}
+        @AuraEnabled public Boolean autoMerge {get;set;}
+        @AuraEnabled public List<String> statuses {get;set;}
+        @AuraEnabled public Boolean showIgnored {get;set;}
+
+        public candidateFilter(){
+            this.statuses = new List<String>{'New'};
+        }
+        public candidateFilter(String objectType, String ruleName){
+            this();
+            this.objectType = objectType;
+            this.ruleName = ruleName;
+        }
+        public List<String> safeStatuses(){
+            return (statuses == null || statuses.isEmpty()) ? new List<String>{'New'} : statuses;
+        }
     }
 	/*******************************************************************************************************
 	* @description get active duplicate rules for Object type

--- a/force-app/main/default/classes/MRG_ScanPipeline_TEST.cls
+++ b/force-app/main/default/classes/MRG_ScanPipeline_TEST.cls
@@ -76,12 +76,12 @@ private class MRG_ScanPipeline_TEST {
 		mc.Rule__c = 'test';
 		update mc;
 
-		Integer before = MRG_DuplicateMerge_CTRL.getCount('Account','test');
+		Integer before = MRG_DuplicateMerge_CTRL.getCount(new MRG_Duplicate_SVC.candidateFilter('Account','test'));
 
 		// dismiss it
 		MRG_DuplicateMerge_CTRL.removeRecord(mc.Id);
 
-		Integer after = MRG_DuplicateMerge_CTRL.getCount('Account','test');
+		Integer after = MRG_DuplicateMerge_CTRL.getCount(new MRG_Duplicate_SVC.candidateFilter('Account','test'));
 		system.assertEquals(before - 1, after,
 			'a candidate marked not-a-duplicate should drop out of the count');
 	}

--- a/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
+++ b/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
@@ -20,6 +20,15 @@ jest.mock(
     () => ({ default: jest.fn(() => Promise.resolve(1)) }),
     { virtual: true }
 );
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getStatusOptions',
+    () => ({ default: jest.fn(() => Promise.resolve([
+        { label: 'New', value: 'New' },
+        { label: 'Processed', value: 'Processed' },
+        { label: 'Accounts Merged', value: 'Accounts Merged' }
+    ])) }),
+    { virtual: true }
+);
 const mockMergeRecord = jest.fn(() => Promise.resolve('Records merged'));
 jest.mock(
     '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecord',
@@ -33,6 +42,32 @@ jest.mock(
 );
 jest.mock(
     '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccounts',
+    () => ({ default: jest.fn(() => Promise.resolve('merged')) }),
+    { virtual: true }
+);
+// the grid child (rendered in grid view) statically imports these; provide stubs
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions',
+    () => ({ default: jest.fn(() => Promise.resolve({ leadFields: [{ name: 'Id', label: 'Record ID', type: 'id' }], optionalFields: [], trailFields: [] })) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData',
+    () => ({ default: jest.fn(() => Promise.resolve({ columns: [], groups: [] })) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecords',
+    () => ({ default: jest.fn(() => Promise.resolve('merged')) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecords',
+    () => ({ default: jest.fn(() => Promise.resolve('removed')) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccountsBulk',
     () => ({ default: jest.fn(() => Promise.resolve('merged')) }),
     { virtual: true }
 );
@@ -136,5 +171,18 @@ describe('c-dupe-list', () => {
         ip.dispatchEvent(new CustomEvent('page', { detail: 2, bubbles: true }));
         await flush();
         expect(previewButtons(el).length).toBe(2); // remaining 2 duplicates
+    });
+
+    it('toggles to the grid view and renders the grid component', async () => {
+        const el = await render();
+        const toggle = Array.from(el.shadowRoot.querySelectorAll('lightning-button'))
+            .find(b => b.label === 'Grid View');
+        expect(toggle).toBeTruthy();
+        expect(el.shadowRoot.querySelector('c-merge-candidate-grid')).toBeNull();
+
+        toggle.dispatchEvent(new CustomEvent('click'));
+        await flush();
+        await flush();
+        expect(el.shadowRoot.querySelector('c-merge-candidate-grid')).toBeTruthy();
     });
 });

--- a/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
+++ b/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
@@ -48,12 +48,17 @@ jest.mock(
 // the grid child (rendered in grid view) statically imports these; provide stubs
 jest.mock(
     '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions',
-    () => ({ default: jest.fn(() => Promise.resolve({ leadFields: [{ name: 'Id', label: 'Record ID', type: 'id' }], optionalFields: [], trailFields: [] })) }),
+    () => ({ default: jest.fn(() => Promise.resolve({ leadFields: [{ name: 'Id', label: 'Record ID', type: 'id' }], fields: [], trailFields: [] })) }),
     { virtual: true }
 );
 jest.mock(
     '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData',
     () => ({ default: jest.fn(() => Promise.resolve({ columns: [], groups: [] })) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.saveGridFieldConfig',
+    () => ({ default: jest.fn(() => Promise.resolve()) }),
     { virtual: true }
 );
 jest.mock(

--- a/force-app/main/default/lwc/dupeList/dupeList.html
+++ b/force-app/main/default/lwc/dupeList/dupeList.html
@@ -1,7 +1,7 @@
 <template>
     <lightning-card title="Duplicate Records" icon-name="standard:task">
         <div class="slds-m-around_medium">
-            <lightning-layout>
+            <lightning-layout multiple-rows="true" vertical-align="end">
                 <lightning-layout-item padding="around-small" size="2">
                     <lightning-combobox
                         name="objectType"
@@ -22,8 +22,54 @@
                             onchange={handleRuleFilterChange}></lightning-combobox>
                     </lightning-layout-item>
                 </template>
+                <lightning-layout-item padding="around-small" size="2">
+                    <lightning-input
+                        type="number"
+                        name="confidenceMin"
+                        label="Confidence Min"
+                        value={confidenceMin}
+                        onchange={handleConfidenceMinChange}></lightning-input>
+                </lightning-layout-item>
+                <lightning-layout-item padding="around-small" size="2">
+                    <lightning-input
+                        type="number"
+                        name="confidenceMax"
+                        label="Confidence Max"
+                        value={confidenceMax}
+                        onchange={handleConfidenceMaxChange}></lightning-input>
+                </lightning-layout-item>
+                <lightning-layout-item padding="around-small" size="2">
+                    <lightning-combobox
+                        name="autoMerge"
+                        label="Auto Merge?"
+                        value={autoMerge}
+                        options={autoMergeOptions}
+                        onchange={handleAutoMergeChange}></lightning-combobox>
+                </lightning-layout-item>
+                <lightning-layout-item padding="around-small" size="2">
+                    <lightning-checkbox-group
+                        name="statuses"
+                        label="Status"
+                        options={statusOptions}
+                        value={statuses}
+                        onchange={handleStatusChange}></lightning-checkbox-group>
+                </lightning-layout-item>
+                <lightning-layout-item padding="around-small" size="2">
+                    <lightning-button
+                        label="Clear Filters"
+                        onclick={handleClearFilters}></lightning-button>
+                </lightning-layout-item>
             </lightning-layout>
         </div>
+        <div class="slds-m-horizontal_medium slds-m-bottom_small">
+            <lightning-button label={toggleViewLabel} icon-name="utility:table" onclick={handleToggleView}></lightning-button>
+        </div>
+        <template if:true={isGridView}>
+            <div class="slds-m-horizontal_small slds-m-bottom_small">
+                <c-merge-candidate-grid object-type={objectType} filter={filterParam}></c-merge-candidate-grid>
+            </div>
+        </template>
+        <template if:true={isListView}>
         <template if:true={showSpinner}>
             <div class="slds-is-relative">
                 <lightning-spinner variant="brand" size="large" alternative-text="Processing..."></lightning-spinner>
@@ -90,6 +136,7 @@
                     </div>
                 </template>
             </div>
+        </template>
         </template>
     </lightning-card>
     <template if:true={isModalOpen}>

--- a/force-app/main/default/lwc/dupeList/dupeList.js
+++ b/force-app/main/default/lwc/dupeList/dupeList.js
@@ -3,6 +3,7 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getKeepGroups from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getKeepGroups';
 import getDuplicateRules from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getRules';
 import getCount from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getCount';
+import getStatusOptions from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getStatusOptions';
 import doMergeRecord from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecord';
 import doRemoveRecord from '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecord';
 import doMergeAccounts from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccounts';
@@ -13,6 +14,13 @@ import doMergeAccounts from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccou
 const CAP = 2000;
 const GROUPS_PER_PAGE = 10;
 const PAIRS_PER_PAGE = 5;
+// last-used filters are remembered across sessions (#83)
+const FILTER_STORAGE_KEY = 'mergeControl.dupeList.filters';
+const AUTO_MERGE_OPTIONS = [
+    {label:'Any', value:''},
+    {label:'Yes', value:'true'},
+    {label:'No', value:'false'}
+];
 
 export default class DupeList extends LightningElement {
     @track objectType;
@@ -26,20 +34,33 @@ export default class DupeList extends LightningElement {
     @track isModalOpen = false;
     @track showSpinner = false;
     @track ruleOptions;
+    // filters (#83)
+    confidenceMin;
+    confidenceMax;
+    autoMerge = '';
+    statuses = ['New'];
+    statusOptions = [];
+    view = 'list';
+    // the candidateFilter-shaped object passed to the Apex wires; reassigned to re-fire the wire
+    filterParam = {objectType:'Contact', ruleName:null, statuses:['New']};
 
+    autoMergeOptions = AUTO_MERGE_OPTIONS;
     objectOptions = [{label:'Account',value:'Account'},{label:'Contact', value:'Contact'}];
     notificationBody;
     notificationStyle;
     notificationTitle;
 
     connectedCallback(){
+        this.restoreFilters();
         if(this.objectType == null || this.objectType === undefined){
             this.objectType = 'Contact';
-            this.fetchRules();
         }
+        this.fetchStatusOptions();
+        this.fetchRules();
+        this.rebuildFilter();
     }
 
-    @wire(getKeepGroups, {objectType:'$objectType', ruleName:'$rule', limitAmt: CAP, offsetAmt: 0})
+    @wire(getKeepGroups, {filter:'$filterParam', limitAmt: CAP, offsetAmt: 0})
         getRowData({error, data}) {
             if(data){
                 this.allGroups = this.decorate(data);
@@ -81,6 +102,15 @@ export default class DupeList extends LightningElement {
         return this.ruleOptions;
     }
 
+    // ---- list / grid view toggle (#84) ----
+    get isListView(){ return this.view !== 'grid'; }
+    get isGridView(){ return this.view === 'grid'; }
+    get toggleViewLabel(){ return this.isGridView ? 'List View' : 'Grid View'; }
+    handleToggleView(){
+        this.view = this.isGridView ? 'list' : 'grid';
+        this.persistFilters();
+    }
+
     get hasGroups(){
         return this.allGroups != null && this.allGroups.length > 0;
     }
@@ -117,7 +147,7 @@ export default class DupeList extends LightningElement {
     }
 
     fetchCount(){
-        getCount({objectType:this.objectType,ruleName:this.rule})
+        getCount({filter:this.filterParam})
             .then(result=>{ this.totalDuplicates = result != null ? Number(result) : null; })
             .catch(error=>{ this.error=error; this.handleError(); });
     }
@@ -126,18 +156,85 @@ export default class DupeList extends LightningElement {
             .then(result=>{ this.rules = result; })
             .catch(error=>{ this.error=error; this.handleError(); });
     }
+    fetchStatusOptions(){
+        getStatusOptions()
+            .then(result=>{ this.statusOptions = result || []; })
+            .catch(error=>{ this.error=error; this.handleError(); });
+    }
+
+    // ---- filter handling (#83) ----
+    // builds the candidateFilter-shaped object the wires consume, re-firing the wire, and remembers it
+    rebuildFilter(){
+        this.filterParam = {
+            objectType: this.objectType,
+            ruleName: this.rule || null,
+            confidenceMin: (this.confidenceMin === '' || this.confidenceMin == null) ? null : Number(this.confidenceMin),
+            confidenceMax: (this.confidenceMax === '' || this.confidenceMax == null) ? null : Number(this.confidenceMax),
+            autoMerge: this.autoMerge === '' ? null : (this.autoMerge === 'true'),
+            statuses: (this.statuses && this.statuses.length) ? this.statuses : ['New']
+        };
+        this.currentGroupPage = 1;
+        this.persistFilters();
+    }
+    persistFilters(){
+        try {
+            window.localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify({
+                objectType:this.objectType, rule:this.rule,
+                confidenceMin:this.confidenceMin, confidenceMax:this.confidenceMax,
+                autoMerge:this.autoMerge, statuses:this.statuses, view:this.view
+            }));
+        } catch(e){ /* storage unavailable — filters simply won't persist this session */ }
+    }
+    restoreFilters(){
+        try {
+            var saved = JSON.parse(window.localStorage.getItem(FILTER_STORAGE_KEY));
+            if(saved){
+                this.objectType = saved.objectType || this.objectType;
+                this.rule = saved.rule || null;
+                this.confidenceMin = saved.confidenceMin;
+                this.confidenceMax = saved.confidenceMax;
+                this.autoMerge = saved.autoMerge == null ? '' : saved.autoMerge;
+                this.statuses = (saved.statuses && saved.statuses.length) ? saved.statuses : ['New'];
+                this.view = saved.view === 'grid' ? 'grid' : 'list';
+            }
+        } catch(e){ /* nothing saved or storage unavailable */ }
+    }
 
     handleRuleFilterChange(event){
         this.rule = event.detail.value;
-        this.currentGroupPage = 1;
+        this.rebuildFilter();
     }
     handleObjectFilterChange(event){
         if(this.objectType != event.detail.value){
-            this.currentGroupPage = 1;
             this.objectType = event.detail.value;
-            this.fetchRules();
             this.rule = null;
+            this.fetchRules();
+            this.rebuildFilter();
         }
+    }
+    handleConfidenceMinChange(event){
+        this.confidenceMin = event.detail.value;
+        this.rebuildFilter();
+    }
+    handleConfidenceMaxChange(event){
+        this.confidenceMax = event.detail.value;
+        this.rebuildFilter();
+    }
+    handleAutoMergeChange(event){
+        this.autoMerge = event.detail.value;
+        this.rebuildFilter();
+    }
+    handleStatusChange(event){
+        this.statuses = event.detail.value;
+        this.rebuildFilter();
+    }
+    handleClearFilters(){
+        this.rule = null;
+        this.confidenceMin = null;
+        this.confidenceMax = null;
+        this.autoMerge = '';
+        this.statuses = ['New'];
+        this.rebuildFilter();
     }
     handleGroupPage(event){
         this.currentGroupPage = Number(event.detail);

--- a/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
@@ -3,10 +3,13 @@ import MergeCandidateGrid from 'c/mergeCandidateGrid';
 
 const FIELD_OPTIONS = {
     leadFields: [{ name: 'Id', label: 'Record ID', type: 'id' }],
-    optionalFields: [{ name: 'Phone', label: 'Phone', type: 'phone' }],
     trailFields: [
         { name: 'CreatedDate', label: 'Created Date', type: 'datetime' },
         { name: 'LastModifiedDate', label: 'Last Modified Date', type: 'datetime' }
+    ],
+    fields: [
+        { name: 'Email', label: 'Email', type: 'email', displayLabel: 'Email (Email)', selected: true },
+        { name: 'Phone', label: 'Phone', type: 'phone', displayLabel: 'Phone (Phone)', selected: false }
     ]
 };
 const GRID_DATA = {
@@ -42,6 +45,12 @@ jest.mock(
 jest.mock(
     '@salesforce/apex/MRG_DuplicateMerge_CTRL.getCount',
     () => ({ default: jest.fn(() => Promise.resolve(1)) }),
+    { virtual: true }
+);
+const mockSaveConfig = jest.fn(() => Promise.resolve());
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.saveGridFieldConfig',
+    () => ({ default: (...args) => mockSaveConfig(...args) }),
     { virtual: true }
 );
 const mockMergeRecords = jest.fn(() => Promise.resolve('1 record(s) merged'));
@@ -111,7 +120,7 @@ describe('c-merge-candidate-grid', () => {
         expect(mockMergeRecords).toHaveBeenCalledWith({ recordIds: ['mc1'] });
     });
 
-    it('reveals optional field checkboxes when the field panel is toggled', async () => {
+    it('reveals selectable field checkboxes when the field panel is toggled', async () => {
         const el = await render();
         expect(el.shadowRoot.querySelector('.grid-field-panel')).toBeNull();
         buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
@@ -121,5 +130,32 @@ describe('c-merge-candidate-grid', () => {
         const optional = Array.from(panel.querySelectorAll('lightning-input'))
             .find(i => i.dataset.field === 'Phone');
         expect(optional).toBeTruthy();
+    });
+
+    it('saves the selection server-side when a field is toggled', async () => {
+        const el = await render();
+        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        const phone = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input'))
+            .find(i => i.dataset.field === 'Phone');
+        phone.checked = true;
+        phone.dispatchEvent(new CustomEvent('change'));
+        await flush();
+        // Email (default-selected) + Phone (just added)
+        expect(mockSaveConfig).toHaveBeenCalledWith({ objectType: 'Contact', fields: ['Email', 'Phone'] });
+    });
+
+    it('filters the field list by label or api name', async () => {
+        const el = await render();
+        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        const search = Array.from(el.shadowRoot.querySelectorAll('lightning-input'))
+            .find(i => i.type === 'search');
+        search.dispatchEvent(new CustomEvent('change', { detail: { value: 'phone' } }));
+        await flush();
+        const checks = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input'))
+            .filter(i => i.type === 'checkbox');
+        expect(checks.length).toBe(1);
+        expect(checks[0].dataset.field).toBe('Phone');
     });
 });

--- a/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
@@ -132,7 +132,7 @@ describe('c-merge-candidate-grid', () => {
         expect(optional).toBeTruthy();
     });
 
-    it('saves the selection server-side when a field is toggled', async () => {
+    it('batches toggles and saves the selection only when Save is clicked', async () => {
         const el = await render();
         buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
         await flush();
@@ -140,6 +140,10 @@ describe('c-merge-candidate-grid', () => {
             .find(i => i.dataset.field === 'Phone');
         phone.checked = true;
         phone.dispatchEvent(new CustomEvent('change'));
+        await flush();
+        expect(mockSaveConfig).not.toHaveBeenCalled(); // toggles are batched, not saved yet
+
+        buttonByLabel(el, 'Save').dispatchEvent(new CustomEvent('click'));
         await flush();
         // Email (default-selected) + Phone (just added)
         expect(mockSaveConfig).toHaveBeenCalledWith({ objectType: 'Contact', fields: ['Email', 'Phone'] });

--- a/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
@@ -1,0 +1,125 @@
+import { createElement } from 'lwc';
+import MergeCandidateGrid from 'c/mergeCandidateGrid';
+
+const FIELD_OPTIONS = {
+    leadFields: [{ name: 'Id', label: 'Record ID', type: 'id' }],
+    optionalFields: [{ name: 'Phone', label: 'Phone', type: 'phone' }],
+    trailFields: [
+        { name: 'CreatedDate', label: 'Created Date', type: 'datetime' },
+        { name: 'LastModifiedDate', label: 'Last Modified Date', type: 'datetime' }
+    ]
+};
+const GRID_DATA = {
+    columns: [
+        { name: 'Id', label: 'Record ID', type: 'id' },
+        { name: 'Email', label: 'Email', type: 'email' }
+    ],
+    groups: [
+        {
+            keepId: '003A', keepName: 'Acme', objectType: 'Contact',
+            rows: [
+                { rowType: 'keep', recordId: '003A', candidateId: null, selectable: false,
+                  cells: [{ name: 'Id', value: '003A' }, { name: 'Email', value: 'a@x.com' }] },
+                { rowType: 'duplicate', recordId: '003B', candidateId: 'mc1', selectable: true,
+                  cells: [{ name: 'Id', value: '003B' }, { name: 'Email', value: 'b@x.com' }] },
+                { rowType: 'result', recordId: '003A', candidateId: null, selectable: false,
+                  cells: [{ name: 'Id', value: '003A' }, { name: 'Email', value: 'a@x.com' }] }
+            ]
+        }
+    ]
+};
+
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions',
+    () => ({ default: jest.fn(() => Promise.resolve(FIELD_OPTIONS)) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData',
+    () => ({ default: jest.fn(() => Promise.resolve(GRID_DATA)) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getCount',
+    () => ({ default: jest.fn(() => Promise.resolve(1)) }),
+    { virtual: true }
+);
+const mockMergeRecords = jest.fn(() => Promise.resolve('1 record(s) merged'));
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecords',
+    () => ({ default: (...args) => mockMergeRecords(...args) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecords',
+    () => ({ default: jest.fn(() => Promise.resolve('removed')) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccountsBulk',
+    () => ({ default: jest.fn(() => Promise.resolve('merged')) }),
+    { virtual: true }
+);
+
+function flush() {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}
+function buttonByLabel(el, label) {
+    return Array.from(el.shadowRoot.querySelectorAll('lightning-button')).find(b => b.label === label);
+}
+async function render() {
+    const el = createElement('c-merge-candidate-grid', { is: MergeCandidateGrid });
+    el.objectType = 'Contact';
+    el.filter = { objectType: 'Contact', ruleName: 'test', statuses: ['New'] };
+    document.body.appendChild(el);
+    await flush();
+    return el;
+}
+
+describe('c-merge-candidate-grid', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('renders a column per field and a row per keep/duplicate/result', async () => {
+        const el = await render();
+        const headers = el.shadowRoot.querySelectorAll('thead th');
+        // one "Row" header + one per column
+        expect(headers.length).toBe(GRID_DATA.columns.length + 1);
+        // a checkbox is rendered only for the selectable duplicate row
+        const checkboxes = Array.from(el.shadowRoot.querySelectorAll('lightning-input'))
+            .filter(i => i.type === 'checkbox');
+        expect(checkboxes.length).toBe(1);
+    });
+
+    it('enables actions on selection and merges the selected candidate', async () => {
+        const el = await render();
+        expect(buttonByLabel(el, 'Merge').disabled).toBe(true);
+
+        const checkbox = Array.from(el.shadowRoot.querySelectorAll('lightning-input'))
+            .find(i => i.dataset.candidate === 'mc1');
+        checkbox.checked = true;
+        checkbox.dispatchEvent(new CustomEvent('change'));
+        await flush();
+
+        expect(buttonByLabel(el, 'Merge').disabled).toBe(false);
+        buttonByLabel(el, 'Merge').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(mockMergeRecords).toHaveBeenCalledWith({ recordIds: ['mc1'] });
+    });
+
+    it('reveals optional field checkboxes when the field panel is toggled', async () => {
+        const el = await render();
+        expect(el.shadowRoot.querySelector('.grid-field-panel')).toBeNull();
+        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        const panel = el.shadowRoot.querySelector('.grid-field-panel');
+        expect(panel).toBeTruthy();
+        const optional = Array.from(panel.querySelectorAll('lightning-input'))
+            .find(i => i.dataset.field === 'Phone');
+        expect(optional).toBeTruthy();
+    });
+});

--- a/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
@@ -132,7 +132,7 @@ describe('c-merge-candidate-grid', () => {
         expect(optional).toBeTruthy();
     });
 
-    it('batches toggles and saves the selection only when Save is clicked', async () => {
+    it('batches toggles, saves on Save, and closes the panel', async () => {
         const el = await render();
         buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
         await flush();
@@ -147,6 +147,28 @@ describe('c-merge-candidate-grid', () => {
         await flush();
         // Email (default-selected) + Phone (just added)
         expect(mockSaveConfig).toHaveBeenCalledWith({ objectType: 'Contact', fields: ['Email', 'Phone'] });
+        expect(el.shadowRoot.querySelector('.grid-field-panel')).toBeNull(); // save closes the panel
+    });
+
+    it('reorders selected fields and persists the new column order', async () => {
+        const el = await render();
+        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        // select Phone so both Email and Phone are selected
+        const phone = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input'))
+            .find(i => i.dataset.field === 'Phone');
+        phone.checked = true;
+        phone.dispatchEvent(new CustomEvent('change'));
+        await flush();
+        // move Phone above Email
+        const phoneUp = Array.from(el.shadowRoot.querySelectorAll('lightning-button-icon'))
+            .find(b => b.dataset.field === 'Phone' && b.iconName === 'utility:up');
+        expect(phoneUp).toBeTruthy();
+        phoneUp.dispatchEvent(new CustomEvent('click'));
+        await flush();
+        buttonByLabel(el, 'Save').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(mockSaveConfig).toHaveBeenCalledWith({ objectType: 'Contact', fields: ['Phone', 'Email'] });
     });
 
     it('filters the field list by label or api name', async () => {

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
@@ -15,3 +15,6 @@
     max-height: 30rem;
     overflow-y: auto;
 }
+.grid-field-save {
+    font-size: 0.75rem;
+}

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
@@ -1,0 +1,17 @@
+.grid-table {
+    font-size: 0.8rem;
+}
+.grid-row_keep td {
+    background-color: #f3f9ff;
+}
+.grid-row_result td {
+    background-color: #f3faf6;
+    font-weight: 600;
+}
+.grid-row_duplicate td {
+    background-color: #ffffff;
+}
+.grid-field-panel {
+    max-height: 30rem;
+    overflow-y: auto;
+}

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
@@ -1,5 +1,15 @@
+.grid-scroll {
+    overflow-x: auto;
+    width: 100%;
+}
 .grid-table {
     font-size: 0.8rem;
+    width: auto;
+}
+.grid-table th,
+.grid-table td {
+    min-width: 8rem;
+    white-space: nowrap;
 }
 .grid-row_keep td {
     background-color: #f3f9ff;

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
@@ -1,3 +1,12 @@
+/* fill the available width as a block so the host doesn't size to the (wide) table content */
+:host {
+    display: block;
+}
+/* flex items default to min-width:auto and won't shrink below their content; min-width:0 lets the
+   table column stay within the available width so the scroll happens inside .grid-scroll, not the page */
+.grid-main {
+    min-width: 0;
+}
 .grid-scroll {
     overflow-x: auto;
     width: 100%;

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -1,0 +1,106 @@
+<template>
+    <div class="slds-box slds-box_x-small slds-m-around_x-small">
+        <!-- toolbar -->
+        <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-end slds-wrap slds-m-bottom_small">
+            <div class="slds-grid slds-gutters_x-small slds-grid_vertical-align-end slds-wrap">
+                <div class="slds-col" style="min-width:7rem;">
+                    <lightning-combobox
+                        label="Per Page"
+                        value={pageSizeValue}
+                        options={pageSizeOptions}
+                        onchange={handlePageSizeChange}></lightning-combobox>
+                </div>
+                <div class="slds-col slds-align-bottom">
+                    <lightning-button label="Configure Fields" icon-name="utility:settings" onclick={toggleFieldPanel}></lightning-button>
+                </div>
+            </div>
+            <div class="slds-col slds-align-bottom">
+                <lightning-button label="Merge" variant="success" disabled={actionsDisabled} onclick={handleMergeSelected} class="slds-m-right_xx-small"></lightning-button>
+                <lightning-button label="Merge Accounts" disabled={actionsDisabled} onclick={handleMergeAccountsSelected} class="slds-m-right_xx-small"></lightning-button>
+                <lightning-button label="Remove" variant="destructive" disabled={actionsDisabled} onclick={handleRemoveSelected}></lightning-button>
+            </div>
+        </div>
+
+        <template if:true={cappedNotice}>
+            <div class="slds-text-color_weak slds-text-body_small slds-m-bottom_x-small">{cappedNotice}</div>
+        </template>
+        <template if:true={showSpinner}>
+            <div class="slds-is-relative slds-p-around_medium">
+                <lightning-spinner variant="brand" size="medium" alternative-text="Loading..."></lightning-spinner>
+            </div>
+        </template>
+        <template if:true={hasPager}>
+            <c-pager total-pages={totalPages} current-page={pageNumber} onpage={handlePage}></c-pager>
+        </template>
+
+        <div class="slds-grid slds-gutters">
+            <div class="slds-col">
+                <table class="slds-table slds-table_bordered slds-table_cell-buffer slds-table_fixed-layout grid-table">
+                    <thead>
+                        <tr class="slds-line-height_reset">
+                            <th class="slds-text-title_caps" scope="col" style="width:6rem;"><span title="Row">Row</span></th>
+                            <template for:each={columns} for:item="col">
+                                <th key={col.name} class="slds-text-title_caps" scope="col"><span title={col.label}>{col.label}</span></th>
+                            </template>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <template for:each={groups} for:item="group">
+                            <tr key={group.keepId} class="slds-theme_shade">
+                                <th colspan={columnSpan} scope="row" class="slds-p-vertical_xx-small">
+                                    <strong>Keep:&nbsp;{group.keepName}</strong>
+                                </th>
+                            </tr>
+                            <template for:each={group.rows} for:item="row">
+                                <tr key={row.key} class={row.rowClass}>
+                                    <td>
+                                        <template if:true={row.selectable}>
+                                            <lightning-input
+                                                type="checkbox"
+                                                variant="label-hidden"
+                                                label="Select duplicate"
+                                                checked={row.checked}
+                                                data-candidate={row.candidateId}
+                                                onchange={handleRowSelect}></lightning-input>
+                                        </template>
+                                        <span class="slds-text-body_small slds-text-color_weak">{row.rowLabel}</span>
+                                    </td>
+                                    <template for:each={row.cells} for:item="cell">
+                                        <td key={cell.key}>
+                                            <div class="slds-truncate" title={cell.value}>{cell.value}</div>
+                                        </td>
+                                    </template>
+                                </tr>
+                            </template>
+                        </template>
+                    </tbody>
+                </table>
+                <template if:false={hasGroups}>
+                    <div class="slds-p-around_medium slds-text-color_weak">No merge candidates match the current filters.</div>
+                </template>
+            </div>
+
+            <template if:true={showFieldPanel}>
+                <div class="slds-col slds-size_1-of-4 grid-field-panel slds-box slds-theme_default">
+                    <div class="slds-text-title_caps slds-m-bottom_x-small">Show Fields</div>
+                    <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
+                        Id, Created Date, Last Modified Date and the first columns always appear.
+                    </p>
+                    <template for:each={optionalFields} for:item="opt">
+                        <div key={opt.name} class="slds-p-bottom_xx-small">
+                            <lightning-input
+                                type="checkbox"
+                                label={opt.label}
+                                checked={opt.selected}
+                                data-field={opt.name}
+                                onchange={handleFieldToggle}></lightning-input>
+                        </div>
+                    </template>
+                    <template if:false={hasOptionalFields}>
+                        <div class="slds-text-color_weak slds-text-body_small">No additional fields available.</div>
+                    </template>
+                </div>
+            </template>
+        </div>
+    </div>
+</template>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -83,14 +83,22 @@
             <template if:true={showFieldPanel}>
                 <div class="slds-col slds-size_1-of-4 grid-field-panel slds-box slds-theme_default">
                     <div class="slds-text-title_caps slds-m-bottom_x-small">Show Fields</div>
-                    <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">
-                        Id, Created Date, Last Modified Date and the first columns always appear.
+                    <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
+                        Id, Created Date and Last Modified Date always appear. Selections are saved for this object for all users.
                     </p>
-                    <template for:each={optionalFields} for:item="opt">
+                    <lightning-input
+                        type="search"
+                        label="Find fields"
+                        variant="label-hidden"
+                        placeholder="Filter by label or API name"
+                        value={filterText}
+                        onchange={handleFilterChange}
+                        class="slds-m-bottom_x-small"></lightning-input>
+                    <template for:each={visibleFields} for:item="opt">
                         <div key={opt.name} class="slds-p-bottom_xx-small">
                             <lightning-input
                                 type="checkbox"
-                                label={opt.label}
+                                label={opt.displayLabel}
                                 checked={opt.selected}
                                 data-field={opt.name}
                                 onchange={handleFieldToggle}></lightning-input>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -35,7 +35,8 @@
 
         <div class="slds-grid slds-gutters">
             <div class="slds-col">
-                <table class="slds-table slds-table_bordered slds-table_cell-buffer slds-table_fixed-layout grid-table">
+                <div class="grid-scroll">
+                <table class="slds-table slds-table_bordered slds-table_cell-buffer grid-table">
                     <thead>
                         <tr class="slds-line-height_reset">
                             <th class="slds-text-title_caps" scope="col" style="width:6rem;"><span title="Row">Row</span></th>
@@ -75,6 +76,7 @@
                         </template>
                     </tbody>
                 </table>
+                </div>
                 <template if:false={hasGroups}>
                     <div class="slds-p-around_medium slds-text-color_weak">No merge candidates match the current filters.</div>
                 </template>
@@ -92,7 +94,7 @@
                             class="grid-field-save"></lightning-button>
                     </div>
                     <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
-                        Id, Created Date and Last Modified Date always appear. Check or uncheck fields, then Save (shared for this object for all users).
+                        Id, Created Date and Last Modified Date always appear. Check or uncheck fields and use the arrows to order the columns, then Save (shared for this object for all users).
                     </p>
                     <lightning-input
                         type="search"
@@ -103,13 +105,37 @@
                         onchange={handleFilterChange}
                         class="slds-m-bottom_x-small"></lightning-input>
                     <template for:each={visibleFields} for:item="opt">
-                        <div key={opt.name} class="slds-p-bottom_xx-small">
-                            <lightning-input
-                                type="checkbox"
-                                label={opt.displayLabel}
-                                checked={opt.selected}
-                                data-field={opt.name}
-                                onchange={handleFieldToggle}></lightning-input>
+                        <div key={opt.name} class="slds-grid slds-grid_vertical-align-center slds-p-bottom_xx-small">
+                            <span class="slds-col">
+                                <lightning-input
+                                    type="checkbox"
+                                    label={opt.displayLabel}
+                                    checked={opt.selected}
+                                    data-field={opt.name}
+                                    onchange={handleFieldToggle}></lightning-input>
+                            </span>
+                            <template if:true={opt.selected}>
+                                <span class="slds-shrink-none">
+                                    <lightning-button-icon
+                                        icon-name="utility:up"
+                                        variant="bare"
+                                        size="small"
+                                        alternative-text="Move up"
+                                        title="Move up"
+                                        disabled={opt.disableMoveUp}
+                                        data-field={opt.name}
+                                        onclick={handleMoveUp}></lightning-button-icon>
+                                    <lightning-button-icon
+                                        icon-name="utility:down"
+                                        variant="bare"
+                                        size="small"
+                                        alternative-text="Move down"
+                                        title="Move down"
+                                        disabled={opt.disableMoveDown}
+                                        data-field={opt.name}
+                                        onclick={handleMoveDown}></lightning-button-icon>
+                                </span>
+                            </template>
                         </div>
                     </template>
                     <template if:false={hasOptionalFields}>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -82,9 +82,17 @@
 
             <template if:true={showFieldPanel}>
                 <div class="slds-col slds-size_1-of-4 grid-field-panel slds-box slds-theme_default">
-                    <div class="slds-text-title_caps slds-m-bottom_x-small">Show Fields</div>
+                    <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-center slds-m-bottom_x-small">
+                        <div class="slds-text-title_caps">Show Fields</div>
+                        <lightning-button
+                            label="Save"
+                            variant="brand"
+                            disabled={saveFieldsDisabled}
+                            onclick={handleSaveFields}
+                            class="grid-field-save"></lightning-button>
+                    </div>
                     <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
-                        Id, Created Date and Last Modified Date always appear. Selections are saved for this object for all users.
+                        Id, Created Date and Last Modified Date always appear. Check or uncheck fields, then Save (shared for this object for all users).
                     </p>
                     <lightning-input
                         type="search"
@@ -107,6 +115,14 @@
                     <template if:false={hasOptionalFields}>
                         <div class="slds-text-color_weak slds-text-body_small">No additional fields available.</div>
                     </template>
+                    <div class="slds-m-top_x-small slds-border_top slds-p-top_x-small">
+                        <lightning-button
+                            label="Save"
+                            variant="brand"
+                            disabled={saveFieldsDisabled}
+                            onclick={handleSaveFields}
+                            class="grid-field-save"></lightning-button>
+                    </div>
                 </div>
             </template>
         </div>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -35,48 +35,49 @@
 
         <div class="slds-grid slds-gutters">
             <div class="slds-col">
-                <div class="grid-scroll">
-                <table class="slds-table slds-table_bordered slds-table_cell-buffer grid-table">
-                    <thead>
-                        <tr class="slds-line-height_reset">
-                            <th class="slds-text-title_caps" scope="col" style="width:6rem;"><span title="Row">Row</span></th>
-                            <template for:each={columns} for:item="col">
-                                <th key={col.name} class="slds-text-title_caps" scope="col"><span title={col.label}>{col.label}</span></th>
-                            </template>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <template for:each={groups} for:item="group">
-                            <tr key={group.keepId} class="slds-theme_shade">
-                                <th colspan={columnSpan} scope="row" class="slds-p-vertical_xx-small">
-                                    <strong>Keep:&nbsp;{group.keepName}</strong>
-                                </th>
-                            </tr>
-                            <template for:each={group.rows} for:item="row">
-                                <tr key={row.key} class={row.rowClass}>
-                                    <td>
-                                        <template if:true={row.selectable}>
-                                            <lightning-input
-                                                type="checkbox"
-                                                variant="label-hidden"
-                                                label="Select duplicate"
-                                                checked={row.checked}
-                                                data-candidate={row.candidateId}
-                                                onchange={handleRowSelect}></lightning-input>
+                <template for:each={groups} for:item="group">
+                    <div key={group.keepId} class="slds-m-bottom_small">
+                        <div class="slds-text-title_caps slds-p-vertical_xx-small slds-p-horizontal_x-small slds-theme_shade">
+                            <strong>Keep:&nbsp;{group.keepName}</strong>
+                        </div>
+                        <!-- each group scrolls horizontally on its own -->
+                        <div class="grid-scroll">
+                            <table class="slds-table slds-table_bordered slds-table_cell-buffer grid-table">
+                                <thead>
+                                    <tr class="slds-line-height_reset">
+                                        <th class="slds-text-title_caps" scope="col" style="width:6rem;"><span title="Row">Row</span></th>
+                                        <template for:each={columns} for:item="col">
+                                            <th key={col.name} class="slds-text-title_caps" scope="col"><span title={col.label}>{col.label}</span></th>
                                         </template>
-                                        <span class="slds-text-body_small slds-text-color_weak">{row.rowLabel}</span>
-                                    </td>
-                                    <template for:each={row.cells} for:item="cell">
-                                        <td key={cell.key}>
-                                            <div class="slds-truncate" title={cell.value}>{cell.value}</div>
-                                        </td>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <template for:each={group.rows} for:item="row">
+                                        <tr key={row.key} class={row.rowClass}>
+                                            <td>
+                                                <template if:true={row.selectable}>
+                                                    <lightning-input
+                                                        type="checkbox"
+                                                        variant="label-hidden"
+                                                        label="Select duplicate"
+                                                        checked={row.checked}
+                                                        data-candidate={row.candidateId}
+                                                        onchange={handleRowSelect}></lightning-input>
+                                                </template>
+                                                <span class="slds-text-body_small slds-text-color_weak">{row.rowLabel}</span>
+                                            </td>
+                                            <template for:each={row.cells} for:item="cell">
+                                                <td key={cell.key}>
+                                                    <div class="slds-truncate" title={cell.value}>{cell.value}</div>
+                                                </td>
+                                            </template>
+                                        </tr>
                                     </template>
-                                </tr>
-                            </template>
-                        </template>
-                    </tbody>
-                </table>
-                </div>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </template>
                 <template if:false={hasGroups}>
                     <div class="slds-p-around_medium slds-text-color_weak">No merge candidates match the current filters.</div>
                 </template>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -34,7 +34,7 @@
         </template>
 
         <div class="slds-grid slds-gutters">
-            <div class="slds-col">
+            <div class="slds-col grid-main">
                 <template for:each={groups} for:item="group">
                     <div key={group.keepId} class="slds-m-bottom_small">
                         <div class="slds-text-title_caps slds-p-vertical_xx-small slds-p-horizontal_x-small slds-theme_shade">

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -39,6 +39,7 @@ export default class MergeCandidateGrid extends LightningElement {
     leadFields = [];
     trailFields = [];
     filterText = '';
+    fieldsDirty = false;
     selectedCandidateIds = [];
     pageSize = DEFAULT_PAGE_SIZE;
     pageNumber = 1;
@@ -163,15 +164,24 @@ export default class MergeCandidateGrid extends LightningElement {
     handleFilterChange(event){
         this.filterText = event.detail.value;
     }
+    // toggles only update local state so the user can check/uncheck several fields before saving
     handleFieldToggle(event){
         var name = event.currentTarget.dataset.field;
         var checked = event.target.checked;
         this.allFields = this.allFields.map(f=> f.name === name ? Object.assign({}, f, {selected:checked}) : f);
-        // persist the selection for this object, shared across all users, then refresh the grid columns
+        this.fieldsDirty = true;
+    }
+    get saveFieldsDisabled(){ return !this.fieldsDirty; }
+    // persist the (multi-field) selection for this object, shared across all users, then refresh the grid
+    handleSaveFields(){
         saveGridFieldConfig({objectType:this.objectType, fields:this.selectedNames})
+            .then(()=>{
+                this.fieldsDirty = false;
+                this.pageNumber = 1;
+                this.reload();
+                this.toast('Fields saved', 'Grid fields updated.', 'success');
+            })
             .catch(error=>this.handleError(error));
-        this.pageNumber = 1;
-        this.reload();
     }
 
     // ---- paging ----

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -35,7 +35,7 @@ export default class MergeCandidateGrid extends LightningElement {
 
     @track columns = [];
     @track groups = [];
-    @track allFields = [];
+    @track panelFields = [];
     leadFields = [];
     trailFields = [];
     filterText = '';
@@ -61,17 +61,17 @@ export default class MergeCandidateGrid extends LightningElement {
             .then(result=>{
                 this.leadFields = result.leadFields || [];
                 this.trailFields = result.trailFields || [];
-                // server returns every selectable field (label-sorted) with its saved/default selected state
-                this.allFields = (result.fields || []).map(o=>Object.assign({}, o));
+                // server returns selected fields first (in saved order), then the rest by label
+                this.panelFields = (result.fields || []).map(o=>Object.assign({}, o));
                 this._loaded = true;
                 this.reload();
             })
             .catch(error=>this.handleError(error));
     }
 
-    // selected field API names, in label order (allFields arrives label-sorted from the server)
+    // selected field API names, in the panel's current (user-defined) order
     get selectedNames(){
-        return this.allFields.filter(f=>f.selected).map(f=>f.name);
+        return this.panelFields.filter(f=>f.selected).map(f=>f.name);
     }
     // the ordered field API names sent to the server: Id, selected fields (label order), Created/Last Modified
     get fieldNames(){
@@ -151,15 +151,21 @@ export default class MergeCandidateGrid extends LightningElement {
 
     // ---- field side panel ----
     toggleFieldPanel(){ this.showFieldPanel = !this.showFieldPanel; }
-    get hasOptionalFields(){ return this.allFields.length > 0; }
-    // selected fields first (label order), then the rest (label order), filtered by label or api name
+    get hasOptionalFields(){ return this.panelFields.length > 0; }
+    // the panel keeps its current order while editing (selected fields only float to the top on Save);
+    // filtered by label or api name (contains). Each item carries move-up/down enablement for reordering.
     get visibleFields(){
         var text = (this.filterText || '').toLowerCase();
-        var matched = this.allFields.filter(f=>
-            !text
-            || (f.label || '').toLowerCase().indexOf(text) !== -1
-            || (f.name || '').toLowerCase().indexOf(text) !== -1);
-        return matched.filter(f=>f.selected).concat(matched.filter(f=>!f.selected));
+        var selected = this.panelFields.filter(f=>f.selected);
+        return this.panelFields
+            .filter(f=>
+                !text
+                || (f.label || '').toLowerCase().indexOf(text) !== -1
+                || (f.name || '').toLowerCase().indexOf(text) !== -1)
+            .map(f=>Object.assign({}, f, {
+                disableMoveUp: !(f.selected && selected.indexOf(f) > 0),
+                disableMoveDown: !(f.selected && selected.indexOf(f) < selected.length - 1)
+            }));
     }
     handleFilterChange(event){
         this.filterText = event.detail.value;
@@ -168,20 +174,48 @@ export default class MergeCandidateGrid extends LightningElement {
     handleFieldToggle(event){
         var name = event.currentTarget.dataset.field;
         var checked = event.target.checked;
-        this.allFields = this.allFields.map(f=> f.name === name ? Object.assign({}, f, {selected:checked}) : f);
+        this.panelFields = this.panelFields.map(f=> f.name === name ? Object.assign({}, f, {selected:checked}) : f);
+        this.fieldsDirty = true;
+    }
+    handleMoveUp(event){ this.moveSelected(event.currentTarget.dataset.field, -1); }
+    handleMoveDown(event){ this.moveSelected(event.currentTarget.dataset.field, 1); }
+    // swaps a selected field with its adjacent selected field (reorders the display columns)
+    moveSelected(name, dir){
+        var arr = this.panelFields.slice();
+        var i = arr.findIndex(f=>f.name === name);
+        if(i < 0 || !arr[i].selected)
+            return;
+        var j = i + dir;
+        while(j >= 0 && j < arr.length && !arr[j].selected)
+            j += dir;
+        if(j < 0 || j >= arr.length)
+            return;
+        var tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
+        this.panelFields = arr;
         this.fieldsDirty = true;
     }
     get saveFieldsDisabled(){ return !this.fieldsDirty; }
-    // persist the (multi-field) selection for this object, shared across all users, then refresh the grid
+    // persist the (multi-field, ordered) selection for this object across all users, refresh the grid,
+    // float selected fields to the top of the panel and close it
     handleSaveFields(){
         saveGridFieldConfig({objectType:this.objectType, fields:this.selectedNames})
             .then(()=>{
                 this.fieldsDirty = false;
+                this.resortPanel();
+                this.showFieldPanel = false;
                 this.pageNumber = 1;
                 this.reload();
                 this.toast('Fields saved', 'Grid fields updated.', 'success');
             })
             .catch(error=>this.handleError(error));
+    }
+    // after save: selected fields first (in their chosen order), then unselected by label
+    resortPanel(){
+        var selected = this.panelFields.filter(f=>f.selected);
+        var unselected = this.panelFields.filter(f=>!f.selected)
+            .slice()
+            .sort((a,b)=>(a.label || '').toLowerCase().localeCompare((b.label || '').toLowerCase()));
+        this.panelFields = selected.concat(unselected);
     }
 
     // ---- paging ----

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -3,21 +3,21 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import getGridData from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData';
 import getGridFieldOptions from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions';
 import getCount from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getCount';
+import saveGridFieldConfig from '@salesforce/apex/MRG_DuplicateMerge_CTRL.saveGridFieldConfig';
 import mergeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecords';
 import removeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecords';
 import mergeAccountsBulk from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccountsBulk';
 
 // the grid shows a page of candidates grouped by kept record (keep / duplicate(s) / simulated result),
-// for a configurable field set. The first columns + Id/Created/LastModified always appear; extra fields
-// are toggled in the side panel. Paging is bounded to the top 2000 confidence-ranked candidates, matching
-// the list view.
+// for a configurable field set. Only Id/Created/LastModified always appear; every other field is toggled
+// in the side panel and the selection is saved per object for all users. Paging is bounded to the top
+// 2000 confidence-ranked candidates, matching the list view.
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_RECORDS = 2000;
 const PAGE_SIZE_OPTIONS = [
     {label:'10', value:'10'}, {label:'25', value:'25'}, {label:'50', value:'50'},
     {label:'100', value:'100'}, {label:'200', value:'200'}
 ];
-const FIELD_STORAGE_PREFIX = 'mergeControl.grid.fields.';
 
 export default class MergeCandidateGrid extends LightningElement {
     @api objectType;
@@ -35,10 +35,10 @@ export default class MergeCandidateGrid extends LightningElement {
 
     @track columns = [];
     @track groups = [];
-    @track optionalFields = [];
+    @track allFields = [];
     leadFields = [];
     trailFields = [];
-    selectedOptional = [];
+    filterText = '';
     selectedCandidateIds = [];
     pageSize = DEFAULT_PAGE_SIZE;
     pageNumber = 1;
@@ -60,18 +60,22 @@ export default class MergeCandidateGrid extends LightningElement {
             .then(result=>{
                 this.leadFields = result.leadFields || [];
                 this.trailFields = result.trailFields || [];
-                this.optionalFields = (result.optionalFields || []).map(o=>Object.assign({}, o, {selected:false}));
-                this.restoreFieldSelection();
+                // server returns every selectable field (label-sorted) with its saved/default selected state
+                this.allFields = (result.fields || []).map(o=>Object.assign({}, o));
                 this._loaded = true;
                 this.reload();
             })
             .catch(error=>this.handleError(error));
     }
 
-    // the ordered field API names sent to the server: lead (Id + first 10), chosen optionals, trail
+    // selected field API names, in label order (allFields arrives label-sorted from the server)
+    get selectedNames(){
+        return this.allFields.filter(f=>f.selected).map(f=>f.name);
+    }
+    // the ordered field API names sent to the server: Id, selected fields (label order), Created/Last Modified
     get fieldNames(){
         var names = this.leadFields.map(f=>f.name);
-        names = names.concat(this.selectedOptional);
+        names = names.concat(this.selectedNames);
         names = names.concat(this.trailFields.map(f=>f.name));
         return names;
     }
@@ -146,32 +150,28 @@ export default class MergeCandidateGrid extends LightningElement {
 
     // ---- field side panel ----
     toggleFieldPanel(){ this.showFieldPanel = !this.showFieldPanel; }
-    get hasOptionalFields(){ return this.optionalFields.length > 0; }
+    get hasOptionalFields(){ return this.allFields.length > 0; }
+    // selected fields first (label order), then the rest (label order), filtered by label or api name
+    get visibleFields(){
+        var text = (this.filterText || '').toLowerCase();
+        var matched = this.allFields.filter(f=>
+            !text
+            || (f.label || '').toLowerCase().indexOf(text) !== -1
+            || (f.name || '').toLowerCase().indexOf(text) !== -1);
+        return matched.filter(f=>f.selected).concat(matched.filter(f=>!f.selected));
+    }
+    handleFilterChange(event){
+        this.filterText = event.detail.value;
+    }
     handleFieldToggle(event){
         var name = event.currentTarget.dataset.field;
         var checked = event.target.checked;
-        var set = new Set(this.selectedOptional);
-        if(checked) set.add(name); else set.delete(name);
-        this.selectedOptional = Array.from(set);
-        this.optionalFields = this.optionalFields.map(o=>Object.assign({}, o, {selected:this.selectedOptional.includes(o.name)}));
-        this.persistFieldSelection();
+        this.allFields = this.allFields.map(f=> f.name === name ? Object.assign({}, f, {selected:checked}) : f);
+        // persist the selection for this object, shared across all users, then refresh the grid columns
+        saveGridFieldConfig({objectType:this.objectType, fields:this.selectedNames})
+            .catch(error=>this.handleError(error));
         this.pageNumber = 1;
         this.reload();
-    }
-    persistFieldSelection(){
-        try {
-            window.localStorage.setItem(FIELD_STORAGE_PREFIX + this.objectType, JSON.stringify(this.selectedOptional));
-        } catch(e){ /* storage unavailable */ }
-    }
-    restoreFieldSelection(){
-        try {
-            var saved = JSON.parse(window.localStorage.getItem(FIELD_STORAGE_PREFIX + this.objectType));
-            if(Array.isArray(saved)){
-                var available = this.optionalFields.map(o=>o.name);
-                this.selectedOptional = saved.filter(n=>available.includes(n));
-                this.optionalFields = this.optionalFields.map(o=>Object.assign({}, o, {selected:this.selectedOptional.includes(o.name)}));
-            }
-        } catch(e){ /* nothing saved or storage unavailable */ }
     }
 
     // ---- paging ----

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -1,0 +1,236 @@
+import { LightningElement, api, track } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import getGridData from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData';
+import getGridFieldOptions from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions';
+import getCount from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getCount';
+import mergeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecords';
+import removeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecords';
+import mergeAccountsBulk from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccountsBulk';
+
+// the grid shows a page of candidates grouped by kept record (keep / duplicate(s) / simulated result),
+// for a configurable field set. The first columns + Id/Created/LastModified always appear; extra fields
+// are toggled in the side panel. Paging is bounded to the top 2000 confidence-ranked candidates, matching
+// the list view.
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_RECORDS = 2000;
+const PAGE_SIZE_OPTIONS = [
+    {label:'10', value:'10'}, {label:'25', value:'25'}, {label:'50', value:'50'},
+    {label:'100', value:'100'}, {label:'200', value:'200'}
+];
+const FIELD_STORAGE_PREFIX = 'mergeControl.grid.fields.';
+
+export default class MergeCandidateGrid extends LightningElement {
+    @api objectType;
+
+    _filter;
+    @api
+    get filter(){ return this._filter; }
+    set filter(value){
+        this._filter = value;
+        this.pageNumber = 1;
+        this.selectedCandidateIds = [];
+        if(this._loaded)
+            this.reload();
+    }
+
+    @track columns = [];
+    @track groups = [];
+    @track optionalFields = [];
+    leadFields = [];
+    trailFields = [];
+    selectedOptional = [];
+    selectedCandidateIds = [];
+    pageSize = DEFAULT_PAGE_SIZE;
+    pageNumber = 1;
+    totalCandidates = 0;
+    showFieldPanel = false;
+    showSpinner = false;
+    pageSizeOptions = PAGE_SIZE_OPTIONS;
+    error;
+    _loaded = false;
+
+    connectedCallback(){
+        this.loadFieldOptions();
+    }
+
+    loadFieldOptions(){
+        if(!this.objectType)
+            return;
+        getGridFieldOptions({objectType:this.objectType})
+            .then(result=>{
+                this.leadFields = result.leadFields || [];
+                this.trailFields = result.trailFields || [];
+                this.optionalFields = (result.optionalFields || []).map(o=>Object.assign({}, o, {selected:false}));
+                this.restoreFieldSelection();
+                this._loaded = true;
+                this.reload();
+            })
+            .catch(error=>this.handleError(error));
+    }
+
+    // the ordered field API names sent to the server: lead (Id + first 10), chosen optionals, trail
+    get fieldNames(){
+        var names = this.leadFields.map(f=>f.name);
+        names = names.concat(this.selectedOptional);
+        names = names.concat(this.trailFields.map(f=>f.name));
+        return names;
+    }
+
+    reload(){
+        if(!this.objectType || !this._filter)
+            return;
+        this.showSpinner = true;
+        Promise.all([
+            getGridData({filter:this._filter, fields:this.fieldNames, pageSize:this.pageSize, pageNumber:this.pageNumber}),
+            getCount({filter:this._filter})
+        ]).then(results=>{
+            var grid = results[0];
+            var count = results[1];
+            this.columns = (grid && grid.columns) ? grid.columns : [];
+            this.groups = this.decorateGroups((grid && grid.groups) ? grid.groups : []);
+            this.totalCandidates = count != null ? Number(count) : 0;
+            this.showSpinner = false;
+        }).catch(error=>{ this.showSpinner = false; this.handleError(error); });
+    }
+
+    decorateGroups(groups){
+        return groups.map(g=>({
+            keepId: g.keepId,
+            keepName: g.keepName,
+            objectType: g.objectType,
+            rows: (g.rows || []).map((r, idx)=>this.decorateRow(g.keepId, r, idx))
+        }));
+    }
+    decorateRow(keepId, r, idx){
+        return {
+            key: keepId + '|' + r.rowType + '|' + (r.recordId || '') + '|' + idx,
+            rowType: r.rowType,
+            rowLabel: this.rowLabel(r.rowType),
+            recordId: r.recordId,
+            candidateId: r.candidateId,
+            selectable: r.selectable,
+            checked: r.candidateId ? this.selectedCandidateIds.includes(r.candidateId) : false,
+            rowClass: this.rowClass(r.rowType),
+            cells: (r.cells || []).map(c=>({ key: r.rowType + '|' + (r.recordId || '') + '|' + c.name, name: c.name, value: c.value }))
+        };
+    }
+    rowLabel(rowType){
+        if(rowType === 'keep') return 'Keep';
+        if(rowType === 'result') return 'Result';
+        return 'Duplicate';
+    }
+    rowClass(rowType){
+        if(rowType === 'keep') return 'slds-hint-parent grid-row_keep';
+        if(rowType === 'result') return 'slds-hint-parent grid-row_result';
+        return 'slds-hint-parent grid-row_duplicate';
+    }
+
+    // ---- selection ----
+    handleRowSelect(event){
+        var candidateId = event.currentTarget.dataset.candidate;
+        var checked = event.target.checked;
+        var set = new Set(this.selectedCandidateIds);
+        if(checked) set.add(candidateId); else set.delete(candidateId);
+        this.selectedCandidateIds = Array.from(set);
+        this.refreshChecked();
+    }
+    refreshChecked(){
+        this.groups = this.groups.map(g=>Object.assign({}, g, {
+            rows: g.rows.map(r=>Object.assign({}, r, {
+                checked: r.candidateId ? this.selectedCandidateIds.includes(r.candidateId) : false
+            }))
+        }));
+    }
+    get hasSelection(){ return this.selectedCandidateIds.length > 0; }
+    get actionsDisabled(){ return !this.hasSelection; }
+
+    // ---- field side panel ----
+    toggleFieldPanel(){ this.showFieldPanel = !this.showFieldPanel; }
+    get hasOptionalFields(){ return this.optionalFields.length > 0; }
+    handleFieldToggle(event){
+        var name = event.currentTarget.dataset.field;
+        var checked = event.target.checked;
+        var set = new Set(this.selectedOptional);
+        if(checked) set.add(name); else set.delete(name);
+        this.selectedOptional = Array.from(set);
+        this.optionalFields = this.optionalFields.map(o=>Object.assign({}, o, {selected:this.selectedOptional.includes(o.name)}));
+        this.persistFieldSelection();
+        this.pageNumber = 1;
+        this.reload();
+    }
+    persistFieldSelection(){
+        try {
+            window.localStorage.setItem(FIELD_STORAGE_PREFIX + this.objectType, JSON.stringify(this.selectedOptional));
+        } catch(e){ /* storage unavailable */ }
+    }
+    restoreFieldSelection(){
+        try {
+            var saved = JSON.parse(window.localStorage.getItem(FIELD_STORAGE_PREFIX + this.objectType));
+            if(Array.isArray(saved)){
+                var available = this.optionalFields.map(o=>o.name);
+                this.selectedOptional = saved.filter(n=>available.includes(n));
+                this.optionalFields = this.optionalFields.map(o=>Object.assign({}, o, {selected:this.selectedOptional.includes(o.name)}));
+            }
+        } catch(e){ /* nothing saved or storage unavailable */ }
+    }
+
+    // ---- paging ----
+    get pageSizeValue(){ return String(this.pageSize); }
+    handlePageSizeChange(event){
+        var v = Number(event.detail.value);
+        if(v < 10) v = 10;
+        if(v > 200) v = 200;
+        this.pageSize = v;
+        this.pageNumber = 1;
+        this.reload();
+    }
+    get totalPages(){
+        var capped = Math.min(this.totalCandidates, MAX_RECORDS);
+        return Math.max(1, Math.ceil(capped / this.pageSize));
+    }
+    get hasPager(){ return this.totalPages > 1; }
+    handlePage(event){
+        this.pageNumber = Number(event.detail);
+        this.reload();
+    }
+    get cappedNotice(){
+        return this.totalCandidates > MAX_RECORDS
+            ? 'Showing the ' + MAX_RECORDS + ' highest-confidence candidates of ' + this.totalCandidates + ' total.'
+            : null;
+    }
+
+    // ---- bulk actions ----
+    get hasGroups(){ return this.groups.length > 0; }
+    get columnSpan(){ return this.columns.length + 1; }
+
+    handleMergeSelected(){ this.runAction(mergeRecords); }
+    handleRemoveSelected(){ this.runAction(removeRecords); }
+    handleMergeAccountsSelected(){ this.runAction(mergeAccountsBulk); }
+    runAction(apexFn){
+        if(!this.hasSelection)
+            return;
+        this.showSpinner = true;
+        apexFn({recordIds:this.selectedCandidateIds})
+            .then(response=>{
+                this.selectedCandidateIds = [];
+                this.toast('Success', response, 'success');
+                this.dispatchEvent(new CustomEvent('refresh'));
+                this.reload();
+            })
+            .catch(error=>{ this.showSpinner = false; this.handleError(error); });
+    }
+
+    // ---- notifications ----
+    toast(title, message, variant){
+        this.dispatchEvent(new ShowToastEvent({ title:title, message:message, variant:variant }));
+    }
+    handleError(error){
+        this.error = error;
+        var message = 'Unknown error';
+        if(error && error.body){
+            if(Array.isArray(error.body)) message = error.body.map(e=>e.message).join(', ');
+            else if(typeof error.body.message === 'string') message = error.body.message;
+        }
+        this.toast('An error has occurred', message, 'error');
+    }
+}

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -245,7 +245,6 @@ export default class MergeCandidateGrid extends LightningElement {
 
     // ---- bulk actions ----
     get hasGroups(){ return this.groups.length > 0; }
-    get columnSpan(){ return this.columns.length + 1; }
 
     handleMergeSelected(){ this.runAction(mergeRecords); }
     handleRemoveSelected(){ this.runAction(removeRecords); }

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js-meta.xml
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/MergeGridConfig__c/MergeGridConfig__c.object-meta.xml
+++ b/force-app/main/default/objects/MergeGridConfig__c/MergeGridConfig__c.object-meta.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Stores the merge-candidate grid field selection per object type, shared across all users.</description>
+    <enableActivities>false</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>false</enableHistory>
+    <enableReports>false</enableReports>
+    <enableSearch>false</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <label>Merge Grid Config</label>
+    <nameField>
+        <displayFormat>MGC-{0000}</displayFormat>
+        <label>Merge Grid Config Name</label>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Merge Grid Configs</pluralLabel>
+    <sharingModel>ReadWrite</sharingModel>
+</CustomObject>

--- a/force-app/main/default/objects/MergeGridConfig__c/fields/Fields__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeGridConfig__c/fields/Fields__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Fields__c</fullName>
+    <description>JSON array of the selected field API names shown in the grid for this object.</description>
+    <label>Fields</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/MergeGridConfig__c/fields/ObjectType__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeGridConfig__c/fields/ObjectType__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ObjectType__c</fullName>
+    <description>The SObject API name this grid configuration applies to.</description>
+    <externalId>true</externalId>
+    <label>Object Type</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>true</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
@@ -221,6 +221,11 @@
         <field>MergeFieldHistory__c.MergedRecordId__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>MergeGridConfig__c.Fields__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Merge Control Administrator</label>
     <objectPermissions>
@@ -239,6 +244,15 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>true</modifyAllRecords>
         <object>MergeFieldHistory__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>MergeGridConfig__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <tabSettings>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.4.6",
-      "versionNumber": "2.4.6.NEXT"
+      "versionName": "ver 2.5.0",
+      "versionNumber": "2.5.0.NEXT"
     }
   ],
   "namespace": "",


### PR DESCRIPTION
Closes #83 and #84.

## #83 — Configurable filtering of the merge-candidate list
- `MRG_Duplicate_SVC.candidateFilter` (object, rule, confidence range, auto-merge, status, showIgnored) + `getWhereClause(filter)`; `getCount`/`getKeepGroups` take the filter (existing string overloads kept for backward compat).
- `dupeList` adds Confidence min/max, Auto-Merge (Any/Yes/No), Status (New/Processed/Accounts Merged) and Clear filters. Last-used filters persist in `localStorage`.
- `getStatusOptions` enumerates Status values (it's a Text field, not a picklist; deriving via GROUP BY would re-trip the 50k row limit).

## #84 — Grid display
- `getGridData(filter, fields, pageSize, pageNumber)`: a page of candidates grouped by kept record, each group showing keep / duplicate(s) / **simulated merge result**, for the requested fields. Reuses the bulk `MRG_Merge_SVC.getMergeHistoryResult` so a page is one call.
- `getGridFieldOptions(objectType)`: selectable fields **minus** any hidden via preview settings (`PreviewFields__mdt.Disable__c`); Id first, Created/Last Modified last, first 10 lead, rest optional.
- New `mergeCandidateGrid` LWC: configurable columns via a collapsible side panel, multi-select rows → bulk **Merge / Merge Accounts / Remove**, page size 10–200 (default 50) + paging. `dupeList` gets a **List ⇄ Grid** toggle (persisted).
- Bulk actions: `mergeRecords` / `removeRecords` / `mergeAccountsBulk`.

## Tests
- Apex: `MRG_DuplicateMerge_TEST` 16/16 (status options, grid shape, page-size clamping, filter dimensions, bulk actions).
- Jest: full suite 52/52 (grid render/select/merge/field-panel, view toggle).
- Deployed clean to gsgDEV (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)