### PR TITLE
feat: Priority Order preservation rule for picklist fields (#91)

### DIFF
--- a/force-app/main/default/classes/MRG_Merge_SVC.cls
+++ b/force-app/main/default/classes/MRG_Merge_SVC.cls
@@ -178,6 +178,8 @@ public with sharing class MRG_Merge_SVC {
 		@auraEnabled public String containsValue;
 		// for rule == 'Concatenate': the character joining the unique values (default ';')
 		@auraEnabled public String concatenateCharacter;
+		// for rule == 'Priority Order': ranked semicolon-delimited values, highest priority first
+		@auraEnabled public String priorityOrder;
 
 		public mergeFieldWrap(MergeFieldSetting__mdt mergeField) {
 			this.id = mergeField.Id;
@@ -200,6 +202,7 @@ public with sharing class MRG_Merge_SVC {
 			this.apexClass = mergeField.ApexClass__c;
 			this.containsValue = mergeField.ContainsValue__c;
 			this.concatenateCharacter = mergeField.ConcatenateCharacter__c;
+			this.priorityOrder = mergeField.PriorityOrder__c;
 		}
 		public Integer compareTo(Object compareTo) {
 			mergeFieldWrap sortObj = (mergeFieldWrap) compareTo;
@@ -259,7 +262,8 @@ public with sharing class MRG_Merge_SVC {
 			TieBreakRule__c = mfw.tieBreakRule,
 			ApexClass__c = mfw.apexClass,
 			ContainsValue__c = mfw.containsValue,
-			ConcatenateCharacter__c = mfw.concatenateCharacter
+			ConcatenateCharacter__c = mfw.concatenateCharacter,
+			PriorityOrder__c = mfw.priorityOrder
 		);
 		mergeField.Type__c = mfw.type == 't' ? 'Track' : 'Preserve';
 		if(String.isNotBlank(mfw.id))
@@ -350,7 +354,8 @@ public with sharing class MRG_Merge_SVC {
 					PreservationRule__c,
 					ApexClass__c,
 					ContainsValue__c,
-					ConcatenateCharacter__c
+					ConcatenateCharacter__c,
+					PriorityOrder__c
 					FROM MergeFieldSetting__mdt
 				]);
 			}
@@ -916,6 +921,16 @@ public with sharing class MRG_Merge_SVC {
 										mergedFieldIsKept = true;
 									}
 								}
+							} else if(preserveField.rule != null && preserveField.rule.equalsIgnoreCase('Priority Order')) {
+								// keep the value ranked highest in the configured priority list; unlisted
+								// values rank below every listed value
+								if(priorityBeats(mergeRecordFieldValue, keptRecordfieldValue, preserveField.priorityOrder)) {
+									keepValue = mergeRecordFieldValue;
+									mergeValue = keptRecordfieldValue;
+									keptRec.put(fieldName, keepValue);
+									hasChange = true;
+									mergedFieldIsKept = true;
+								}
 							} else if(isChild && masterFieldIsKept){
 								keepValue = mergeRecordFieldValue;
 								mergeValue = keptRecordfieldValue;
@@ -1116,6 +1131,47 @@ public with sharing class MRG_Merge_SVC {
 			return false;
 		Schema.SObjectField field = objType.getDescribe().fields.getMap().get(fieldName.toLowerCase());
 		return field != null && field.getDescribe().getType() == Schema.DisplayType.MULTIPICKLIST;
+	}
+	/*******************************************************************************************************
+	* @description whether the merge (losing) record's value outranks the kept value in the configured
+	* priority list. Ranks are matched case-insensitively on trimmed values; a value not in the list
+	* ranks below every listed value. A null kept value is always outranked by a non-null merge value.
+	* @param mergeVal the merged record's value
+	* @param keepVal the surviving record's value
+	* @param priorityOrder the ranked, semicolon-delimited list of values (highest priority first)
+	* @return Boolean true when the merge value should be preserved
+	*/
+	public static Boolean priorityBeats(Object mergeVal, Object keepVal, String priorityOrder) {
+		if(mergeVal == null)
+			return false;
+		if(keepVal == null)
+			return true;
+		Integer mergeRank = priorityRank(mergeVal, priorityOrder);
+		Integer keepRank = priorityRank(keepVal, priorityOrder);
+		return mergeRank < keepRank;
+	}
+	/*******************************************************************************************************
+	* @description the rank of a value in a semicolon-delimited priority list (0 = highest priority);
+	* values not in the list (or a blank list) rank below all listed values
+	* @param value the field value
+	* @param priorityOrder the ranked, semicolon-delimited list of values
+	* @return Integer the rank
+	*/
+	public static Integer priorityRank(Object value, String priorityOrder) {
+		Integer unlisted = 2147483647;
+		if(value == null || String.isBlank(priorityOrder))
+			return unlisted;
+		String needle = String.valueOf(value).trim();
+		Integer rank = 0;
+		for(String part:priorityOrder.split(';')) {
+			String trimmed = part.trim();
+			if(String.isBlank(trimmed))
+				continue;
+			if(trimmed.equalsIgnoreCase(needle))
+				return rank;
+			rank++;
+		}
+		return unlisted;
 	}
 	/*******************************************************************************************************
 	* @description whether a field can use the Concatenate rule: free-text field types (text, text area,

--- a/force-app/main/default/classes/MRG_Metadata_SVC.cls
+++ b/force-app/main/default/classes/MRG_Metadata_SVC.cls
@@ -233,6 +233,8 @@ public with sharing class MRG_Metadata_SVC {
 		fieldKeyValues.put('ContainsValue__c', mergeField.ContainsValue__c);
 		// Concatenate rule: the character joining the unique values
 		fieldKeyValues.put('ConcatenateCharacter__c', mergeField.ConcatenateCharacter__c);
+		// Priority Order rule: ranked semicolon-delimited values, highest priority first
+		fieldKeyValues.put('PriorityOrder__c', mergeField.PriorityOrder__c);
 		String qualifiedName = !mergeField.QualifiedAPIName.contains('.') ? 'MergeFieldSetting__mdt.'+mergeField.QualifiedAPIName : mergeField.QualifiedAPIName;	   	
 		mdRecordNames.add(qualifiedName);
 		

--- a/force-app/main/default/classes/MRG_PriorityOrderRule_TEST.cls
+++ b/force-app/main/default/classes/MRG_PriorityOrderRule_TEST.cls
@@ -1,0 +1,107 @@
+/**
+* @author tj@tjgriffin.com
+* @group Merge
+* @description unit + end-to-end tests for the Priority Order preservation rule (#91): the field
+* keeps the highest-priority value (per a ranked semicolon-delimited list) across the merge group.
+*/
+@isTest
+private class MRG_PriorityOrderRule_TEST {
+
+	static final String ORDER = 'Owner;Manager;Employee';
+
+	static testMethod void testPriorityRank() {
+		system.assertEquals(0, MRG_Merge_SVC.priorityRank('Owner', ORDER), 'first listed value ranks 0');
+		system.assertEquals(1, MRG_Merge_SVC.priorityRank('Manager', ORDER), 'second listed value ranks 1');
+		system.assertEquals(2, MRG_Merge_SVC.priorityRank('Employee', ORDER), 'third listed value ranks 2');
+		system.assertEquals(0, MRG_Merge_SVC.priorityRank(' owner ', ORDER), 'match is trimmed and case-insensitive');
+		system.assert(MRG_Merge_SVC.priorityRank('Partner', ORDER) > 2, 'unlisted value ranks below all listed values');
+		system.assert(MRG_Merge_SVC.priorityRank('Owner', null) > 0, 'blank list -> everything unlisted');
+		system.assert(MRG_Merge_SVC.priorityRank(null, ORDER) > 2, 'null value -> unlisted');
+	}
+
+	static testMethod void testPriorityRankSkipsBlankSegments() {
+		system.assertEquals(0, MRG_Merge_SVC.priorityRank('Owner', ' Owner ; ; Manager '), 'blank segments are skipped');
+		system.assertEquals(1, MRG_Merge_SVC.priorityRank('Manager', ' Owner ; ; Manager '), 'ranks skip blank segments');
+	}
+
+	static testMethod void testPriorityBeats() {
+		system.assert(MRG_Merge_SVC.priorityBeats('Owner', 'Manager', ORDER), 'higher priority merge value wins');
+		system.assert(!MRG_Merge_SVC.priorityBeats('Employee', 'Manager', ORDER), 'lower priority merge value loses');
+		system.assert(!MRG_Merge_SVC.priorityBeats('Manager', 'Manager', ORDER), 'equal values keep the surviving value');
+		system.assert(MRG_Merge_SVC.priorityBeats('Employee', 'Partner', ORDER), 'listed merge value beats an unlisted kept value');
+		system.assert(!MRG_Merge_SVC.priorityBeats('Partner', 'Employee', ORDER), 'unlisted merge value never beats a listed kept value');
+		system.assert(!MRG_Merge_SVC.priorityBeats('Partner', 'Intern', ORDER), 'two unlisted values keep the surviving value');
+		system.assert(MRG_Merge_SVC.priorityBeats('Employee', null, ORDER), 'a null kept value always takes the merge value');
+		system.assert(!MRG_Merge_SVC.priorityBeats(null, 'Employee', ORDER), 'a null merge value never wins');
+	}
+
+	static testMethod void testContactPriorityOrderEndToEnd() {
+		// keep holds the LOWEST priority value; the highest across the group must survive
+		List<Contact> cons = MRG_TestFactory.contacts(3);
+		Id keepId = cons[0].Id;
+		Id mergeId1 = cons[1].Id;
+		Id mergeId2 = cons[2].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, LeadSource='Employee'),
+			new Contact(Id=mergeId1, LeadSource='Manager'),
+			new Contact(Id=mergeId2, LeadSource='Owner')
+		};
+		MergeFieldSetting__mdt setting = MRG_TestFactory.mergeField('Contact','LeadSource','Preserve','Priority Order');
+		setting.PriorityOrder__c = ORDER;
+		MRG_TestFactory.registerMergeFields(new List<MergeFieldSetting__mdt>{ setting });
+		List<MergeCandidate__c> candidates = MRG_TestFactory.mergeCandidatePairs(keepId, new List<Id>{ mergeId1, mergeId2 }, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(candidates, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals('Owner', (String) MRG_TestFactory.keptValue(keepId,'Contact','LeadSource'),
+			'Priority Order keeps the highest-priority value across the merge group');
+		system.assert(MRG_TestFactory.historyByField(keepId).containsKey('leadsource'),
+			'changed preserved field should be tracked');
+	}
+
+	static testMethod void testContactPriorityOrderKeptValueAlreadyHighest() {
+		// keep already holds the highest priority value; nothing should change
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, LeadSource='Owner'),
+			new Contact(Id=mergeId, LeadSource='Employee')
+		};
+		MergeFieldSetting__mdt setting = MRG_TestFactory.mergeField('Contact','LeadSource','Preserve','Priority Order');
+		setting.PriorityOrder__c = ORDER;
+		MRG_TestFactory.registerMergeFields(new List<MergeFieldSetting__mdt>{ setting });
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals('Owner', (String) MRG_TestFactory.keptValue(keepId,'Contact','LeadSource'),
+			'the kept record already holds the highest-priority value');
+	}
+
+	static testMethod void testContactPriorityOrderUnlistedMergeValueLoses() {
+		// merged record's value is not in the list; the kept listed value survives
+		List<Contact> cons = MRG_TestFactory.contacts(2);
+		Id keepId = cons[0].Id;
+		Id mergeId = cons[1].Id;
+		update new List<Contact>{
+			new Contact(Id=keepId, LeadSource='Employee'),
+			new Contact(Id=mergeId, LeadSource='Partner')
+		};
+		MergeFieldSetting__mdt setting = MRG_TestFactory.mergeField('Contact','LeadSource','Preserve','Priority Order');
+		setting.PriorityOrder__c = ORDER;
+		MRG_TestFactory.registerMergeFields(new List<MergeFieldSetting__mdt>{ setting });
+		MergeCandidate__c mc = MRG_TestFactory.mergeCandidate(keepId, mergeId, 'Contact');
+
+		Test.startTest();
+		MRG_TestFactory.runMerge(new List<MergeCandidate__c>{ mc }, 'Contact');
+		Test.stopTest();
+
+		system.assertEquals('Employee', (String) MRG_TestFactory.keptValue(keepId,'Contact','LeadSource'),
+			'an unlisted merge value never displaces a listed kept value');
+	}
+}

--- a/force-app/main/default/classes/MRG_PriorityOrderRule_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/MRG_PriorityOrderRule_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/__tests__/mergeSingleRecord.test.js
@@ -191,6 +191,39 @@ describe('c-merge-single-record', () => {
         expect(getReadableObjectFields.getLastConfig().objectType).toBe('Contact');
     });
 
+    it('offers Priority Order only for a single picklist field', async () => {
+        const el = createElement('c-merge-single-record', { is: MergeSingleRecord });
+        el.usedFields = [];
+        el.record = { name: 'TEMPx', type: 'p', rule: 'Newest', objectName: 'Contact', fieldName: 'LeadSource', conditions: [] };
+        document.body.appendChild(el);
+        getReadableObjectFields.emit([{ label: 'Lead Source', name: 'LeadSource', type: 'PICKLIST' }]);
+        await flush();
+        await flush();
+        expect(ruleCombobox(el).options.some(o => o.value === 'Priority Order')).toBe(true);
+    });
+
+    it('hides Priority Order for a non-picklist field', async () => {
+        const el = createElement('c-merge-single-record', { is: MergeSingleRecord });
+        el.usedFields = [];
+        el.record = { name: 'TEMPx', type: 'p', rule: 'Newest', objectName: 'Contact', fieldName: 'MailingState', conditions: [] };
+        document.body.appendChild(el);
+        getReadableObjectFields.emit([{ label: 'Mailing State', name: 'MailingState', type: 'STRING' }]);
+        await flush();
+        await flush();
+        expect(ruleCombobox(el).options.some(o => o.value === 'Priority Order')).toBe(false);
+    });
+
+    it('shows Priority Order + Fallback tabs and the ranked-values input for the rule', async () => {
+        const el = await renderWithRule('Priority Order');
+        expect(tabLabels(el)).toEqual(['Priority Order', 'Fallback Field']);
+        expect(hasInput(el, 'Priority Order')).toBe(true);
+    });
+
+    it('keeps Priority Order in the options when it is already the saved rule', async () => {
+        const el = await renderWithRule('Priority Order');
+        expect(ruleCombobox(el).options.some(o => o.value === 'Priority Order')).toBe(true);
+    });
+
     it('shows the Tie-Break Rule picker in the Complex section', async () => {
         const el = await renderWithRule('Complex');
         const labels = Array.from(el.shadowRoot.querySelectorAll('lightning-combobox')).map(c => c.label);

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.html
@@ -246,6 +246,19 @@
                                     </div>
                                 </template>
 
+                                <template if:true={isPriorityOrder}>
+                                    <div class={panelClass.priority} role="tabpanel">
+                                        <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
+                                            Rank the picklist values highest priority first, separated by semicolons
+                                            (e.g. Owner;Manager;Employee). The highest-priority value across the merge
+                                            candidates is preserved; values not listed rank below all listed values.
+                                        </p>
+                                        <lightning-input label="Priority Order" value={mergeRecord.priorityOrder}
+                                            placeholder="First;Second;Third" onchange={handlePriorityOrderChange}>
+                                        </lightning-input>
+                                    </div>
+                                </template>
+
                                 <template if:true={isApex}>
                                     <div class={panelClass.apex} role="tabpanel">
                                         <p class="slds-text-body_small slds-text-color_weak slds-m-bottom_small">

--- a/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
+++ b/force-app/main/default/lwc/mergeSingleRecord/mergeSingleRecord.js
@@ -65,11 +65,19 @@ export default class mergeSingleRecord extends LightningElement {
         if(this.isConcatenatableField || (this.mergeRecord != null && this.mergeRecord.rule === 'Concatenate')){
             options.push({label:'Concatenate',value:'Concatenate'});
         }
+        if(this.isPicklistField || (this.mergeRecord != null && this.mergeRecord.rule === 'Priority Order')){
+            options.push({label:'Priority Order',value:'Priority Order'});
+        }
         return options;
     }
     get isMultiPicklistField() {
         return this.mergeRecord != null && this.mergeRecord.fieldName != null
             && this.fieldTypeByName[this.mergeRecord.fieldName] === 'MULTIPICKLIST';
+    }
+    // Priority Order applies to single picklist fields
+    get isPicklistField() {
+        return this.mergeRecord != null && this.mergeRecord.fieldName != null
+            && this.fieldTypeByName[this.mergeRecord.fieldName] === 'PICKLIST';
     }
     // Concatenate applies to free-text field types and multi-select picklists
     get isConcatenatableField() {
@@ -147,6 +155,10 @@ export default class mergeSingleRecord extends LightningElement {
         return this.mergeRecord !== undefined && this.mergeRecord != null && this.preserve && this.mergeRecord.rule == 'Concatenate';
     }
 
+    get isPriorityOrder(){
+        return this.mergeRecord !== undefined && this.mergeRecord != null && this.preserve && this.mergeRecord.rule == 'Priority Order';
+    }
+
     // the character shown in the Concatenate tab: multiselects are locked to ';'
     get concatenateCharacterValue(){
         if(this.isMultiPicklistField){
@@ -157,7 +169,7 @@ export default class mergeSingleRecord extends LightningElement {
 
     // rules that need configuration beyond the simple ones -> auto-open the Advanced section
     get isAdvancedRule(){
-        return this.isRelatedField || this.isContains || this.isComplex || this.isApex || this.isConcatenate;
+        return this.isRelatedField || this.isContains || this.isComplex || this.isApex || this.isConcatenate || this.isPriorityOrder;
     }
     // Advanced (incl. the always-present Fallback tab) is available once an object is chosen
     get showAdvanced(){
@@ -176,6 +188,7 @@ export default class mergeSingleRecord extends LightningElement {
         if(this.isComplex) return 'ruleDef';
         if(this.isApex) return 'apex';
         if(this.isConcatenate) return 'concat';
+        if(this.isPriorityOrder) return 'priority';
         return 'fallback';
     }
     // nav tabs: the rule-specific tab(s) first, Fallback Field always last
@@ -186,6 +199,7 @@ export default class mergeSingleRecord extends LightningElement {
         else if(this.isComplex){ t.push({key:'ruleDef', label:'Rule Definition'}); t.push({key:'tieBreak', label:'Tie-Break'}); }
         else if(this.isApex) t.push({key:'apex', label:'Apex Class'});
         else if(this.isConcatenate) t.push({key:'concat', label:'Concatenate Character'});
+        else if(this.isPriorityOrder) t.push({key:'priority', label:'Priority Order'});
         t.push({key:'fallback', label:'Fallback Field'});
         return t.map(tab=>({
             key: tab.key,
@@ -203,6 +217,7 @@ export default class mergeSingleRecord extends LightningElement {
             tieBreak: cls('tieBreak'),
             apex: cls('apex'),
             concat: cls('concat'),
+            priority: cls('priority'),
             fallback: cls('fallback')
         };
     }
@@ -382,6 +397,9 @@ export default class mergeSingleRecord extends LightningElement {
     }
     handleConcatenateCharacterChange(event){
         this.mergeRecord.concatenateCharacter = event.target.value || ';';
+    }
+    handlePriorityOrderChange(event){
+        this.mergeRecord.priorityOrder = event.target.value;
     }
     doEdit(event){
         this.isEdit=true;

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PreservationRule__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PreservationRule__c.field-meta.xml
@@ -56,6 +56,11 @@
                 <label>Concatenate</label>
             </value>
             <value>
+                <fullName>Priority Order</fullName>
+                <default>false</default>
+                <label>Priority Order</label>
+            </value>
+            <value>
                 <fullName>Related Field</fullName>
                 <default>false</default>
                 <label>Related Field</label>

--- a/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PriorityOrder__c.field-meta.xml
+++ b/force-app/main/default/objects/MergeFieldSetting__mdt/fields/PriorityOrder__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>PriorityOrder__c</fullName>
+    <description>For Preservation Rule = Priority Order: the ranked, semicolon-delimited list of values (highest priority first). The merged records' value with the highest priority is preserved; values not in the list rank below all listed values.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Priority Order</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>


### PR DESCRIPTION
## Issue #91 — Priority Order preservation rule

Lets an admin rank picklist values so the highest-priority value across the merge candidates survives — e.g. `Owner;Manager;Employee` on `Type__c` preserves Owner over Manager over Employee, without Apex or relying on lexical ordering.

### How it works
- New `PreservationRule__c` value **Priority Order** + `MergeFieldSetting__mdt.PriorityOrder__c` (long text) holding the ranked, semicolon-delimited value list, highest priority first.
- `MRG_Merge_SVC` pairwise branch: the merge value displaces the kept value only when it ranks strictly higher (`priorityBeats` / `priorityRank`). Matching is trimmed and case-insensitive. Values not in the list rank below every listed value, so an unlisted value never displaces a listed one; a null kept value always loses to a non-null merge value. Across a 3+ record group the pairwise loop converges on the highest-priority value regardless of processing order.
- Wired through `mergeFieldWrap`, the merge-field SOQL, and the `MRG_Metadata_SVC` save mapping.
- `mergeSingleRecord` offers the rule for **single picklist** fields (and always keeps it in the options when it''s the saved rule) with a Priority Order advanced tab for the ranked list.

### Tests
- **Apex:** `MRG_PriorityOrderRule_TEST` — rank/beats unit tests (case/trim, unlisted, nulls, blank segments) plus three end-to-end merges through the production path: 3-record Owner/Manager/Employee group, kept-already-highest, and unlisted-merge-value-loses. Affected suite: 35/35 pass on gsgDEV.
- **Jest:** option gating (PICKLIST yes, STRING no), tab + ranked-values input, saved-rule guard. 75/75 pass.

### Deploy
Deployed to **gsgDEV** for review — try it on a picklist field via Merge Control Settings → Field Tracking Settings (hard-refresh to bust the component cache).

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)