### PR TITLE
feat: grid result-value override + wider preview (2.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ The Merge Control app provides SF Administrators with the following tools relate
 
 ## Installation
 
-Current release: **2.6.0** (unlocked package, `04tKb000000Eh0AIAS`)
+Current release: **2.7.0** (unlocked package, `04tKb000000Eh0yIAC`)
 
 Install via URL:
-- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Eh0AIAS
-- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Eh0AIAS
+- Production / Developer Edition: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Eh0yIAC
+- Sandbox: https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKb000000Eh0yIAC
 
 Or with the Salesforce CLI:
 
 ```
-sf package install --package 04tKb000000Eh0AIAS --target-org <org-alias> --wait 10
+sf package install --package 04tKb000000Eh0yIAC --target-org <org-alias> --wait 10
 ```
 
 After installing, assign the **Merge Control Administrator** permission set to administrators.

--- a/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_CTRL.cls
@@ -189,6 +189,9 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         Map<Id, SObject> displayMap = new Map<Id, SObject>(
             Database.query('SELECT ' + String.join(displayFields, ',') + ' FROM ' + objectType + ' WHERE Id IN :recordIds'));
 
+        // any saved keep-value overrides, keyed by kept record id (overlaid on the keep row below)
+        Map<Id, Map<String,Object>> overridesByKeep = MRG_Merge_SVC.getManualOverridesByKeepId(candidates);
+
         // simulate the merges once for these candidates; map the result records by kept id
         MRG_Merge_SVC.mergeHistoryResult mr = MRG_Merge_SVC.getMergeHistoryResult(candidates, objectType);
         Map<Id, Map<String,Object>> resultByKeepId = new Map<Id, Map<String,Object>>();
@@ -223,7 +226,8 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         }
         for(String keepId:keepOrder){
             gridGroup g = byKeep.get(keepId);
-            g.rows.add(buildResultRow(displayFields, displayMap.get(keepId), resultByKeepId.get(Id.valueOf(keepId))));
+            Id kid = Id.valueOf(keepId);
+            g.rows.add(buildResultRow(displayFields, displayMap.get(keepId), resultByKeepId.get(kid), overridesByKeep.get(kid)));
             resp.groups.add(g);
         }
         return resp;
@@ -400,6 +404,56 @@ public with sharing class MRG_DuplicateMerge_CTRL {
         } catch(Exception e){
             return e.getMessage();
         }
+    }
+	/*******************************************************************************************************
+	* @description overrides a single kept-field value for a grid group: writes the chosen value as a
+	* field override onto every candidate pair that shares the kept record, preserving any other overrides
+	* already stored. Mirrors the preview's manual override, keyed by kept record id at merge time.
+	* @param candidateIds the merge candidate ids of the group (all pairs sharing the kept record)
+	* @param field the field API name being overridden
+	* @param value the chosen value (one of the non-null values across the group's records)
+	* @return String response
+	*/
+    @AuraEnabled
+    public static String setKeepFieldOverride(List<Id> candidateIds, String field, String value){
+        if(candidateIds == null || candidateIds.isEmpty() || String.isBlank(field))
+            return 'No override to save';
+        List<MergeCandidate__c> cands = [
+            SELECT Id, Object__c, Override__c, PairKey__c, KeepRecordId__c, MergeRecordId__c
+            FROM MergeCandidate__c WHERE Id IN :candidateIds];
+        if(cands.isEmpty())
+            return 'No candidates';
+        // resolve the field's SOAP type so a typed value (date/number/boolean) coerces correctly at merge
+        String fieldType = null;
+        Schema.SObjectType sobjType = Schema.getGlobalDescribe().get(cands[0].Object__c);
+        if(sobjType != null){
+            Map<String, Schema.SObjectField> fmap = sobjType.getDescribe().fields.getMap();
+            if(fmap.containsKey(field.toLowerCase()))
+                fieldType = fmap.get(field.toLowerCase()).getDescribe().getSOAPType().name();
+        }
+        for(MergeCandidate__c c:cands){
+            List<MRG_MergeCandidate.fieldOverride> overrides = String.isBlank(c.Override__c)
+                ? new List<MRG_MergeCandidate.fieldOverride>()
+                : (List<MRG_MergeCandidate.fieldOverride>) JSON.deserialize(c.Override__c, List<MRG_MergeCandidate.fieldOverride>.class);
+            Boolean found = false;
+            for(MRG_MergeCandidate.fieldOverride o:overrides){
+                if(o.fieldName == field){ o.fieldValue = value; o.fieldType = fieldType; found = true; break; }
+            }
+            if(!found){
+                MRG_MergeCandidate.fieldOverride o = new MRG_MergeCandidate.fieldOverride();
+                o.fieldName = field;
+                o.fieldValue = value;
+                o.fieldType = fieldType;
+                overrides.add(o);
+            }
+            c.Override__c = JSON.serialize(overrides);
+            // PairKey__c is required; backfill its canonical value if a legacy record is missing it so the
+            // override update doesn't fail required-field validation
+            if(String.isBlank(c.PairKey__c) && String.isNotBlank(c.KeepRecordId__c) && String.isNotBlank(c.MergeRecordId__c))
+                c.PairKey__c = c.KeepRecordId__c + '-' + c.MergeRecordId__c;
+        }
+        update cands;
+        return 'Keep value overridden';
     }
 	/*******************************************************************************************************
 	* @description merges the Accounts for several contact candidates at once (grid multi-select, #84)
@@ -632,7 +686,7 @@ public with sharing class MRG_DuplicateMerge_CTRL {
 	* @description the simulated result row: the kept record's value overlaid with any field the merge
 	* engine changed (read from the serialized result map so unqueried fields don't throw)
 	*/
-    private static gridRow buildResultRow(List<String> fields, SObject keepRec, Map<String,Object> resultMap){
+    private static gridRow buildResultRow(List<String> fields, SObject keepRec, Map<String,Object> resultMap, Map<String,Object> ov){
         gridRow row = new gridRow();
         row.rowType = 'result';
         row.recordId = keepRec != null ? (String) keepRec.get('Id') : null;
@@ -646,6 +700,9 @@ public with sharing class MRG_DuplicateMerge_CTRL {
             Object val = (resultMap != null && resultMap.containsKey(lf)) ? resultMap.get(lf)
                 : (keepRec != null ? keepRec.get(fld) : null);
             cell.value = toStr(val);
+            // flag values that came from a manual override so the grid can highlight them
+            if(ov != null && ov.containsKey(fld))
+                cell.overrideValue = toStr(ov.get(fld));
             row.cells.add(cell);
         }
         return row;
@@ -703,5 +760,6 @@ public with sharing class MRG_DuplicateMerge_CTRL {
     public class gridCell {
         @AuraEnabled public String name;
         @AuraEnabled public String value;
+        @AuraEnabled public String overrideValue;
     }
 }

--- a/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
+++ b/force-app/main/default/classes/MRG_DuplicateMerge_TEST.cls
@@ -251,6 +251,39 @@ private class MRG_DuplicateMerge_TEST {
 		system.assert(resp.groups.isEmpty(), 'no candidate ids should yield no groups');
 	}
 
+	static testMethod void testGridRowsResultOverrideFlag(){
+		// the setup stored a MailingPostalCode override on the candidate; the result row should flag it
+		List<Id> ids = new List<Id>();
+		for(MergeCandidate__c c:[SELECT Id FROM MergeCandidate__c])
+			ids.add(c.Id);
+		MRG_DuplicateMerge_CTRL.gridResponse resp = MRG_DuplicateMerge_CTRL.getGridRows(
+			'Contact', new List<String>{'MailingPostalCode'}, ids);
+		String overrideVal = null;
+		for(MRG_DuplicateMerge_CTRL.gridRow r:resp.groups[0].rows){
+			if(r.rowType == 'result'){
+				for(MRG_DuplicateMerge_CTRL.gridCell cell:r.cells)
+					if(cell.name == 'MailingPostalCode') overrideVal = cell.overrideValue;
+			}
+		}
+		system.assertEquals('78754', overrideVal, 'the stored override should be flagged on the result row cell');
+	}
+
+	static testMethod void testSetKeepFieldOverride(){
+		MergeCandidate__c mc = [SELECT Id FROM MergeCandidate__c LIMIT 1];
+		test.startTest();
+		String resp = MRG_DuplicateMerge_CTRL.setKeepFieldOverride(new List<Id>{mc.Id}, 'MailingCity', 'Dallas');
+		test.stopTest();
+		system.assertEquals('Keep value overridden', resp);
+		MergeCandidate__c reloaded = [SELECT Override__c FROM MergeCandidate__c WHERE Id=:mc.Id];
+		List<MRG_MergeCandidate.fieldOverride> overrides =
+			(List<MRG_MergeCandidate.fieldOverride>) JSON.deserialize(reloaded.Override__c, List<MRG_MergeCandidate.fieldOverride>.class);
+		Map<String,String> byField = new Map<String,String>();
+		for(MRG_MergeCandidate.fieldOverride o:overrides)
+			byField.put(o.fieldName, o.fieldValue);
+		system.assertEquals('Dallas', byField.get('MailingCity'), 'the new field override should be added');
+		system.assertEquals('78754', byField.get('MailingPostalCode'), 'the pre-existing override should be preserved');
+	}
+
 	static testMethod void testRunActionOverFilterRemove(){
 		MRG_Duplicate_SVC.candidateFilter f = new MRG_Duplicate_SVC.candidateFilter('Contact','test');
 		test.startTest();

--- a/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/__tests__/mergeCandidateGrid.test.js
@@ -83,6 +83,12 @@ jest.mock(
     () => ({ default: (...args) => mockRunOverFilter(...args) }),
     { virtual: true }
 );
+const mockSetOverride = jest.fn(() => Promise.resolve('Keep value overridden'));
+jest.mock(
+    '@salesforce/apex/MRG_DuplicateMerge_CTRL.setKeepFieldOverride',
+    () => ({ default: (...args) => mockSetOverride(...args) }),
+    { virtual: true }
+);
 
 function flush() {
     return new Promise(resolve => setTimeout(resolve, 0));
@@ -180,6 +186,24 @@ describe('c-merge-candidate-grid', () => {
         await flush();
         expect(mockSaveConfig).toHaveBeenCalledWith({ objectType: 'Contact', fields: ['Email', 'Phone'] });
         expect(el.shadowRoot.querySelector('.grid-field-panel')).toBeNull();
+    });
+
+    it('overrides the merge result: pencil opens a combobox, selection persists to the group candidates', async () => {
+        const el = await render();
+        // Email differs across keep/duplicate, so the result Email cell is editable
+        const pencil = Array.from(el.shadowRoot.querySelectorAll('lightning-button-icon')).find(b => b.iconName === 'utility:edit');
+        expect(pencil).toBeTruthy();
+        pencil.dispatchEvent(new CustomEvent('click'));
+        await flush();
+        const combo = el.shadowRoot.querySelector('select[data-field="Email"]');
+        expect(combo).toBeTruthy();
+        // both distinct non-null values across the group are offered
+        const optionValues = Array.from(combo.querySelectorAll('option')).map(o => o.value).sort();
+        expect(optionValues).toEqual(['a@x.com', 'b@x.com']);
+        combo.value = 'b@x.com';
+        combo.dispatchEvent(new CustomEvent('change'));
+        await flush();
+        expect(mockSetOverride).toHaveBeenCalledWith({ candidateIds: ['mc1'], field: 'Email', value: 'b@x.com' });
     });
 
     it('filters the field list by label or api name', async () => {

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.css
@@ -47,3 +47,38 @@
 .grid-pagesize {
     width: 6rem;
 }
+/* widen the preview modal so the field table isn't cramped */
+.grid-preview-modal .slds-modal__container {
+    width: 90%;
+    max-width: 80rem;
+}
+/* keep-cell inline edit: the value truncates and always leaves room for the pencil, which is
+   faint until the keep row is hovered. */
+.grid-cell-inner {
+    flex-wrap: nowrap;
+}
+.grid-cell-inner > span {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.grid-edit-pencil {
+    flex: 0 0 auto;
+    opacity: 0.45;
+}
+.grid-row_result td:hover .grid-edit-pencil {
+    opacity: 1;
+}
+.grid-cell_overridden {
+    background-color: #fef3c7;
+    font-weight: 600;
+    padding: 0 0.25rem;
+    border-radius: 0.125rem;
+}
+.grid-edit-select {
+    font-size: 0.8rem;
+    max-width: 100%;
+    padding: 0.1rem 0.25rem;
+    border: 1px solid #c9c9c9;
+    border-radius: 0.125rem;
+    background-color: #fff;
+}

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.html
@@ -93,7 +93,36 @@
                                             </td>
                                             <template for:each={row.cells} for:item="cell">
                                                 <td key={cell.key}>
-                                                    <div class="slds-truncate" title={cell.value}>{cell.value}</div>
+                                                    <template if:true={cell.isEditing}>
+                                                        <!-- native select so the dropdown escapes the grid's horizontal-scroll overflow clip -->
+                                                        <select
+                                                            class="grid-edit-select"
+                                                            aria-label="Merge result value"
+                                                            data-keep={cell.keepId}
+                                                            data-field={cell.field}
+                                                            onchange={handleOverrideChange}
+                                                            onblur={handleOverrideCancel}>
+                                                            <template for:each={cell.options} for:item="opt">
+                                                                <option key={opt.value} value={opt.value} selected={opt.isSelected}>{opt.label}</option>
+                                                            </template>
+                                                        </select>
+                                                    </template>
+                                                    <template if:false={cell.isEditing}>
+                                                        <div class="slds-grid slds-grid_vertical-align-center grid-cell-inner">
+                                                            <span class={cell.cellClass} title={cell.value}>{cell.value}</span>
+                                                            <template if:true={cell.editable}>
+                                                                <lightning-button-icon
+                                                                    icon-name="utility:edit"
+                                                                    variant="bare"
+                                                                    size="x-small"
+                                                                    alternative-text="Edit merge result value"
+                                                                    title="Edit merge result value"
+                                                                    data-key={cell.key}
+                                                                    onclick={handleOverrideEditStart}
+                                                                    class="grid-edit-pencil slds-m-left_xx-small"></lightning-button-icon>
+                                                            </template>
+                                                        </div>
+                                                    </template>
                                                 </td>
                                             </template>
                                         </tr>
@@ -162,7 +191,7 @@
     <!-- preview modal with in-group navigation -->
     <template if:true={isModalOpen}>
         <template if:true={selectedRecordId}>
-            <section role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="grid-modal-heading" class="slds-modal slds-fade-in-open">
+            <section role="dialog" tabindex="-1" aria-modal="true" aria-labelledby="grid-modal-heading" class="slds-modal slds-fade-in-open slds-modal_large grid-preview-modal">
                 <div class="slds-modal__container">
                     <header class="slds-modal__header">
                         <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse" title="Close" onclick={closeModal}>

--- a/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
+++ b/force-app/main/default/lwc/mergeCandidateGrid/mergeCandidateGrid.js
@@ -9,6 +9,7 @@ import mergeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeRecords'
 import removeRecords from '@salesforce/apex/MRG_DuplicateMerge_CTRL.removeRecords';
 import mergeAccountsBulk from '@salesforce/apex/MRG_DuplicateMerge_CTRL.mergeAccountsBulk';
 import runActionOverFilter from '@salesforce/apex/MRG_DuplicateMerge_CTRL.runActionOverFilter';
+import setKeepFieldOverride from '@salesforce/apex/MRG_DuplicateMerge_CTRL.setKeepFieldOverride';
 
 // the grid mirrors the list view's two-level paging: it loads the working set of groups (up to CAP)
 // via getKeepGroups, pages groups (outer) and duplicates within a group (inner) client-side, and lazily
@@ -53,6 +54,8 @@ export default class MergeCandidateGrid extends LightningElement {
     isModalOpen = false;
     selectedRecordId;
     @track navItems = [];
+    // the keep cell (keepId::field) currently being edited inline
+    editingCellKey = null;
 
     groupPageOptions = GROUP_PAGE_OPTIONS;
     _loaded = false;
@@ -150,18 +153,19 @@ export default class MergeCandidateGrid extends LightningElement {
             const visiblePairs = pairs.slice((pairPage - 1) * PAIRS_PER_PAGE, pairPage * PAIRS_PER_PAGE);
             const displayRows = [];
             if(rows){
-                displayRows.push(this.staticRow(g.keepId, 'keep', 'Keep', 'grid-row_keep', rows.keepCells));
+                displayRows.push(this.staticRow(g.keepId, 'keep', 'Keep', 'grid-row_keep', this.plainCells(g.keepId + '-keep', rows.keepCells)));
                 visiblePairs.forEach(p=>{
                     const checked = this.selectAllMax || selected.has(p.id);
                     (rows.dupByCandidate[p.id] || []).forEach((d, di)=>{
                         displayRows.push({
                             key: g.keepId + '-dup-' + p.id + '-' + di,
                             rowType: 'duplicate', rowLabel: 'Duplicate', rowClass: 'grid-row_duplicate',
-                            selectable: true, candidateId: p.id, keepId: g.keepId, checked: checked, cells: d.cells
+                            selectable: true, candidateId: p.id, keepId: g.keepId, checked: checked,
+                            cells: this.plainCells(g.keepId + '-dup-' + p.id + '-' + di, d.cells)
                         });
                     });
                 });
-                displayRows.push(this.staticRow(g.keepId, 'result', 'Result', 'grid-row_result', rows.resultCells));
+                displayRows.push(this.staticRow(g.keepId, 'result', 'Result', 'grid-row_result', this.buildEditableCells(g.keepId, rows)));
             }
             return {
                 keepId: g.keepId,
@@ -178,6 +182,67 @@ export default class MergeCandidateGrid extends LightningElement {
     staticRow(keepId, rowType, rowLabel, rowClass, cells){
         return { key: keepId + '-' + rowType, rowType: rowType, rowLabel: rowLabel, rowClass: rowClass,
             selectable: false, candidateId: null, keepId: keepId, checked: false, cells: cells || [] };
+    }
+    // non-editable cells (duplicate/result rows) keyed for stable rendering
+    plainCells(prefix, cells){
+        return (cells || []).map(c=>({ key: prefix + '::' + c.name, value: c.value, editable: false, cellClass: 'slds-truncate' }));
+    }
+    // result-row cells, each editable to one of the distinct non-null values across the group's records
+    // (choosing a value writes a manual override that decides what the merge keeps for that field)
+    buildEditableCells(keepId, rows){
+        const systemFields = ['id', 'createddate', 'lastmodifieddate'];
+        const keepCells = rows.keepCells || [];
+        const dupMap = rows.dupByCandidate || {};
+        return (rows.resultCells || []).map(c=>{
+            const field = c.name;
+            const options = [];
+            const seen = new Set();
+            const add = v=>{ if(v != null && v !== '' && !seen.has(v)){ seen.add(v); options.push({label:v, value:v}); } };
+            const kc = keepCells.find(x=>x.name === field);
+            if(kc) add(kc.value);
+            Object.keys(dupMap).forEach(cid=>{
+                (dupMap[cid] || []).forEach(d=>{
+                    const dc = (d.cells || []).find(x=>x.name === field);
+                    if(dc) add(dc.value);
+                });
+            });
+            const hasOverride = c.overrideValue != null && c.overrideValue !== '';
+            const editable = systemFields.indexOf((field || '').toLowerCase()) === -1 && options.length > 1;
+            const editKey = keepId + '::' + field;
+            return {
+                key: editKey,
+                value: c.value,
+                editable: editable,
+                options: options.map(o=>({ label:o.label, value:o.value, isSelected: o.value === c.value })),
+                keepId: keepId,
+                field: field,
+                isEditing: this.editingCellKey === editKey,
+                cellClass: hasOverride ? 'slds-truncate grid-cell_overridden' : 'slds-truncate'
+            };
+        });
+    }
+    handleOverrideEditStart(event){
+        this.editingCellKey = event.currentTarget.dataset.key;
+    }
+    handleOverrideCancel(){
+        this.editingCellKey = null;
+    }
+    handleOverrideChange(event){
+        const keepId = event.currentTarget.dataset.keep;
+        const field = event.currentTarget.dataset.field;
+        const value = event.target.value;
+        this.editingCellKey = null;
+        this.saveFieldOverride(keepId, field, value);
+    }
+    saveFieldOverride(keepId, field, value){
+        const group = (this.allGroups || []).find(g=>g.keepId == keepId);
+        const candidateIds = group ? (group.pairs || []).map(p=>p.id) : [];
+        if(!candidateIds.length)
+            return;
+        this.rowsLoading = true;
+        setKeepFieldOverride({candidateIds:candidateIds, field:field, value:value})
+            .then(()=>{ this.loadVisibleRows(); this.toast('Saved', 'Merge result value overridden.', 'success'); })
+            .catch(error=>{ this.rowsLoading = false; this.handleError(error); });
     }
     get hasGroups(){ return this.allGroups.length > 0; }
     get showSpinner(){ return this.loadingGroups || this.rowsLoading; }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -25,6 +25,7 @@
     "merge@2.4.4-1": "04tKb000000EgzMIAS",
     "merge@2.4.5-1": "04tKb000000EgzRIAS",
     "merge@2.5.0-2": "04tKb000000EgzqIAC",
-    "merge@2.6.0-2": "04tKb000000Eh0AIAS"
+    "merge@2.6.0-2": "04tKb000000Eh0AIAS",
+    "merge@2.7.0-1": "04tKb000000Eh0yIAC"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "merge",
-      "versionName": "ver 2.6.0",
-      "versionNumber": "2.6.0.NEXT"
+      "versionName": "ver 2.7.0",
+      "versionNumber": "2.7.0.NEXT"
     }
   ],
   "namespace": "",


### PR DESCRIPTION
## Summary
- **Grid result-value override**: each editable **Result** cell in grid mode shows a hover pencil that opens a native picklist of the distinct non-null values across the group's records. Selecting one writes a manual override onto every candidate pair sharing the kept record (preserving other overrides), reloads, and highlights the result cell — mirroring the preview's editable "Merge Result" column.
- **Native `<select>`** so the picklist dropdown isn't clipped by the grid's horizontal-scroll overflow (fixes unselectable picklist on bottom rows).
- **`PairKey__c` backfill**: the override save backfills the required/unique `PairKey__c` (`KeepRecordId__c-MergeRecordId__c`) when a legacy record is missing it, so the update doesn't fail required-field validation.
- **Wider grid preview modal** (`slds-modal_large`, up to 80rem).
- Bumps package to **2.7.0** (released version `04tKb000000Eh0yIAC`).

## Testing
- LWC: 57 jest tests pass (added an override-flow test for `mergeCandidateGrid`).
- Apex: 21 `MRG_DuplicateMerge_TEST` tests pass on gsgDEV (added `testGridRowsResultOverrideFlag` + `testSetKeepFieldOverride`).
- Verified the override save end-to-end against gsgDEV; installed 2.7.0 in lcvFULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)