### PR TITLE
feat: grid select-all, preview, two-level paging (#84)

### DIFF
--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -135,39 +135,24 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         return (List<String>) JSON.deserialize(cfgs[0].Fields__c, List<String>.class);
     }
 	/*******************************************************************************************************
-	* @description grid data (#84): a page of candidates grouped by kept record, each group showing the
-	* kept record, its duplicate(s) and the simulated merge result, for the requested display fields.
-	* The simulated result reuses the bulk preview engine (MRG_Merge_SVC.getMergeHistoryResult) so up to
-	* a page of candidates is computed in a single call.
-	* @param filter the candidate filter
+	* @description grid rows (#84) for a set of candidates (the duplicates of the groups currently in
+	* view): each kept record's group shows the kept record, its duplicate(s) and the simulated merge
+	* result, for the requested display fields. The simulated result reuses the bulk preview engine
+	* (MRG_Merge_SVC.getMergeHistoryResult) so a page of visible groups is computed in a single call.
+	* Group/within-group paging is handled client-side over getKeepGroups, so only the visible groups'
+	* candidates are passed here.
+	* @param objectType the SObject type
 	* @param fields the ordered display field API names (Id/CreatedDate/LastModifiedDate handled as well)
-	* @param pageSize candidates per page (clamped 10..200, default 50)
-	* @param pageNumber 1-based page number (bounded to the top 2000 confidence-ranked candidates)
+	* @param candidateIds the merge candidate ids whose groups are currently in view
 	* @return gridResponse columns + grouped rows
 	*/
     @AuraEnabled
-    public static gridResponse getGridData(MRG_Duplicate_SVC.candidateFilter filter, List<String> fields, Integer pageSize, Integer pageNumber){
-        MRG_Duplicate_SVC.candidateFilter f = filter == null ? new MRG_Duplicate_SVC.candidateFilter() : filter;
-        // locals below are the bind targets referenced by getWhereClause(filter)
-        String objectType = f.objectType;
-        String ruleName = f.ruleName;
-        Decimal confidenceMin = f.confidenceMin;
-        Decimal confidenceMax = f.confidenceMax;
-        Boolean autoMerge = f.autoMerge;
-        List<String> statuses = f.safeStatuses();
-        // clamp page size + offset (OFFSET maxes at 2000, matching the list's top-2000 window)
-        pageSize = pageSize == null ? 50 : pageSize;
-        if(pageSize < 10) pageSize = 10;
-        if(pageSize > 200) pageSize = 200;
-        if(pageNumber == null || pageNumber < 1) pageNumber = 1;
-        Integer offsetAmt = (pageNumber - 1) * pageSize;
-        if(offsetAmt < 0) offsetAmt = 0;
-        if(offsetAmt > 2000) offsetAmt = 2000;
-
+    public static gridResponse getGridRows(String objectType, List<String> fields, List<Id> candidateIds){
         gridResponse resp = new gridResponse();
         resp.columns = new List<gridFieldOption>();
         resp.groups = new List<gridGroup>();
-        if(String.isBlank(objectType) || Schema.getGlobalDescribe().get(objectType) == null)
+        if(String.isBlank(objectType) || candidateIds == null || candidateIds.isEmpty()
+            || Schema.getGlobalDescribe().get(objectType) == null)
             return resp;
         Map<String, Schema.SObjectField> fmap = Schema.getGlobalDescribe().get(objectType).getDescribe().fields.getMap();
 
@@ -189,20 +174,14 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         for(String fld:displayFields)
             resp.columns.add(fieldOption(fmap, fld));
 
-        // page of candidates (highest confidence first)
-        String pairQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL();
-        pairQuery += MRG_Duplicate_SVC.getWhereClause(f);
-        pairQuery += ' ORDER BY ConfidenceScore__c DESC NULLS LAST, KeepRecordId__c, CreatedDate DESC, Id ASC';
-        pairQuery += ' LIMIT ' + pageSize;
-        if(offsetAmt > 0)
-            pairQuery += ' OFFSET :offsetAmt';
-        List<MergeCandidate__c> pageCandidates = (List<MergeCandidate__c>) Database.query(pairQuery);
-        if(pageCandidates.isEmpty())
+        String soqlQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL() + ' WHERE Id IN :candidateIds';
+        List<MergeCandidate__c> candidates = (List<MergeCandidate__c>) Database.query(soqlQuery);
+        if(candidates.isEmpty())
             return resp;
 
         // bulk fetch the display values for the kept + duplicate records
         Set<Id> recordIds = new Set<Id>();
-        for(MergeCandidate__c c:pageCandidates){
+        for(MergeCandidate__c c:candidates){
             if(String.isNotBlank(c.KeepRecordId__c)) recordIds.add(c.KeepRecordId__c);
             if(String.isNotBlank(c.MergeRecordId__c)) recordIds.add(c.MergeRecordId__c);
             if(String.isNotBlank(c.Merge2RecordId__c)) recordIds.add(c.Merge2RecordId__c);
@@ -210,8 +189,8 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         Map<Id, SObject> displayMap = new Map<Id, SObject>(
             Database.query('SELECT ' + String.join(displayFields, ',') + ' FROM ' + objectType + ' WHERE Id IN :recordIds'));
 
-        // simulate the merges once for the whole page; map the result records by kept id
-        MRG_Merge_SVC.mergeHistoryResult mr = MRG_Merge_SVC.getMergeHistoryResult(pageCandidates, objectType);
+        // simulate the merges once for these candidates; map the result records by kept id
+        MRG_Merge_SVC.mergeHistoryResult mr = MRG_Merge_SVC.getMergeHistoryResult(candidates, objectType);
         Map<Id, Map<String,Object>> resultByKeepId = new Map<Id, Map<String,Object>>();
         if(mr != null && mr.updateRecords != null){
             for(SObject u:mr.updateRecords){
@@ -220,10 +199,10 @@ public with sharing class MRG_DuplicateMerge_CTRL {
             }
         }
 
-        // group by kept record, preserving the confidence order
+        // group by kept record (client controls group ordering/paging)
         Map<String, gridGroup> byKeep = new Map<String, gridGroup>();
         List<String> keepOrder = new List<String>();
-        for(MergeCandidate__c c:pageCandidates){
+        for(MergeCandidate__c c:candidates){
             String keepId = c.KeepRecordId__c;
             if(!byKeep.containsKey(keepId)){
                 gridGroup g = new gridGroup();
@@ -248,6 +227,18 @@ public with sharing class MRG_DuplicateMerge_CTRL {
             resp.groups.add(g);
         }
         return resp;
+    }
+	/*******************************************************************************************************
+	* @description runs a grid action (merge / mergeAccounts / remove) over EVERY candidate matching the
+	* filter, in the background (#84 "select all maximum"). Returns the AsyncApexJob id.
+	* @param filter the candidate filter
+	* @param action 'merge' | 'mergeAccounts' | 'remove'
+	* @return Id the batch AsyncApexJob id
+	*/
+    @AuraEnabled
+    public static Id runActionOverFilter(MRG_Duplicate_SVC.candidateFilter filter, String action){
+        Integer scopeSize = action == 'remove' ? 200 : 20;
+        return Database.executeBatch(new MRG_GridAction_BATCH(filter, action), scopeSize);
     }
 
 	/*******************************************************************************************************

--- a/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
@@ -226,12 +226,14 @@ private class MRG_DuplicateMerge_TEST {
 		system.assertEquals(1, [SELECT COUNT() FROM MergeGridConfig__c WHERE ObjectType__c='Contact'], 'one config record per object type');
 	}
 
-	static testMethod void testGridData(){
+	static testMethod void testGridRows(){
 		MRG_Merge_TEST.createMergeFields();
-		MRG_Duplicate_SVC.candidateFilter f = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		List<Id> ids = new List<Id>();
+		for(MergeCandidate__c c:[SELECT Id FROM MergeCandidate__c])
+			ids.add(c.Id);
 		test.startTest();
-		MRG_DuplicateMerge_CTRL.gridResponse resp = MRG_DuplicateMerge_CTRL.getGridData(
-			f, new List<String>{'Email','CreatedDate','LastModifiedDate'}, 50, 1);
+		MRG_DuplicateMerge_CTRL.gridResponse resp = MRG_DuplicateMerge_CTRL.getGridRows(
+			'Contact', new List<String>{'Email','CreatedDate','LastModifiedDate'}, ids);
 		test.stopTest();
 		system.assert(!resp.columns.isEmpty(), 'columns should be returned');
 		system.assertEquals('Id', resp.columns[0].name, 'Id should be the first column');
@@ -244,13 +246,28 @@ private class MRG_DuplicateMerge_TEST {
 		system.assert(rowTypes.contains('result'), 'a simulated result row should be present');
 	}
 
-	static testMethod void testGridDataPageSizeClamped(){
+	static testMethod void testGridRowsEmpty(){
+		MRG_DuplicateMerge_CTRL.gridResponse resp = MRG_DuplicateMerge_CTRL.getGridRows('Contact', new List<String>{'Email'}, new List<Id>());
+		system.assert(resp.groups.isEmpty(), 'no candidate ids should yield no groups');
+	}
+
+	static testMethod void testRunActionOverFilterRemove(){
 		MRG_Duplicate_SVC.candidateFilter f = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
-		// below-min and above-max page sizes must not throw and still return the page
-		MRG_DuplicateMerge_CTRL.gridResponse small = MRG_DuplicateMerge_CTRL.getGridData(f, new List<String>{'Email'}, 1, 1);
-		MRG_DuplicateMerge_CTRL.gridResponse big = MRG_DuplicateMerge_CTRL.getGridData(f, new List<String>{'Email'}, 9999, 1);
-		system.assert(!small.groups.isEmpty(), 'a below-min page size should clamp to 10 and still return data');
-		system.assert(!big.groups.isEmpty(), 'an above-max page size should clamp to 200 and still return data');
+		test.startTest();
+		Id jobId = MRG_DuplicateMerge_CTRL.runActionOverFilter(f, 'remove');
+		test.stopTest();
+		system.assertNotEquals(null, jobId, 'a batch job id should be returned');
+		for(MergeCandidate__c c:[SELECT NotADuplicate__c FROM MergeCandidate__c WHERE Object__c='Contact' AND Rule__c='test'])
+			system.assertEquals(true, c.NotADuplicate__c, 'remove-over-filter should mark matching candidates not a duplicate');
+	}
+
+	static testMethod void testRunActionOverFilterMerge(){
+		MRG_Merge_TEST.createMergeFields();
+		MRG_Duplicate_SVC.candidateFilter f = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
+		test.startTest();
+		Id jobId = MRG_DuplicateMerge_CTRL.runActionOverFilter(f, 'merge');
+		test.stopTest();
+		system.assertNotEquals(null, jobId, 'a batch job id should be returned for a merge');
 	}
 
 	static testMethod void testCountFilters(){

--- a/force-app/main/default/classes/MRG_GridAction_BATCH.cls
+++ b/force-app/main/default/classes/MRG_GridAction_BATCH.cls
@@ -1,0 +1,82 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description batch that runs a grid action (merge / mergeAccounts / remove) over every merge
+* candidate matching a filter — backs the grid's "select all (maximum)" actions (#84).
+*/
+public with sharing class MRG_GridAction_BATCH implements Database.Batchable<sObject>, Database.Stateful {
+    @testvisible private String action;
+    // bind targets referenced by MRG_Duplicate_SVC.getWhereClause(filter)
+    @testvisible private String objectType;
+    @testvisible private String ruleName;
+    @testvisible private Decimal confidenceMin;
+    @testvisible private Decimal confidenceMax;
+    @testvisible private Boolean autoMerge;
+    @testvisible private List<String> statuses;
+    private MRG_Duplicate_SVC.candidateFilter filter;
+    // original trigger-disabled state to restore after a merge run
+    private Boolean accountTriggerDisabled;
+    private Boolean contactTriggerDisabled;
+
+    public MRG_GridAction_BATCH(MRG_Duplicate_SVC.candidateFilter filter, String action){
+        this.filter = filter == null ? new MRG_Duplicate_SVC.candidateFilter() : filter;
+        this.action = action;
+        this.objectType = this.filter.objectType;
+        this.ruleName = this.filter.ruleName;
+        this.confidenceMin = this.filter.confidenceMin;
+        this.confidenceMax = this.filter.confidenceMax;
+        this.autoMerge = this.filter.autoMerge;
+        this.statuses = this.filter.safeStatuses();
+    }
+
+    private Boolean isMergeAction(){
+        return action == 'merge' || action == 'mergeAccounts';
+    }
+
+    public Database.QueryLocator start(Database.BatchableContext bc){
+        if(isMergeAction()){
+            MergeControlSettings__c settings = MRG_Merge_SVC.getSettings();
+            if(settings != null){
+                if(accountTriggerDisabled == null) accountTriggerDisabled = settings.DisableAccountTrigger__c;
+                if(contactTriggerDisabled == null) contactTriggerDisabled = settings.DisableContactTrigger__c;
+                settings.DisableAccountTrigger__c = true;
+                settings.DisableContactTrigger__c = true;
+                upsert settings;
+            }
+        }
+        String soqlQuery = MRG_Duplicate_SVC.getMergeCandidateFieldSOQL() + MRG_Duplicate_SVC.getWhereClause(filter);
+        return Database.getQueryLocator(soqlQuery);
+    }
+
+    public void execute(Database.BatchableContext bc, List<sObject> scope){
+        List<MergeCandidate__c> candidates = (List<MergeCandidate__c>) scope;
+        if(action == 'remove'){
+            for(MergeCandidate__c c:candidates)
+                c.NotADuplicate__c = true;
+            update candidates;
+        } else if(action == 'mergeAccounts'){
+            for(MergeCandidate__c c:candidates)
+                MRG_AccountMerge_SVC.mergeAccounts(c);
+        } else {
+            Map<String, List<MergeCandidate__c>> byObject = new Map<String, List<MergeCandidate__c>>();
+            for(MergeCandidate__c c:candidates){
+                if(!byObject.containsKey(c.Object__c))
+                    byObject.put(c.Object__c, new List<MergeCandidate__c>());
+                byObject.get(c.Object__c).add(c);
+            }
+            for(String objType:byObject.keySet())
+                MRG_Merge_SVC.processMergesFromBatch(byObject.get(objType), objType, false);
+        }
+    }
+
+    public void finish(Database.BatchableContext bc){
+        if(isMergeAction()){
+            MergeControlSettings__c settings = MRG_Merge_SVC.getSettings();
+            if(settings != null){
+                settings.DisableAccountTrigger__c = accountTriggerDisabled == null ? false : accountTriggerDisabled;
+                settings.DisableContactTrigger__c = contactTriggerDisabled == null ? false : contactTriggerDisabled;
+                upsert settings;
+            }
+        }
+    }
+}

--- a/force-app/main/default/classes/MRG_GridAction_BATCH.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_GridAction_BATCH.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
+++ b/force-app/main/default/lwc/dupeList/__tests__/dupeList.test.js
@@ -52,13 +52,18 @@ jest.mock(
     { virtual: true }
 );
 jest.mock(
-    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData',
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridRows',
     () => ({ default: jest.fn(() => Promise.resolve({ columns: [], groups: [] })) }),
     { virtual: true }
 );
 jest.mock(
     '@salesforce/apex/MRG_DuplicateMerge_CTRL.saveGridFieldConfig',
     () => ({ default: jest.fn(() => Promise.resolve()) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.runActionOverFilter',
+    () => ({ default: jest.fn(() => Promise.resolve('707000000000000AAA')) }),
     { virtual: true }
 );
 jest.mock(

--- a/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
@@ -90,6 +90,12 @@ function flush() {
 function buttonByLabel(el, label) {
     return Array.from(el.shadowRoot.querySelectorAll('lightning-button')).find(b => b.label === label);
 }
+function nativeButtonByText(el, text) {
+    return Array.from(el.shadowRoot.querySelectorAll('button.slds-button')).find(b => b.textContent.trim() === text);
+}
+function gearButton(el) {
+    return Array.from(el.shadowRoot.querySelectorAll('lightning-button-icon')).find(b => b.iconName === 'utility:settings');
+}
 async function render() {
     const el = createElement('c-merge-candidate-grid', { is: MergeCandidateGrid });
     el.objectType = 'Contact';
@@ -118,22 +124,22 @@ describe('c-merge-candidate-grid', () => {
         expect(preview).toBeTruthy();
     });
 
-    it('select all (page) then Merge calls the bulk action with the page candidate ids', async () => {
+    it('select page then Merge calls the bulk action with the page candidate ids', async () => {
         const el = await render();
-        expect(buttonByLabel(el, 'Merge').disabled).toBe(true);
-        buttonByLabel(el, 'Select all (page)').dispatchEvent(new CustomEvent('click'));
+        expect(nativeButtonByText(el, 'Merge').disabled).toBe(true);
+        nativeButtonByText(el, 'Select page').dispatchEvent(new CustomEvent('click'));
         await flush();
-        expect(buttonByLabel(el, 'Merge').disabled).toBe(false);
-        buttonByLabel(el, 'Merge').dispatchEvent(new CustomEvent('click'));
+        expect(nativeButtonByText(el, 'Merge').disabled).toBe(false);
+        nativeButtonByText(el, 'Merge').dispatchEvent(new CustomEvent('click'));
         await flush();
         expect(mockMergeRecords).toHaveBeenCalledWith({ recordIds: ['mc1'] });
     });
 
-    it('select all (maximum) then Merge runs the background batch over the filter', async () => {
+    it('select all pages then Merge runs the background batch over the filter', async () => {
         const el = await render();
-        buttonByLabel(el, 'Select all (maximum)').dispatchEvent(new CustomEvent('click'));
+        nativeButtonByText(el, 'Select all pages').dispatchEvent(new CustomEvent('click'));
         await flush();
-        buttonByLabel(el, 'Merge').dispatchEvent(new CustomEvent('click'));
+        nativeButtonByText(el, 'Merge').dispatchEvent(new CustomEvent('click'));
         await flush();
         expect(mockMergeRecords).not.toHaveBeenCalled();
         expect(mockRunOverFilter).toHaveBeenCalled();
@@ -150,9 +156,20 @@ describe('c-merge-candidate-grid', () => {
         expect(el.shadowRoot.querySelector('c-merge-preview')).toBeTruthy();
     });
 
+    it('header Preview opens the modal for the current selection', async () => {
+        const el = await render();
+        expect(nativeButtonByText(el, 'Preview').disabled).toBe(true);
+        nativeButtonByText(el, 'Select page').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(nativeButtonByText(el, 'Preview').disabled).toBe(false);
+        nativeButtonByText(el, 'Preview').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(el.shadowRoot.querySelector('c-merge-preview')).toBeTruthy();
+    });
+
     it('batches field toggles, saves on Save, and closes the panel', async () => {
         const el = await render();
-        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
+        gearButton(el).dispatchEvent(new CustomEvent('click'));
         await flush();
         const phone = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input')).find(i => i.dataset.field === 'Phone');
         phone.checked = true;
@@ -167,7 +184,7 @@ describe('c-merge-candidate-grid', () => {
 
     it('filters the field list by label or api name', async () => {
         const el = await render();
-        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
+        gearButton(el).dispatchEvent(new CustomEvent('click'));
         await flush();
         const search = Array.from(el.shadowRoot.querySelectorAll('lightning-input')).find(i => i.type === 'search');
         search.dispatchEvent(new CustomEvent('change', { detail: { value: 'phone' } }));

--- a/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
@@ -1,6 +1,12 @@
 import { createElement } from 'lwc';
 import MergeCandidateGrid from 'c/mergeCandidateGrid';
 
+const KEEP_GROUPS = [
+    {
+        keepId: '003A', keepName: 'Acme', objectType: 'Contact',
+        pairs: [{ id: 'mc1', mergeId: '003B', mergeName: 'Acme 2', confidenceScore: 90 }]
+    }
+];
 const FIELD_OPTIONS = {
     leadFields: [{ name: 'Id', label: 'Record ID', type: 'id' }],
     trailFields: [
@@ -12,34 +18,36 @@ const FIELD_OPTIONS = {
         { name: 'Phone', label: 'Phone', type: 'phone', displayLabel: 'Phone (Phone)', selected: false }
     ]
 };
-const GRID_DATA = {
+const GRID_ROWS = {
     columns: [
         { name: 'Id', label: 'Record ID', type: 'id' },
         { name: 'Email', label: 'Email', type: 'email' }
     ],
     groups: [
         {
-            keepId: '003A', keepName: 'Acme', objectType: 'Contact',
+            keepId: '003A',
             rows: [
-                { rowType: 'keep', recordId: '003A', candidateId: null, selectable: false,
-                  cells: [{ name: 'Id', value: '003A' }, { name: 'Email', value: 'a@x.com' }] },
-                { rowType: 'duplicate', recordId: '003B', candidateId: 'mc1', selectable: true,
-                  cells: [{ name: 'Id', value: '003B' }, { name: 'Email', value: 'b@x.com' }] },
-                { rowType: 'result', recordId: '003A', candidateId: null, selectable: false,
-                  cells: [{ name: 'Id', value: '003A' }, { name: 'Email', value: 'a@x.com' }] }
+                { rowType: 'keep', recordId: '003A', candidateId: null, cells: [{ name: 'Id', value: '003A' }, { name: 'Email', value: 'a@x.com' }] },
+                { rowType: 'duplicate', recordId: '003B', candidateId: 'mc1', cells: [{ name: 'Id', value: '003B' }, { name: 'Email', value: 'b@x.com' }] },
+                { rowType: 'result', recordId: '003A', candidateId: null, cells: [{ name: 'Id', value: '003A' }, { name: 'Email', value: 'a@x.com' }] }
             ]
         }
     ]
 };
 
 jest.mock(
-    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions',
-    () => ({ default: jest.fn(() => Promise.resolve(FIELD_OPTIONS)) }),
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getKeepGroups',
+    () => ({ default: jest.fn(() => Promise.resolve(KEEP_GROUPS)) }),
     { virtual: true }
 );
 jest.mock(
-    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData',
-    () => ({ default: jest.fn(() => Promise.resolve(GRID_DATA)) }),
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridRows',
+    () => ({ default: jest.fn(() => Promise.resolve(GRID_ROWS)) }),
+    { virtual: true }
+);
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions',
+    () => ({ default: jest.fn(() => Promise.resolve(FIELD_OPTIONS)) }),
     { virtual: true }
 );
 jest.mock(
@@ -69,6 +77,12 @@ jest.mock(
     () => ({ default: jest.fn(() => Promise.resolve('merged')) }),
     { virtual: true }
 );
+const mockRunOverFilter = jest.fn(() => Promise.resolve('707000000000000AAA'));
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.runActionOverFilter',
+    () => ({ default: (...args) => mockRunOverFilter(...args) }),
+    { virtual: true }
+);
 
 function flush() {
     return new Promise(resolve => setTimeout(resolve, 0));
@@ -82,6 +96,7 @@ async function render() {
     el.filter = { objectType: 'Contact', ruleName: 'test', statuses: ['New'] };
     document.body.appendChild(el);
     await flush();
+    await flush();
     return el;
 }
 
@@ -93,94 +108,71 @@ describe('c-merge-candidate-grid', () => {
         jest.clearAllMocks();
     });
 
-    it('renders a column per field and a row per keep/duplicate/result', async () => {
+    it('renders a group with keep/duplicate/result rows and a column per field', async () => {
         const el = await render();
         const headers = el.shadowRoot.querySelectorAll('thead th');
-        // one "Row" header + one per column
-        expect(headers.length).toBe(GRID_DATA.columns.length + 1);
-        // a checkbox is rendered only for the selectable duplicate row
-        const checkboxes = Array.from(el.shadowRoot.querySelectorAll('lightning-input'))
-            .filter(i => i.type === 'checkbox');
-        expect(checkboxes.length).toBe(1);
+        expect(headers.length).toBe(GRID_ROWS.columns.length + 1); // Row + columns, one group
+        const checkboxes = Array.from(el.shadowRoot.querySelectorAll('lightning-input')).filter(i => i.type === 'checkbox');
+        expect(checkboxes.length).toBe(1); // one selectable duplicate row
+        const preview = Array.from(el.shadowRoot.querySelectorAll('lightning-button-icon')).find(b => b.iconName === 'utility:preview');
+        expect(preview).toBeTruthy();
     });
 
-    it('enables actions on selection and merges the selected candidate', async () => {
+    it('select all (page) then Merge calls the bulk action with the page candidate ids', async () => {
         const el = await render();
         expect(buttonByLabel(el, 'Merge').disabled).toBe(true);
-
-        const checkbox = Array.from(el.shadowRoot.querySelectorAll('lightning-input'))
-            .find(i => i.dataset.candidate === 'mc1');
-        checkbox.checked = true;
-        checkbox.dispatchEvent(new CustomEvent('change'));
+        buttonByLabel(el, 'Select all (page)').dispatchEvent(new CustomEvent('click'));
         await flush();
-
         expect(buttonByLabel(el, 'Merge').disabled).toBe(false);
         buttonByLabel(el, 'Merge').dispatchEvent(new CustomEvent('click'));
         await flush();
         expect(mockMergeRecords).toHaveBeenCalledWith({ recordIds: ['mc1'] });
     });
 
-    it('reveals selectable field checkboxes when the field panel is toggled', async () => {
+    it('select all (maximum) then Merge runs the background batch over the filter', async () => {
         const el = await render();
-        expect(el.shadowRoot.querySelector('.grid-field-panel')).toBeNull();
-        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
+        buttonByLabel(el, 'Select all (maximum)').dispatchEvent(new CustomEvent('click'));
         await flush();
-        const panel = el.shadowRoot.querySelector('.grid-field-panel');
-        expect(panel).toBeTruthy();
-        const optional = Array.from(panel.querySelectorAll('lightning-input'))
-            .find(i => i.dataset.field === 'Phone');
-        expect(optional).toBeTruthy();
+        buttonByLabel(el, 'Merge').dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(mockMergeRecords).not.toHaveBeenCalled();
+        expect(mockRunOverFilter).toHaveBeenCalled();
+        const args = mockRunOverFilter.mock.calls[0][0];
+        expect(args.action).toBe('merge');
+        expect(args.filter.objectType).toBe('Contact');
     });
 
-    it('batches toggles, saves on Save, and closes the panel', async () => {
+    it('opens the preview modal from a duplicate row', async () => {
+        const el = await render();
+        const preview = Array.from(el.shadowRoot.querySelectorAll('lightning-button-icon')).find(b => b.iconName === 'utility:preview');
+        preview.dispatchEvent(new CustomEvent('click'));
+        await flush();
+        expect(el.shadowRoot.querySelector('c-merge-preview')).toBeTruthy();
+    });
+
+    it('batches field toggles, saves on Save, and closes the panel', async () => {
         const el = await render();
         buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
         await flush();
-        const phone = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input'))
-            .find(i => i.dataset.field === 'Phone');
+        const phone = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input')).find(i => i.dataset.field === 'Phone');
         phone.checked = true;
         phone.dispatchEvent(new CustomEvent('change'));
         await flush();
-        expect(mockSaveConfig).not.toHaveBeenCalled(); // toggles are batched, not saved yet
-
+        expect(mockSaveConfig).not.toHaveBeenCalled();
         buttonByLabel(el, 'Save').dispatchEvent(new CustomEvent('click'));
         await flush();
-        // Email (default-selected) + Phone (just added)
         expect(mockSaveConfig).toHaveBeenCalledWith({ objectType: 'Contact', fields: ['Email', 'Phone'] });
-        expect(el.shadowRoot.querySelector('.grid-field-panel')).toBeNull(); // save closes the panel
-    });
-
-    it('reorders selected fields and persists the new column order', async () => {
-        const el = await render();
-        buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
-        await flush();
-        // select Phone so both Email and Phone are selected
-        const phone = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input'))
-            .find(i => i.dataset.field === 'Phone');
-        phone.checked = true;
-        phone.dispatchEvent(new CustomEvent('change'));
-        await flush();
-        // move Phone above Email
-        const phoneUp = Array.from(el.shadowRoot.querySelectorAll('lightning-button-icon'))
-            .find(b => b.dataset.field === 'Phone' && b.iconName === 'utility:up');
-        expect(phoneUp).toBeTruthy();
-        phoneUp.dispatchEvent(new CustomEvent('click'));
-        await flush();
-        buttonByLabel(el, 'Save').dispatchEvent(new CustomEvent('click'));
-        await flush();
-        expect(mockSaveConfig).toHaveBeenCalledWith({ objectType: 'Contact', fields: ['Phone', 'Email'] });
+        expect(el.shadowRoot.querySelector('.grid-field-panel')).toBeNull();
     });
 
     it('filters the field list by label or api name', async () => {
         const el = await render();
         buttonByLabel(el, 'Configure Fields').dispatchEvent(new CustomEvent('click'));
         await flush();
-        const search = Array.from(el.shadowRoot.querySelectorAll('lightning-input'))
-            .find(i => i.type === 'search');
+        const search = Array.from(el.shadowRoot.querySelectorAll('lightning-input')).find(i => i.type === 'search');
         search.dispatchEvent(new CustomEvent('change', { detail: { value: 'phone' } }));
         await flush();
-        const checks = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input'))
-            .filter(i => i.type === 'checkbox');
+        const checks = Array.from(el.shadowRoot.querySelectorAll('.grid-field-panel lightning-input')).filter(i => i.type === 'checkbox');
         expect(checks.length).toBe(1);
         expect(checks[0].dataset.field).toBe('Phone');
     });

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
@@ -37,3 +37,13 @@
 .grid-field-save {
     font-size: 0.75rem;
 }
+/* one size smaller than the default SLDS button */
+.btn-sm {
+    font-size: 0.75rem;
+    line-height: 1.55;
+    padding: 0 0.5rem;
+    margin-right: 0.25rem;
+}
+.grid-pagesize {
+    width: 6rem;
+}

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -1,34 +1,36 @@
 <template>
     <div class="slds-box slds-box_x-small slds-m-around_x-small">
-        <!-- toolbar: paging size, field config, bulk actions -->
-        <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-end slds-wrap slds-m-bottom_x-small">
-            <div class="slds-grid slds-gutters_x-small slds-grid_vertical-align-end slds-wrap">
-                <div class="slds-col" style="min-width:8rem;">
+        <!-- toolbar: paging size + field config (left), selection + bulk actions (right) -->
+        <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-end slds-wrap slds-m-bottom_x-small grid-toolbar">
+            <div class="slds-grid slds-grid_vertical-align-end slds-wrap">
+                <div class="slds-col grid-pagesize">
                     <lightning-combobox
                         label="Groups / page"
                         value={groupsPerPageValue}
                         options={groupPageOptions}
                         onchange={handleGroupsPerPageChange}></lightning-combobox>
                 </div>
-                <div class="slds-col slds-align-bottom">
-                    <lightning-button label="Configure Fields" icon-name="utility:settings" onclick={toggleFieldPanel}></lightning-button>
+                <div class="slds-col slds-align-bottom slds-m-left_xx-small">
+                    <lightning-button-icon icon-name="utility:settings" variant="border" size="small" alternative-text="Configure Fields" title="Configure Fields" onclick={toggleFieldPanel}></lightning-button-icon>
+                </div>
+                <div class="slds-col slds-align-bottom slds-m-left_large">
+                    <button class="slds-button slds-button_neutral btn-sm" onclick={handleSelectAllPage}>Select page</button>
+                    <button class="slds-button slds-button_neutral btn-sm" onclick={handleSelectAllMax}>Select all pages</button>
                 </div>
             </div>
             <div class="slds-col slds-align-bottom">
-                <lightning-button label="Merge" variant="success" disabled={actionsDisabled} onclick={handleMergeSelected} class="slds-m-right_xx-small"></lightning-button>
-                <lightning-button label="Merge Accounts" disabled={actionsDisabled} onclick={handleMergeAccountsSelected} class="slds-m-right_xx-small"></lightning-button>
-                <lightning-button label="Remove" variant="destructive" disabled={actionsDisabled} onclick={handleRemoveSelected}></lightning-button>
+                <button class="slds-button slds-button_neutral btn-sm" disabled={previewDisabled} onclick={handleHeaderPreview}>Preview</button>
+                <button class="slds-button slds-button_success btn-sm" disabled={actionsDisabled} onclick={handleMergeSelected}>Merge</button>
+                <button class="slds-button slds-button_neutral btn-sm" disabled={actionsDisabled} onclick={handleMergeAccountsSelected}>Merge Accounts</button>
+                <button class="slds-button slds-button_destructive btn-sm" disabled={actionsDisabled} onclick={handleRemoveSelected}>Remove</button>
             </div>
         </div>
-        <!-- selection controls -->
-        <div class="slds-grid slds-gutters_x-small slds-grid_vertical-align-center slds-wrap slds-m-bottom_x-small">
-            <lightning-button label="Select all (page)" onclick={handleSelectAllPage} class="slds-m-right_xx-small"></lightning-button>
-            <lightning-button label="Select all (maximum)" onclick={handleSelectAllMax} class="slds-m-right_xx-small"></lightning-button>
-            <template if:true={selectionLabel}>
-                <span class="slds-text-body_small slds-m-horizontal_x-small">{selectionLabel}</span>
-                <lightning-button label="Clear" variant="base" onclick={handleClearSelection}></lightning-button>
-            </template>
-        </div>
+        <template if:true={selectionLabel}>
+            <div class="slds-grid slds-grid_vertical-align-center slds-m-bottom_x-small">
+                <span class="slds-text-body_small slds-m-right_x-small">{selectionLabel}</span>
+                <button class="slds-button slds-button_neutral btn-sm" onclick={handleClearSelection}>Clear</button>
+            </div>
+        </template>
 
         <template if:true={cappedNotice}>
             <div class="slds-text-color_weak slds-text-body_small slds-m-bottom_x-small">{cappedNotice}</div>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -1,14 +1,14 @@
 <template>
     <div class="slds-box slds-box_x-small slds-m-around_x-small">
-        <!-- toolbar -->
-        <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-end slds-wrap slds-m-bottom_small">
+        <!-- toolbar: paging size, field config, bulk actions -->
+        <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-end slds-wrap slds-m-bottom_x-small">
             <div class="slds-grid slds-gutters_x-small slds-grid_vertical-align-end slds-wrap">
-                <div class="slds-col" style="min-width:7rem;">
+                <div class="slds-col" style="min-width:8rem;">
                     <lightning-combobox
-                        label="Per Page"
-                        value={pageSizeValue}
-                        options={pageSizeOptions}
-                        onchange={handlePageSizeChange}></lightning-combobox>
+                        label="Groups / page"
+                        value={groupsPerPageValue}
+                        options={groupPageOptions}
+                        onchange={handleGroupsPerPageChange}></lightning-combobox>
                 </div>
                 <div class="slds-col slds-align-bottom">
                     <lightning-button label="Configure Fields" icon-name="utility:settings" onclick={toggleFieldPanel}></lightning-button>
@@ -20,6 +20,15 @@
                 <lightning-button label="Remove" variant="destructive" disabled={actionsDisabled} onclick={handleRemoveSelected}></lightning-button>
             </div>
         </div>
+        <!-- selection controls -->
+        <div class="slds-grid slds-gutters_x-small slds-grid_vertical-align-center slds-wrap slds-m-bottom_x-small">
+            <lightning-button label="Select all (page)" onclick={handleSelectAllPage} class="slds-m-right_xx-small"></lightning-button>
+            <lightning-button label="Select all (maximum)" onclick={handleSelectAllMax} class="slds-m-right_xx-small"></lightning-button>
+            <template if:true={selectionLabel}>
+                <span class="slds-text-body_small slds-m-horizontal_x-small">{selectionLabel}</span>
+                <lightning-button label="Clear" variant="base" onclick={handleClearSelection}></lightning-button>
+            </template>
+        </div>
 
         <template if:true={cappedNotice}>
             <div class="slds-text-color_weak slds-text-body_small slds-m-bottom_x-small">{cappedNotice}</div>
@@ -29,42 +38,56 @@
                 <lightning-spinner variant="brand" size="medium" alternative-text="Loading..."></lightning-spinner>
             </div>
         </template>
-        <template if:true={hasPager}>
-            <c-pager total-pages={totalPages} current-page={pageNumber} onpage={handlePage}></c-pager>
+        <template if:true={hasGroupPager}>
+            <c-pager total-pages={groupTotalPages} current-page={currentGroupPage} onpage={handleGroupPage}></c-pager>
         </template>
 
         <div class="slds-grid slds-gutters">
             <div class="slds-col grid-main">
-                <template for:each={groups} for:item="group">
+                <template for:each={pagedGroups} for:item="group">
                     <div key={group.keepId} class="slds-m-bottom_small">
-                        <div class="slds-text-title_caps slds-p-vertical_xx-small slds-p-horizontal_x-small slds-theme_shade">
-                            <strong>Keep:&nbsp;{group.keepName}</strong>
+                        <div class="slds-grid slds-grid_align-spread slds-text-title_caps slds-p-vertical_xx-small slds-p-horizontal_x-small slds-theme_shade">
+                            <span><strong>Keep:&nbsp;{group.keepName}</strong></span>
+                            <span>{group.pairCount} duplicate(s)</span>
                         </div>
                         <!-- each group scrolls horizontally on its own -->
                         <div class="grid-scroll">
                             <table class="slds-table slds-table_bordered slds-table_cell-buffer grid-table">
                                 <thead>
                                     <tr class="slds-line-height_reset">
-                                        <th class="slds-text-title_caps" scope="col" style="width:6rem;"><span title="Row">Row</span></th>
+                                        <th class="slds-text-title_caps" scope="col" style="width:9rem;"><span title="Row">Row</span></th>
                                         <template for:each={columns} for:item="col">
                                             <th key={col.name} class="slds-text-title_caps" scope="col"><span title={col.label}>{col.label}</span></th>
                                         </template>
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <template for:each={group.rows} for:item="row">
+                                    <template for:each={group.displayRows} for:item="row">
                                         <tr key={row.key} class={row.rowClass}>
                                             <td>
-                                                <template if:true={row.selectable}>
-                                                    <lightning-input
-                                                        type="checkbox"
-                                                        variant="label-hidden"
-                                                        label="Select duplicate"
-                                                        checked={row.checked}
-                                                        data-candidate={row.candidateId}
-                                                        onchange={handleRowSelect}></lightning-input>
-                                                </template>
-                                                <span class="slds-text-body_small slds-text-color_weak">{row.rowLabel}</span>
+                                                <div class="slds-grid slds-grid_vertical-align-center">
+                                                    <template if:true={row.selectable}>
+                                                        <lightning-input
+                                                            type="checkbox"
+                                                            variant="label-hidden"
+                                                            label="Select duplicate"
+                                                            checked={row.checked}
+                                                            data-candidate={row.candidateId}
+                                                            onchange={handleRowSelect}
+                                                            class="slds-m-right_xx-small"></lightning-input>
+                                                        <lightning-button-icon
+                                                            icon-name="utility:preview"
+                                                            variant="bare"
+                                                            size="small"
+                                                            alternative-text="Preview"
+                                                            title="Preview"
+                                                            data-record={row.candidateId}
+                                                            data-keep={row.keepId}
+                                                            onclick={handlePreview}
+                                                            class="slds-m-right_xx-small"></lightning-button-icon>
+                                                    </template>
+                                                    <span class="slds-text-body_small slds-text-color_weak">{row.rowLabel}</span>
+                                                </div>
                                             </td>
                                             <template for:each={row.cells} for:item="cell">
                                                 <td key={cell.key}>
@@ -76,6 +99,11 @@
                                 </tbody>
                             </table>
                         </div>
+                        <template if:true={group.showPairPager}>
+                            <div class="slds-border_top slds-p-top_xx-small">
+                                <c-pager total-pages={group.pairTotalPages} current-page={group.pairPage} onpage={handlePairPage} data-keep={group.keepId}></c-pager>
+                            </div>
+                        </template>
                     </div>
                 </template>
                 <template if:false={hasGroups}>
@@ -87,12 +115,7 @@
                 <div class="slds-col slds-size_1-of-4 grid-field-panel slds-box slds-theme_default">
                     <div class="slds-grid slds-grid_align-spread slds-grid_vertical-align-center slds-m-bottom_x-small">
                         <div class="slds-text-title_caps">Show Fields</div>
-                        <lightning-button
-                            label="Save"
-                            variant="brand"
-                            disabled={saveFieldsDisabled}
-                            onclick={handleSaveFields}
-                            class="grid-field-save"></lightning-button>
+                        <lightning-button label="Save" variant="brand" disabled={saveFieldsDisabled} onclick={handleSaveFields} class="grid-field-save"></lightning-button>
                     </div>
                     <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
                         Id, Created Date and Last Modified Date always appear. Check or uncheck fields and use the arrows to order the columns, then Save (shared for this object for all users).
@@ -117,24 +140,8 @@
                             </span>
                             <template if:true={opt.selected}>
                                 <span class="slds-shrink-none">
-                                    <lightning-button-icon
-                                        icon-name="utility:up"
-                                        variant="bare"
-                                        size="small"
-                                        alternative-text="Move up"
-                                        title="Move up"
-                                        disabled={opt.disableMoveUp}
-                                        data-field={opt.name}
-                                        onclick={handleMoveUp}></lightning-button-icon>
-                                    <lightning-button-icon
-                                        icon-name="utility:down"
-                                        variant="bare"
-                                        size="small"
-                                        alternative-text="Move down"
-                                        title="Move down"
-                                        disabled={opt.disableMoveDown}
-                                        data-field={opt.name}
-                                        onclick={handleMoveDown}></lightning-button-icon>
+                                    <lightning-button-icon icon-name="utility:up" variant="bare" size="small" alternative-text="Move up" title="Move up" disabled={opt.disableMoveUp} data-field={opt.name} onclick={handleMoveUp}></lightning-button-icon>
+                                    <lightning-button-icon icon-name="utility:down" variant="bare" size="small" alternative-text="Move down" title="Move down" disabled={opt.disableMoveDown} data-field={opt.name} onclick={handleMoveDown}></lightning-button-icon>
                                 </span>
                             </template>
                         </div>
@@ -143,15 +150,52 @@
                         <div class="slds-text-color_weak slds-text-body_small">No additional fields available.</div>
                     </template>
                     <div class="slds-m-top_x-small slds-border_top slds-p-top_x-small">
-                        <lightning-button
-                            label="Save"
-                            variant="brand"
-                            disabled={saveFieldsDisabled}
-                            onclick={handleSaveFields}
-                            class="grid-field-save"></lightning-button>
+                        <lightning-button label="Save" variant="brand" disabled={saveFieldsDisabled} onclick={handleSaveFields} class="grid-field-save"></lightning-button>
                     </div>
                 </div>
             </template>
         </div>
     </div>
+
+    <!-- preview modal with in-group navigation -->
+    <template if:true={isModalOpen}>
+        <template if:true={selectedRecordId}>
+            <section role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="grid-modal-heading" class="slds-modal slds-fade-in-open">
+                <div class="slds-modal__container">
+                    <header class="slds-modal__header">
+                        <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse" title="Close" onclick={closeModal}>
+                            <lightning-icon icon-name="utility:close" alternative-text="close" variant="inverse" size="small"></lightning-icon>
+                            <span class="slds-assistive-text">Close</span>
+                        </button>
+                        <h2 id="grid-modal-heading" class="slds-text-heading_medium slds-hyphenate">Merge Preview</h2>
+                    </header>
+                    <div class="slds-modal__content slds-p-around_medium">
+                        <lightning-layout>
+                            <lightning-layout-item size="3" padding="around-small">
+                                <div class="slds-text-title_caps slds-p-bottom_x-small">Duplicates</div>
+                                <template for:each={navItems} for:item="nav">
+                                    <div key={nav.id} class="slds-p-bottom_xx-small">
+                                        <lightning-button variant={nav.variant} label={nav.label} onclick={handleNavSelect} data-record={nav.id} class="slds-button_stretch"></lightning-button>
+                                    </div>
+                                </template>
+                                <div class="slds-p-top_small">
+                                    <lightning-button label="Previous" onclick={handlePrev} disabled={hasPrevDisabled} class="slds-m-right_x-small"></lightning-button>
+                                    <lightning-button label="Next" onclick={handleNext} disabled={hasNextDisabled}></lightning-button>
+                                </div>
+                            </lightning-layout-item>
+                            <lightning-layout-item size="9" padding="around-small">
+                                <c-merge-preview record-id={selectedRecordId}></c-merge-preview>
+                            </lightning-layout-item>
+                        </lightning-layout>
+                    </div>
+                    <footer class="slds-modal__footer">
+                        <button class="slds-button slds-button_neutral" onclick={closeModal} title="Cancel">Cancel</button>
+                        <button class="slds-button slds-button_destructive" onclick={handleModalRemove} title="Remove">Remove</button>
+                        <button class="slds-button slds-button_brand" onclick={handleModalMerge} title="Merge">Merge</button>
+                    </footer>
+                </div>
+            </section>
+            <div class="slds-backdrop slds-backdrop_open"></div>
+        </template>
+    </template>
 </template>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -1,22 +1,23 @@
 import { LightningElement, api, track } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
-import getGridData from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridData';
+import getKeepGroups from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getKeepGroups';
+import getGridRows from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridRows';
 import getGridFieldOptions from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getGridFieldOptions';
 import getCount from '@salesforce/apex/MRG_DuplicateMerge_CTRL.getCount';
 import saveGridFieldConfig from '@salesforce/apex/MRG_DuplicateMerge_CTRL.saveGridFieldConfig';
 import mergeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecords';
 import removeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecords';
 import mergeAccountsBulk from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccountsBulk';
+import runActionOverFilter from '@salesforce/apex/MRG_DuplicateMerge_CTRL.runActionOverFilter';
 
-// the grid shows a page of candidates grouped by kept record (keep / duplicate(s) / simulated result),
-// for a configurable field set. Only Id/Created/LastModified always appear; every other field is toggled
-// in the side panel and the selection is saved per object for all users. Paging is bounded to the top
-// 2000 confidence-ranked candidates, matching the list view.
-const DEFAULT_PAGE_SIZE = 50;
-const MAX_RECORDS = 2000;
-const PAGE_SIZE_OPTIONS = [
-    {label:'10', value:'10'}, {label:'25', value:'25'}, {label:'50', value:'50'},
-    {label:'100', value:'100'}, {label:'200', value:'200'}
+// the grid mirrors the list view's two-level paging: it loads the working set of groups (up to CAP)
+// via getKeepGroups, pages groups (outer) and duplicates within a group (inner) client-side, and lazily
+// fetches the field values + simulated merge result for only the groups currently in view (getGridRows).
+const CAP = 2000;
+const PAIRS_PER_PAGE = 5;
+const DEFAULT_GROUPS_PER_PAGE = 10;
+const GROUP_PAGE_OPTIONS = [
+    {label:'5', value:'5'}, {label:'10', value:'10'}, {label:'25', value:'25'}, {label:'50', value:'50'}
 ];
 
 export default class MergeCandidateGrid extends LightningElement {
@@ -27,33 +28,40 @@ export default class MergeCandidateGrid extends LightningElement {
     get filter(){ return this._filter; }
     set filter(value){
         this._filter = value;
-        this.pageNumber = 1;
-        this.selectedCandidateIds = [];
+        this.clearSelection();
         if(this._loaded)
-            this.reload();
+            this.load();
     }
 
+    @track allGroups = [];
     @track columns = [];
-    @track groups = [];
+    @track rowsByKeep = {};
     @track panelFields = [];
     leadFields = [];
     trailFields = [];
     filterText = '';
     fieldsDirty = false;
-    selectedCandidateIds = [];
-    pageSize = DEFAULT_PAGE_SIZE;
-    pageNumber = 1;
+    currentGroupPage = 1;
+    groupsPerPage = DEFAULT_GROUPS_PER_PAGE;
     totalCandidates = 0;
+    selectedCandidateIds = [];
+    selectAllMax = false;
     showFieldPanel = false;
-    showSpinner = false;
-    pageSizeOptions = PAGE_SIZE_OPTIONS;
-    error;
+    loadingGroups = false;
+    rowsLoading = false;
+    // preview modal
+    isModalOpen = false;
+    selectedRecordId;
+    @track navItems = [];
+
+    groupPageOptions = GROUP_PAGE_OPTIONS;
     _loaded = false;
 
     connectedCallback(){
         this.loadFieldOptions();
     }
 
+    // ---- field options + selection persistence ----
     loadFieldOptions(){
         if(!this.objectType)
             return;
@@ -61,102 +69,217 @@ export default class MergeCandidateGrid extends LightningElement {
             .then(result=>{
                 this.leadFields = result.leadFields || [];
                 this.trailFields = result.trailFields || [];
-                // server returns selected fields first (in saved order), then the rest by label
                 this.panelFields = (result.fields || []).map(o=>Object.assign({}, o));
                 this._loaded = true;
-                this.reload();
+                this.load();
             })
             .catch(error=>this.handleError(error));
     }
-
-    // selected field API names, in the panel's current (user-defined) order
     get selectedNames(){
         return this.panelFields.filter(f=>f.selected).map(f=>f.name);
     }
-    // the ordered field API names sent to the server: Id, selected fields (label order), Created/Last Modified
     get fieldNames(){
-        var names = this.leadFields.map(f=>f.name);
-        names = names.concat(this.selectedNames);
-        names = names.concat(this.trailFields.map(f=>f.name));
-        return names;
+        return this.leadFields.map(f=>f.name)
+            .concat(this.selectedNames)
+            .concat(this.trailFields.map(f=>f.name));
     }
 
-    reload(){
+    // ---- load groups (working set) + counts ----
+    load(){
         if(!this.objectType || !this._filter)
             return;
-        this.showSpinner = true;
+        this.loadingGroups = true;
         Promise.all([
-            getGridData({filter:this._filter, fields:this.fieldNames, pageSize:this.pageSize, pageNumber:this.pageNumber}),
+            getKeepGroups({filter:this._filter, limitAmt:CAP, offsetAmt:0}),
             getCount({filter:this._filter})
         ]).then(results=>{
-            var grid = results[0];
-            var count = results[1];
-            this.columns = (grid && grid.columns) ? grid.columns : [];
-            this.groups = this.decorateGroups((grid && grid.groups) ? grid.groups : []);
-            this.totalCandidates = count != null ? Number(count) : 0;
-            this.showSpinner = false;
-        }).catch(error=>{ this.showSpinner = false; this.handleError(error); });
+            this.allGroups = (results[0] || []).map(g=>Object.assign({}, g, {pairPage:1}));
+            this.totalCandidates = results[1] != null ? Number(results[1]) : 0;
+            this.currentGroupPage = 1;
+            this.loadingGroups = false;
+            this.loadVisibleRows();
+        }).catch(error=>{ this.loadingGroups = false; this.handleError(error); });
+    }
+    // the groups on the current outer page
+    get currentGroups(){
+        const start = (this.currentGroupPage - 1) * this.groupsPerPage;
+        return this.allGroups.slice(start, start + this.groupsPerPage);
+    }
+    // fetch field values + simulated result for the groups currently in view only
+    loadVisibleRows(){
+        const ids = [];
+        this.currentGroups.forEach(g=>(g.pairs || []).forEach(p=>ids.push(p.id)));
+        if(!ids.length){
+            this.rowsByKeep = {};
+            this.columns = [];
+            return;
+        }
+        this.rowsLoading = true;
+        getGridRows({objectType:this.objectType, fields:this.fieldNames, candidateIds:ids})
+            .then(resp=>{
+                this.columns = (resp && resp.columns) ? resp.columns : [];
+                this.rowsByKeep = this.indexRows((resp && resp.groups) ? resp.groups : []);
+                this.rowsLoading = false;
+            })
+            .catch(error=>{ this.rowsLoading = false; this.handleError(error); });
+    }
+    indexRows(groups){
+        const map = {};
+        groups.forEach(g=>{
+            const entry = { keepCells: [], resultCells: [], dupByCandidate: {} };
+            (g.rows || []).forEach(r=>{
+                if(r.rowType === 'keep') entry.keepCells = r.cells;
+                else if(r.rowType === 'result') entry.resultCells = r.cells;
+                else if(r.rowType === 'duplicate'){
+                    if(!entry.dupByCandidate[r.candidateId]) entry.dupByCandidate[r.candidateId] = [];
+                    entry.dupByCandidate[r.candidateId].push({ recordId: r.recordId, cells: r.cells });
+                }
+            });
+            map[g.keepId] = entry;
+        });
+        return map;
     }
 
-    decorateGroups(groups){
-        return groups.map(g=>({
-            keepId: g.keepId,
-            keepName: g.keepName,
-            objectType: g.objectType,
-            rows: (g.rows || []).map((r, idx)=>this.decorateRow(g.keepId, r, idx))
-        }));
+    // ---- rendered groups (structure + lazily-loaded rows, sliced to inner page) ----
+    get pagedGroups(){
+        const selected = new Set(this.selectedCandidateIds);
+        return this.currentGroups.map(g=>{
+            const rows = this.rowsByKeep[g.keepId];
+            const pairPage = g.pairPage || 1;
+            const pairs = g.pairs || [];
+            const visiblePairs = pairs.slice((pairPage - 1) * PAIRS_PER_PAGE, pairPage * PAIRS_PER_PAGE);
+            const displayRows = [];
+            if(rows){
+                displayRows.push(this.staticRow(g.keepId, 'keep', 'Keep', 'grid-row_keep', rows.keepCells));
+                visiblePairs.forEach(p=>{
+                    const checked = this.selectAllMax || selected.has(p.id);
+                    (rows.dupByCandidate[p.id] || []).forEach((d, di)=>{
+                        displayRows.push({
+                            key: g.keepId + '-dup-' + p.id + '-' + di,
+                            rowType: 'duplicate', rowLabel: 'Duplicate', rowClass: 'grid-row_duplicate',
+                            selectable: true, candidateId: p.id, keepId: g.keepId, checked: checked, cells: d.cells
+                        });
+                    });
+                });
+                displayRows.push(this.staticRow(g.keepId, 'result', 'Result', 'grid-row_result', rows.resultCells));
+            }
+            return {
+                keepId: g.keepId,
+                keepName: g.keepName,
+                pairCount: pairs.length,
+                pairPage: pairPage,
+                pairTotalPages: Math.max(1, Math.ceil(pairs.length / PAIRS_PER_PAGE)),
+                showPairPager: pairs.length > PAIRS_PER_PAGE,
+                hasRows: !!rows,
+                displayRows: displayRows
+            };
+        });
     }
-    decorateRow(keepId, r, idx){
-        return {
-            key: keepId + '|' + r.rowType + '|' + (r.recordId || '') + '|' + idx,
-            rowType: r.rowType,
-            rowLabel: this.rowLabel(r.rowType),
-            recordId: r.recordId,
-            candidateId: r.candidateId,
-            selectable: r.selectable,
-            checked: r.candidateId ? this.selectedCandidateIds.includes(r.candidateId) : false,
-            rowClass: this.rowClass(r.rowType),
-            cells: (r.cells || []).map(c=>({ key: r.rowType + '|' + (r.recordId || '') + '|' + c.name, name: c.name, value: c.value }))
-        };
+    staticRow(keepId, rowType, rowLabel, rowClass, cells){
+        return { key: keepId + '-' + rowType, rowType: rowType, rowLabel: rowLabel, rowClass: rowClass,
+            selectable: false, candidateId: null, keepId: keepId, checked: false, cells: cells || [] };
     }
-    rowLabel(rowType){
-        if(rowType === 'keep') return 'Keep';
-        if(rowType === 'result') return 'Result';
-        return 'Duplicate';
+    get hasGroups(){ return this.allGroups.length > 0; }
+    get showSpinner(){ return this.loadingGroups || this.rowsLoading; }
+
+    // ---- outer (group) + inner (within-group) paging ----
+    get groupTotalPages(){ return Math.max(1, Math.ceil(this.allGroups.length / this.groupsPerPage)); }
+    get hasGroupPager(){ return this.allGroups.length > this.groupsPerPage; }
+    handleGroupPage(event){
+        this.currentGroupPage = Number(event.detail);
+        this.loadVisibleRows();
     }
-    rowClass(rowType){
-        if(rowType === 'keep') return 'slds-hint-parent grid-row_keep';
-        if(rowType === 'result') return 'slds-hint-parent grid-row_result';
-        return 'slds-hint-parent grid-row_duplicate';
+    handlePairPage(event){
+        const keepId = event.currentTarget.dataset.keep;
+        const page = Number(event.detail);
+        this.allGroups = this.allGroups.map(g=> g.keepId == keepId ? Object.assign({}, g, {pairPage:page}) : g);
+    }
+    get groupsPerPageValue(){ return String(this.groupsPerPage); }
+    handleGroupsPerPageChange(event){
+        this.groupsPerPage = Number(event.detail.value);
+        this.currentGroupPage = 1;
+        this.loadVisibleRows();
+    }
+    get cappedNotice(){
+        return this.totalCandidates > CAP
+            ? 'Showing the ' + CAP + ' highest-confidence candidates of ' + this.totalCandidates + ' total.'
+            : null;
     }
 
     // ---- selection ----
     handleRowSelect(event){
-        var candidateId = event.currentTarget.dataset.candidate;
-        var checked = event.target.checked;
-        var set = new Set(this.selectedCandidateIds);
+        const candidateId = event.currentTarget.dataset.candidate;
+        const checked = event.target.checked;
+        // a manual toggle exits "all maximum" mode and becomes an explicit selection
+        if(this.selectAllMax){
+            this.selectAllMax = false;
+            this.selectedCandidateIds = this.allPageCandidateIds();
+        }
+        const set = new Set(this.selectedCandidateIds);
         if(checked) set.add(candidateId); else set.delete(candidateId);
         this.selectedCandidateIds = Array.from(set);
-        this.refreshChecked();
     }
-    refreshChecked(){
-        this.groups = this.groups.map(g=>Object.assign({}, g, {
-            rows: g.rows.map(r=>Object.assign({}, r, {
-                checked: r.candidateId ? this.selectedCandidateIds.includes(r.candidateId) : false
-            }))
-        }));
+    allPageCandidateIds(){
+        const ids = [];
+        this.currentGroups.forEach(g=>(g.pairs || []).forEach(p=>ids.push(p.id)));
+        return ids;
     }
-    get hasSelection(){ return this.selectedCandidateIds.length > 0; }
+    handleSelectAllPage(){
+        this.selectAllMax = false;
+        this.selectedCandidateIds = this.allPageCandidateIds();
+    }
+    handleSelectAllMax(){
+        this.selectAllMax = true;
+        this.selectedCandidateIds = [];
+    }
+    clearSelection(){
+        this.selectedCandidateIds = [];
+        this.selectAllMax = false;
+    }
+    handleClearSelection(){ this.clearSelection(); }
+    get hasSelection(){ return this.selectAllMax || this.selectedCandidateIds.length > 0; }
     get actionsDisabled(){ return !this.hasSelection; }
+    get selectionLabel(){
+        if(this.selectAllMax)
+            return 'All ' + this.totalCandidates + ' matching selected';
+        if(this.selectedCandidateIds.length)
+            return this.selectedCandidateIds.length + ' selected';
+        return null;
+    }
+
+    // ---- bulk actions ----
+    handleMergeSelected(){ this.runAction('merge', mergeRecords); }
+    handleRemoveSelected(){ this.runAction('remove', removeRecords); }
+    handleMergeAccountsSelected(){ this.runAction('mergeAccounts', mergeAccountsBulk); }
+    runAction(action, idAction){
+        if(!this.hasSelection)
+            return;
+        if(this.selectAllMax){
+            // operate over every matching candidate in the background
+            runActionOverFilter({filter:this._filter, action:action})
+                .then(()=>{
+                    this.toast('Started', 'Processing all ' + this.totalCandidates + ' matching candidates in the background.', 'success');
+                    this.clearSelection();
+                })
+                .catch(error=>this.handleError(error));
+            return;
+        }
+        this.rowsLoading = true;
+        idAction({recordIds:this.selectedCandidateIds})
+            .then(response=>{
+                this.toast('Success', response, 'success');
+                this.clearSelection();
+                this.load();
+            })
+            .catch(error=>{ this.rowsLoading = false; this.handleError(error); });
+    }
 
     // ---- field side panel ----
     toggleFieldPanel(){ this.showFieldPanel = !this.showFieldPanel; }
     get hasOptionalFields(){ return this.panelFields.length > 0; }
-    // the panel keeps its current order while editing (selected fields only float to the top on Save);
-    // filtered by label or api name (contains). Each item carries move-up/down enablement for reordering.
     get visibleFields(){
-        var text = (this.filterText || '').toLowerCase();
-        var selected = this.panelFields.filter(f=>f.selected);
+        const text = (this.filterText || '').toLowerCase();
+        const selected = this.panelFields.filter(f=>f.selected);
         return this.panelFields
             .filter(f=>
                 !text
@@ -167,100 +290,107 @@ export default class MergeCandidateGrid extends LightningElement {
                 disableMoveDown: !(f.selected && selected.indexOf(f) < selected.length - 1)
             }));
     }
-    handleFilterChange(event){
-        this.filterText = event.detail.value;
-    }
-    // toggles only update local state so the user can check/uncheck several fields before saving
+    handleFilterChange(event){ this.filterText = event.detail.value; }
     handleFieldToggle(event){
-        var name = event.currentTarget.dataset.field;
-        var checked = event.target.checked;
+        const name = event.currentTarget.dataset.field;
+        const checked = event.target.checked;
         this.panelFields = this.panelFields.map(f=> f.name === name ? Object.assign({}, f, {selected:checked}) : f);
         this.fieldsDirty = true;
     }
     handleMoveUp(event){ this.moveSelected(event.currentTarget.dataset.field, -1); }
     handleMoveDown(event){ this.moveSelected(event.currentTarget.dataset.field, 1); }
-    // swaps a selected field with its adjacent selected field (reorders the display columns)
     moveSelected(name, dir){
-        var arr = this.panelFields.slice();
-        var i = arr.findIndex(f=>f.name === name);
+        const arr = this.panelFields.slice();
+        const i = arr.findIndex(f=>f.name === name);
         if(i < 0 || !arr[i].selected)
             return;
-        var j = i + dir;
+        let j = i + dir;
         while(j >= 0 && j < arr.length && !arr[j].selected)
             j += dir;
         if(j < 0 || j >= arr.length)
             return;
-        var tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
+        const tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
         this.panelFields = arr;
         this.fieldsDirty = true;
     }
     get saveFieldsDisabled(){ return !this.fieldsDirty; }
-    // persist the (multi-field, ordered) selection for this object across all users, refresh the grid,
-    // float selected fields to the top of the panel and close it
     handleSaveFields(){
         saveGridFieldConfig({objectType:this.objectType, fields:this.selectedNames})
             .then(()=>{
                 this.fieldsDirty = false;
                 this.resortPanel();
                 this.showFieldPanel = false;
-                this.pageNumber = 1;
-                this.reload();
+                this.loadVisibleRows();
                 this.toast('Fields saved', 'Grid fields updated.', 'success');
             })
             .catch(error=>this.handleError(error));
     }
-    // after save: selected fields first (in their chosen order), then unselected by label
     resortPanel(){
-        var selected = this.panelFields.filter(f=>f.selected);
-        var unselected = this.panelFields.filter(f=>!f.selected)
+        const selected = this.panelFields.filter(f=>f.selected);
+        const unselected = this.panelFields.filter(f=>!f.selected)
             .slice()
             .sort((a,b)=>(a.label || '').toLowerCase().localeCompare((b.label || '').toLowerCase()));
         this.panelFields = selected.concat(unselected);
     }
 
-    // ---- paging ----
-    get pageSizeValue(){ return String(this.pageSize); }
-    handlePageSizeChange(event){
-        var v = Number(event.detail.value);
-        if(v < 10) v = 10;
-        if(v > 200) v = 200;
-        this.pageSize = v;
-        this.pageNumber = 1;
-        this.reload();
+    // ---- preview modal with in-group navigation (mirrors the list view) ----
+    handlePreview(event){
+        const candidateId = event.currentTarget.dataset.record;
+        const keepId = event.currentTarget.dataset.keep;
+        const group = (this.allGroups || []).find(g=>g.keepId == keepId);
+        this.navItems = group ? group.pairs.map(p=>this.toNavItem(p, candidateId)) : [];
+        this.selectedRecordId = candidateId;
+        this.isModalOpen = true;
     }
-    get totalPages(){
-        var capped = Math.min(this.totalCandidates, MAX_RECORDS);
-        return Math.max(1, Math.ceil(capped / this.pageSize));
+    toNavItem(pair, selectedId){
+        const conf = (pair.confidenceScore != null && pair.confidenceScore !== undefined) ? ' — ' + pair.confidenceScore : '';
+        return {
+            id: pair.id,
+            label: (pair.mergeName || pair.mergeId) + conf,
+            variant: pair.id === selectedId ? 'brand' : 'neutral'
+        };
     }
-    get hasPager(){ return this.totalPages > 1; }
-    handlePage(event){
-        this.pageNumber = Number(event.detail);
-        this.reload();
+    refreshNavVariants(){
+        this.navItems = this.navItems.map(n=>({ id:n.id, label:n.label, variant: n.id === this.selectedRecordId ? 'brand' : 'neutral' }));
     }
-    get cappedNotice(){
-        return this.totalCandidates > MAX_RECORDS
-            ? 'Showing the ' + MAX_RECORDS + ' highest-confidence candidates of ' + this.totalCandidates + ' total.'
-            : null;
+    get currentNavIndex(){ return this.navItems.findIndex(n=>n.id === this.selectedRecordId); }
+    get hasPrevDisabled(){ return !(this.currentNavIndex > 0); }
+    get hasNextDisabled(){ return !(this.currentNavIndex > -1 && this.currentNavIndex < this.navItems.length - 1); }
+    handleNavSelect(event){
+        this.selectedRecordId = event.currentTarget.dataset.record;
+        this.refreshNavVariants();
     }
-
-    // ---- bulk actions ----
-    get hasGroups(){ return this.groups.length > 0; }
-
-    handleMergeSelected(){ this.runAction(mergeRecords); }
-    handleRemoveSelected(){ this.runAction(removeRecords); }
-    handleMergeAccountsSelected(){ this.runAction(mergeAccountsBulk); }
-    runAction(apexFn){
-        if(!this.hasSelection)
-            return;
-        this.showSpinner = true;
-        apexFn({recordIds:this.selectedCandidateIds})
-            .then(response=>{
-                this.selectedCandidateIds = [];
-                this.toast('Success', response, 'success');
-                this.dispatchEvent(new CustomEvent('refresh'));
-                this.reload();
-            })
-            .catch(error=>{ this.showSpinner = false; this.handleError(error); });
+    handlePrev(){
+        if(this.currentNavIndex > 0){
+            this.selectedRecordId = this.navItems[this.currentNavIndex - 1].id;
+            this.refreshNavVariants();
+        }
+    }
+    handleNext(){
+        if(this.currentNavIndex > -1 && this.currentNavIndex < this.navItems.length - 1){
+            this.selectedRecordId = this.navItems[this.currentNavIndex + 1].id;
+            this.refreshNavVariants();
+        }
+    }
+    closeModal(){
+        this.isModalOpen = false;
+        this.selectedRecordId = null;
+    }
+    handleModalMerge(){
+        const id = this.selectedRecordId;
+        this.isModalOpen = false;
+        this.rowsLoading = true;
+        mergeRecords({recordIds:[id]})
+            .then(response=>{ this.toast('Success', response, 'success'); this.load(); })
+            .catch(error=>{ this.rowsLoading = false; this.handleError(error); });
+    }
+    handleModalRemove(){
+        const id = this.selectedRecordId;
+        this.isModalOpen = false;
+        this.rowsLoading = true;
+        removeRecords({recordIds:[id]})
+            .then(response=>{ this.toast('Success', response, 'success'); this.load(); })
+            .catch(error=>{ this.rowsLoading = false; this.handleError(error); });
     }
 
     // ---- notifications ----
@@ -268,8 +398,7 @@ export default class MergeCandidateGrid extends LightningElement {
         this.dispatchEvent(new ShowToastEvent({ title:title, message:message, variant:variant }));
     }
     handleError(error){
-        this.error = error;
-        var message = 'Unknown error';
+        let message = 'Unknown error';
         if(error && error.body){
             if(Array.isArray(error.body)) message = error.body.map(e=>e.message).join(', ');
             else if(typeof error.body.message === 'string') message = error.body.message;

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -239,12 +239,27 @@ export default class MergeCandidateGrid extends LightningElement {
     handleClearSelection(){ this.clearSelection(); }
     get hasSelection(){ return this.selectAllMax || this.selectedCandidateIds.length > 0; }
     get actionsDisabled(){ return !this.hasSelection; }
+    // preview needs concrete records to step through, so it's unavailable for the "all maximum" mode
+    get previewDisabled(){ return this.selectAllMax || this.selectedCandidateIds.length === 0; }
     get selectionLabel(){
         if(this.selectAllMax)
             return 'All ' + this.totalCandidates + ' matching selected';
         if(this.selectedCandidateIds.length)
             return this.selectedCandidateIds.length + ' selected';
         return null;
+    }
+    // header Preview: open the shared preview modal over the selected candidates (step through them)
+    handleHeaderPreview(){
+        if(this.previewDisabled)
+            return;
+        const byId = {};
+        this.allGroups.forEach(g=>(g.pairs || []).forEach(p=>{ byId[p.id] = p; }));
+        const sel = this.selectedCandidateIds.filter(id=>byId[id]);
+        if(!sel.length)
+            return;
+        this.navItems = sel.map(id=>this.toNavItem(byId[id], sel[0]));
+        this.selectedRecordId = sel[0];
+        this.isModalOpen = true;
     }
 
     // ---- bulk actions ----

--- a/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/mergeControlAdmin.permissionset-meta.xml
@@ -29,6 +29,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>MRG_GridAction_BATCH</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>MRG_DuplicateScan_TEST</apexClass>
         <enabled>true</enabled>
     </classAccesses>


### PR DESCRIPTION
Follow-up to 2.5.0 grid work (#84). **Source-deployed to gsgDEV for testing; no package version built yet.**

## Two-level paging (like the list view)
- Working set loads via `getKeepGroups` (top 2000 by confidence); **outer pager** over keep groups + **inner pager** over duplicates within a group.
- Field values + simulated result are fetched **lazily** for only the groups currently in view (`getGridRows`, replacing the candidate-paged `getGridData`) — bounds the simulation cost.
- "Groups / page" selector (5/10/25/50, default 10).

## Select all
- **Select all (page)** — selects the current group page's candidates (explicit ids, synchronous actions).
- **Select all (maximum)** — selects every filter-matching candidate; Merge / Merge Accounts / Remove then run as a **background batch** (`MRG_GridAction_BATCH` via `runActionOverFilter`), safe at 50k+. Toggling a row checkbox exits max mode.

## Preview
- Preview icon on each duplicate row opens the merge-preview modal with in-group **Previous/Next** navigation (mirrors the list view), plus Merge/Remove from the modal.

## Tests
- Apex: `getGridRows`, `runActionOverFilter` + `MRG_GridAction_BATCH` (merge + remove) — pass in gsgDEV.
- Jest: 55/55 (select-all page/max, preview modal, field config, paging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)